### PR TITLE
minimum name price no longer 1 satoshi

### DIFF
--- a/blockstack/lib/scripts.py
+++ b/blockstack/lib/scripts.py
@@ -123,7 +123,7 @@ def price_name( name, namespace, block_height ):
    Calculate the price of a name (without its namespace ID), given the
    namespace parameters.
 
-   The minimum price is 1 satoshi
+   The minimum price is NAME_COST_UNIT
    """
 
    base = namespace['base']


### PR DESCRIPTION
Comment indicates that minimum name price is 1 satoshi, but minimum name price is `NAME_COST_UNIT` which is currently set to 100 satoshis.