### PR TITLE
Secret cli args weren't being processed when debug flag unset

### DIFF
--- a/blockstack_client/cli.py
+++ b/blockstack_client/cli.py
@@ -378,17 +378,17 @@ def run_cli(argv=None, config_path=CONFIG_PATH):
                 print("Set {} to {}".format(envar, enval), file=sys.stderr)
 
             os.environ[envar] = enval
-   
+
+    # set secrets...
+    for secvar, secval in arg_info['secrets'].items():
+        set_secret(secvar, secval)
+
     # re-exec?
     if arg_info['re-exec']:
  
         new_argv = arg_info['new_argv']
 
         if len(arg_info['secrets']) > 0:
-            # set secrets...
-            for secvar, secval in arg_info['secrets'].items():
-                set_secret(secvar, secval)
-
             secbuf = serialize_secrets()
             fd = write_secrets(secbuf)
 


### PR DESCRIPTION
fixes secret setting so that passed passwords work when not in --debug mode (re-exec code isn't called)