### PR TITLE
[documentation] strip any '//' after 'blockstack:' in .desktop file

### DIFF
--- a/docs/setup_core_portal.md
+++ b/docs/setup_core_portal.md
@@ -99,7 +99,7 @@ With the following contents:
 [Desktop Entry]
 Type=Application
 Terminal=false
-Exec=bash -c 'xdg-open http://localhost:3000/auth?authRequest=$(echo "%u" | sed s/blockstack://)'
+Exec=bash -c 'xdg-open http://localhost:3000/auth?authRequest=$(echo "%u" | sed s,blockstack:/*,,)'
 Name=Blockstack-Portal
 MimeType=x-scheme-handler/blockstack;
 ```


### PR DESCRIPTION
the `.desktop` file didn't work out of the box. This one will work, even if the `blockstack:` is `blockstack://whatever` or `blockstack:whatever`.