### PR TITLE
fix getinfo rpc call name error failure

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -89,7 +89,7 @@ def get_bitcoind( new_bitcoind_opts=None, reset=False, new=False ):
 
    if new or bitcoind is None:
       if new_bitcoind_opts is not None:
-         set_bitcoin_opts( new_bitcoin_opts )
+         set_bitcoin_opts( new_bitcoind_opts )
 
       bitcoin_opts = get_bitcoin_opts()
       new_bitcoind = None


### PR DESCRIPTION
Variable hold bitcoind options was spelled incorrectly causing the following error:
```
(venv) larry@blockstack-explorer-1:~/blockstack-integration-tests$ blockstack ping
[2016-10-28 04:03:20,676] [DEBUG] [spv:103] (15653.140276675929920) Using mainnet
[2016-10-28 04:03:20,885] [DEBUG] [cli:210] (15653.140276675929920) Enabling advanced methods
[2016-10-28 04:03:20,930] [DEBUG] [client:134] (15653.140276675929920) Loaded storage driver 'disk'
[2016-10-28 04:03:20,930] [DEBUG] [client:134] (15653.140276675929920) Loaded storage driver 'blockstack_resolver'
[2016-10-28 04:03:20,931] [DEBUG] [client:134] (15653.140276675929920) Loaded storage driver 'blockstack_server'
[2016-10-28 04:03:20,931] [DEBUG] [client:134] (15653.140276675929920) Loaded storage driver 'http'
[2016-10-28 04:03:20,931] [DEBUG] [client:134] (15653.140276675929920) Loaded storage driver 'dht'
{
    "advanced_mode": true, 
    "cli_version": "0.14.0", 
    "server_alive": false, 
    "server_error": "NameError: global name 'new_bitcoin_opts' is not defined"
}
(venv)
```