### PR TITLE
Removing dependency on pycrypto

### DIFF
--- a/blockstack_client/backend/crypto/utils.py
+++ b/blockstack_client/backend/crypto/utils.py
@@ -24,9 +24,8 @@
 import base64
 
 import scrypt
-
-# TODO: deprecate use of Pycrypto by 0.16
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
 
 from binascii import hexlify, unhexlify
 
@@ -63,11 +62,13 @@ def aes_decrypt_legacy(payload, secret):
 
     try:
         PADDING = '{'
-        DecodeAES = lambda c, e: c.decrypt(base64.b64decode(e)).rstrip(PADDING)
 
         secret = ensure_length(secret)
-        cipher = AES.new(unhexlify(secret))
-        res = DecodeAES(cipher, payload)
+        cipher = Cipher(algorithms.AES(unhexlify(secret)), modes.ECB(),
+                        backend = default_backend())
+        decryptor = cipher.decryptor()
+        res = decryptor.update(base64.b64decode(payload)) + decryptor.finalize()
+        res = res.rstrip(PADDING)
         return res
     except:
         return None

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'defusedxml>=0.4.1',
         'keylib>=0.0.5',
         'mixpanel>=4.3.1',
-        'pycrypto>=2.6.1',
         'simplejson>=3.8.2',
         'jsonschema>=2.5.1',
         'scrypt>=0.8.0',


### PR DESCRIPTION
pycrypto was being used for legacy decryption, but cryptography can take care of that now