### PR TITLE
fixing core api service whitespace issue on macOS

### DIFF
--- a/blockstack_client/cli.py
+++ b/blockstack_client/cli.py
@@ -394,11 +394,18 @@ def run_cli(argv=None, config_path=CONFIG_PATH):
 
             new_argv += ['--secrets', str(fd)]
 
+        new_argv = [sys.executable] + new_argv
         if cli_debug:
-            print("Re-exec as `{}`".format( " ".join(new_argv)), file=sys.stderr)
+            print("Re-exec as `{}`".format(", ".join([
+                '"{}"'.format(i) for i in new_argv])), file=sys.stderr)
 
-        os.execv( new_argv[0], new_argv )
-    
+        try:
+            os.execv(new_argv[0], new_argv)
+        except:
+            import traceback as tb
+            tb.print_exc()
+            sys.exit(1)
+
     # load secrets
     if arg_info['args'].has_key('secret_fd'):
         fd_str = arg_info['args']['secret_fd']


### PR DESCRIPTION
I believe the problem for the api service and cli interface was just in the re-execing of `blockstack`  

The actual core blockstack server will probably still get angry about whitespace, but this should solve the problems for the macOS app deployment since I don't think it runs an actual core node.