### PR TITLE
Correct old PyPi package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blockstack Core
 
-[![PyPI](https://img.shields.io/pypi/v/blockstack.svg)](https://pypi.python.org/pypi/blockstack-server/)
+[![PyPI](https://img.shields.io/pypi/v/blockstack.svg)](https://pypi.python.org/pypi/blockstack/)
 [![Slack](http://slack.blockstack.org/badge.svg)](http://slack.blockstack.org/)
 
 Blockstack is a new decentralized web, where users own their data and apps run on user devices without the need for hosting. Developers can build


### PR DESCRIPTION
The badge at the top of the readme uses `blockstack-server` as PyPi package which doesn't exist (anymore?). This PR changes it to just `blockstack`.