### PR TITLE
Remove language and framework from protocol doc

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -31,8 +31,6 @@ register names by being the first to include the name in a “registration” op
 |Blockchain|bitcoin|
 |Hash storage method|OP_RETURN|
 |Data storage method|Kademlia DHT|
-|Language|Python|
-|Frameworks|Twisted|
 
 #### Name operations
 


### PR DESCRIPTION
The implementation language and framework don't belong in a protocol design document.

Perhaps a separate implementation document.

I'm thinking in terms of alternate implementations of the protocol. They need not have anything to do with Python or Twister, not that there's anything wrong with them...
