### PR TITLE
Indexed storage driver for IPFS

### DIFF
--- a/blockstack_client/backend/drivers/ipfs.py
+++ b/blockstack_client/backend/drivers/ipfs.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    Implements an IPFS driver for blockstack.
+    An index is used for translating names to content addressing names used in IPFS.
+    Assumptions:
+    - Writing user runs it's IPFS node with a pub/priv key pair tagged with it's blockstack id
+      (used for the IPNS entry to have a fixed url for the index)
+"""
+
+import re
+import threading
+from ConfigParser import SafeConfigParser
+
+import ipfsapi
+
+from blockstack_client.backend.drivers.ipfsindex import ipfs_put_indexed_data, ipfs_get_indexed_data, ipfs_index_setup
+from common import *
+
+log = get_logger("blockstack-storage-drivers-ipfs")
+log.setLevel(logging.DEBUG if DEBUG else logging.INFO)
+
+IPFS_API = None
+INDEX_DIRNAME = ""
+DVCONF = None
+
+BLOCKSTACK_DEBUG = (os.environ.get("BLOCKSTACK_DEBUG") == "1")
+
+DEFAULT_GATEAWAY = "https://gateway.ipfs.io"
+IPFS_HASH_PATTERN = re.compile(".*/(ipfs|ipns)/(.*)")
+IPNS_ADDR_PATTERN = re.compile(".*(/ipns/.*)/?")
+IPFS_ADDR_PATTERN = re.compile(".*(/ipfs/.*)/?")
+
+
+class NameUpdateThread(threading.Thread):
+    """
+    Since IPNS name publish takes ages, the task is outsourced to a thread.
+    """
+    def __init__(self, ipfs_api, data_address, blockstack_id, previous_thread=None, driver_name=None, config_path=None):
+        threading.Thread.__init__(self)
+        self.no_newer = threading.Event()
+        self.previous_thread = previous_thread
+        self.ipfs_api = ipfs_api
+        self.data_address = data_address
+        self.blockstack_id = blockstack_id
+        self.driver_name = driver_name
+        self.config_path = config_path
+
+    def run(self):
+        if not self.previous_thread is None:
+            # wait until older publish is done
+            self.previous_thread.join()
+        if self.no_newer.is_set():
+            return
+        name = ipfs_publish_name(self.ipfs_api, "/ipfs/%s" % self.data_address, self.blockstack_id)
+        if not (self.driver_name is None or
+                        self.config_path is None or
+                        name is None):
+            index_settings_set_index_manifest_url(self.driver_name, self.config_path, name)
+
+
+class LocalIndexManifestManipulator(object):
+    """
+    A helper class which preserves the index manifest state.
+    After each insert/update operation the content changes and hence it's ipfs address.
+    Therefore, the IPNS entry has to be republished for the new index manifest address.
+    """
+    def __init__(self, start_manifest_index=None):
+        self.cur_manifest_index = start_manifest_index
+        self.cur_thread = None
+
+    def publish_name(self, ipfs_api, data_address, blockstack_id,
+                     driver_name=None, config_path=None):
+        """
+        Publish the new index manifest address
+        :param ipfs_api: ifps api object
+        :param data_address: the new address
+        :param blockstack_id: the blockstack id for identifying the key
+        :param driver_name: (optional)
+        :param config_path: (optional)
+        :return:
+        """
+        if self.cur_thread is not None:
+            self.cur_thread.no_newer.set()
+        self.cur_thread = NameUpdateThread(ipfs_api, data_address, blockstack_id, previous_thread=self.cur_thread,
+                                           driver_name=driver_name, config_path=config_path)
+        self.cur_thread.daemon = True
+        self.cur_thread.start()
+
+
+def ipfs_url_reformat(data_hash):
+    """
+    Given a IPFS data hash, outputs the default gataway url of the content
+    :param data_hash:
+    :return: the default Gateaway url.
+    """
+    return "%s/ipfs/%s" % (DEFAULT_GATEAWAY, data_hash)
+
+
+def ipns_url_reformat(data_hash):
+    """
+    Given a IPNS pub hash, outputs the default gateway url of the content
+    :param data_hash:
+    :return: the default gateway url.
+    """
+    return "%s/ipns/%s" % (DEFAULT_GATEAWAY, data_hash)
+
+
+def is_ipns_url(url):
+    return "ipns" in url
+
+
+def extract_hash_from_url(ipfs_url):
+    """
+    Extracts the resource path of a IPFS/IPNS URL
+    ex: https://gateway.ipfs.io/ipfs/QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa
+    output: /ipfs/QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa
+    :param ipfs_url:
+    :return: the IPFS/IPNS address
+    """
+    res = IPFS_HASH_PATTERN.match(ipfs_url)
+    if res:
+        return res.group(2)
+    return None
+
+
+def extract_addr_from_ipfs_url(ipfs_url):
+    """
+    Extracts the data hash from a IPFS Url
+    ex: https://gateway.ipfs.io/ipfs/QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa
+    output: QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa
+    :param ipfs_url:
+    :return: the content address
+    """
+    res = IPFS_ADDR_PATTERN.match(ipfs_url)
+    if res:
+        return res.group(1)
+    return None
+
+
+def extract_addr_from_ipns_url(ipns_url):
+    """
+    Extracts the data hash from a IPNS Url
+    ex: https://gateway.ipfs.io/ipns/QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa
+    output: QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa
+    :param ipfs_url:
+    :return: the content address
+    """
+    res = IPNS_ADDR_PATTERN.match(ipns_url)
+    if res:
+        return res.group(1)
+    return None
+
+
+def ipfs_check_key_exists(ipfs_api, key_name):
+    """
+    Check if the ipfs node has the key pair with the given name.
+    :param ipfs_api: the api object
+    :param key_name: the name of the key ex. "defaultkey"
+    :return: true if key exists else false
+    """
+    if key_name is None:
+        return False
+
+    keys = ipfs_api._client.request('/key/list', decoder='json')['Keys']
+    for key in keys:
+        if key['Name'] == key_name:
+            return True
+    return False
+
+
+def ipfs_publish_name(ipfs_api, ipfs_path, key, resolve=False, lifetime="175200h", ttl=None, **kwargs):
+    """
+    Publishes a new IPFS name for a IPNS address
+    :param ipfs_api: the api object
+    :param ipfs_path: the new IPFS path to publish (ex. /ipfs/QmeZfdngL9Lw9489vjfaom5FRV4hbazoP8UuJtQQcjDeZa)
+    :param key: the name of the key IPNS key-pair to use (ex.  "defaultkey")
+    :param resolve: -
+    :param lifetime: -
+    :param ttl: -
+    :param kwargs:
+    :return: dictionary with the resulting IPNS entry
+    """
+    opts = {"lifetime": lifetime, "resolve": resolve, "key": key}
+    if ttl:
+        opts["ttl"] = ttl
+    kwargs.setdefault("opts", opts)
+    args = (ipfs_path,)
+    result = ipfs_api._client.request('/name/publish', decoder='json', args=args, **kwargs)
+    return result
+
+
+def ipfs_put_chunk(dvconf, chunk_buf, name, use_index_put=False):
+    """
+    Driver-level call to put data to ipfs.
+    Returns the URL to the data stored on success. If not an Index Store request -> "/none"
+    Returns None on error
+    """
+    driver_info = dvconf['driver_info']
+    ipfs_server = driver_info['ipfs_server']
+    ipfs_port = driver_info['ipfs_port']
+    blockstack_id = driver_info['blockstack_id']
+    manifest_manipulator = driver_info['manifest_manipulator']
+
+    if ipfs_server is None or ipfs_port is None:
+        log.warn("IPFS server not set, cannot write")
+        return None
+
+    ipfs_api = ipfsapi.connect(ipfs_server, ipfs_port)
+    chunk_buf = str(chunk_buf)
+    try:
+        data_address = ipfs_api.add_str(chunk_buf)
+
+        # check if index specific store request
+        index_name = index_get_manifest_page_path(INDEX_DIRNAME)
+        if index_name == name or use_index_put:
+            # index store, add ipns entry!
+            # (https://github.com/ipfs/examples/tree/master/examples/ipns,
+            # https://groups.google.com/forum/#!topic/ipfs-users/rUK89pYway4)
+            if not ipfs_check_key_exists(ipfs_api, blockstack_id):
+                log.warn("IPFS node does not contain a key pair for the blockstack id {}".format(blockstack_id))
+                return None
+            # IPNS publish, Very slow at the moment :( -> outsource to thread + local caching of the index manifest
+            if use_index_put:
+                manifest_manipulator.publish_name(ipfs_api, data_address, blockstack_id)
+            else:
+                manifest_manipulator.publish_name(ipfs_api, data_address, blockstack_id,
+                                                  driver_name=dvconf['driver_name'], config_path=dvconf['config_path'])
+            return "/none"
+
+        url = ipfs_url_reformat(data_address)
+        log.debug("{} available at {}".format(name, url))
+        return url
+    except Exception as e:
+        if DEBUG:
+            log.exception(e)
+
+        log.error("Failed to save {} bytes to {} in IPFS".format(len(chunk_buf), name))
+        return None
+
+
+def ipfs_delete_chunk(dvconf, name):
+    """
+    Unpin a chunk from ipfs
+    Return True on success
+    Return False on error
+    """
+
+    driver_info = dvconf['driver_info']
+    ipfs_server = driver_info['ipfs_server']
+    ipfs_port = driver_info['ipfs_port']
+
+    if ipfs_server is None or ipfs_port is None:
+        log.warn("IPFS server not set, cannot delete")
+        return None
+
+    ipfs_api = ipfsapi.connect(ipfs_server, ipfs_port)
+    try:
+        ipfs_api.pin_rm(extract_hash_from_url(name))
+        return True
+    except Exception, e:
+        log.exception(e)
+        return False
+
+
+def ipfs_get_chunk(dvconf, name):
+    """
+    Get a chunk form IPFS
+    Return the data on success
+    Return None on error
+    """
+
+    driver_info = dvconf['driver_info']
+    ipfs_server = driver_info['ipfs_server']
+    ipfs_port = driver_info['ipfs_port']
+
+    ipfs_api = None
+
+    if not ipfs_server is None and not ipfs_port is None:
+        ipfs_api = ipfsapi.connect(ipfs_server, ipfs_port)
+
+    try:
+        if ipfs_api is None:
+            # use default gateway
+            req = requests.get(name)
+            if req.status_code != 200:
+                log.debug("Failed retrieving {} status code {}".format(name, req.status_code))
+                return None
+            return req.text
+        else:
+            # use ipfs node
+            path = name
+            if is_ipns_url(path):
+                path = ipfs_api.resolve(extract_addr_from_ipns_url(path))['Path']
+            else:
+                path = extract_addr_from_ipfs_url(path)
+            return ipfs_api.cat(path.split("/")[2])
+    except Exception, e:
+        log.error("Failed to load {}".format(name))
+        return None
+
+
+def storage_init(conf, index=False, force_index=False, **kwargs):
+    """
+    Initialize ipfs storage driver
+    """
+    global DVCONF, IPFS_API
+    compress = False
+    ipfs_server = None
+    ipfs_port = None
+    config_path = conf['path']
+
+    if os.path.exists(config_path):
+
+        parser = SafeConfigParser()
+
+        try:
+            parser.read(config_path)
+        except Exception, e:
+            log.exception(e)
+            return False
+
+        if parser.has_section('ipfs'):
+            if parser.has_option('ipfs', 'server'):
+                ipfs_server = parser.get('ipfs', 'server')
+
+            if parser.has_option('ipfs', 'port'):
+                ipfs_port = int(parser.get('ipfs', 'port'))
+
+            if parser.has_option('ipfs', 'compress'):
+                compress = (parser.get('ipfs', 'compress').lower() in ['1', 'true', 'yes'])
+
+    # blockstack id for identifying the ipfs key used for the IPNS url
+    blockstack_id = kwargs.get('fqu', None)
+
+    # set up driver
+    DVCONF = driver_config("ipfs", config_path, ipfs_get_chunk, ipfs_put_chunk, ipfs_delete_chunk,
+                           driver_info={'blockstack_id': blockstack_id, 'ipfs_server': ipfs_server,
+                                        'ipfs_port': ipfs_port,
+                                        'manifest_manipulator': LocalIndexManifestManipulator()},
+                           index_stem=INDEX_DIRNAME, compress=compress)
+    if index:
+        # instantiate the index
+        url = ipfs_index_setup(DVCONF, force=force_index)
+        if not url:
+            log.error("Failed to set up index")
+            return False
+
+    return True
+
+
+def handles_url(url):
+    """
+    Do we handle this URL?
+    Must point to a ipfs link
+    """
+
+    return DEFAULT_GATEAWAY in url \
+           and ("ipfs" in url or "ipns" in url)
+
+
+def make_mutable_url(data_id):
+    """
+    TODO:rewrite
+    The URL here is a misnomer, since ipfs has content hash addressing.
+
+    This URL here will instruct get_chunk() to go and search through
+    the index for the target data.
+    """
+    data_id = urllib.quote(data_id.replace('/', '-2f'))
+    url = "https://ipfs.io/blockstack/{}".format(data_id)
+    return url
+
+
+def get_immutable_handler(key, **kw):
+    """
+    Get data by hash
+    """
+    blockchain_id = kw.get('fqu', None)
+    index_manifest_url = kw.get('index_manifest_url', None)
+
+    name = 'immutable-{}'.format(key)
+    name = name.replace('/', r'-2f')
+
+    path = '/{}'.format(name)
+    return ipfs_get_indexed_data(DVCONF, blockchain_id, path, index_manifest_url=index_manifest_url)
+
+
+def get_mutable_handler(url, **kw):
+    """
+    Get data by URL
+    """
+    blockchain_id = kw.get('fqu', None)
+    index_manifest_url = kw.get('index_manifest_url', None)
+
+    urltype, urlres = get_url_type(url)
+    if urltype is None and urlres is None:
+        log.error("Invalid URL {}".format(url))
+        return None
+
+    if urltype == 'blockstack':
+        # get via index
+        urlres = urlres.replace('/', r'-2f')
+        path = '/{}'.format(urlres)
+        return ipfs_get_indexed_data(DVCONF, blockchain_id, path, index_manifest_url=index_manifest_url)
+
+    else:
+        # raw ipfs gateaway url
+        return http_get_data(DVCONF, url)
+
+
+def put_immutable_handler(key, data, txid, **kw):
+    """
+    Put data by hash and txid
+    """
+    global DVCONF
+    index_manifest_url = index_settings_get_index_manifest_url(DVCONF['driver_name'], DVCONF['config_path'])
+
+    name = 'immutable-{}'.format(key)
+    name = name.replace('/', r'-2f')
+
+    path = '/{}'.format(name)
+    return ipfs_put_indexed_data(DVCONF, path, data, index_manifest_url=index_manifest_url)
+
+
+def put_mutable_handler(data_id, data_bin, **kw):
+    """
+    Put data by file ID
+    """
+    global DVCONF
+    index_manifest_url = index_settings_get_index_manifest_url(DVCONF['driver_name'], DVCONF['config_path'])
+    data_id = data_id.replace('/', r'-2f')
+    path = '/{}'.format(data_id)
+
+    return ipfs_put_indexed_data(DVCONF, path, data_bin, index_manifest_url=index_manifest_url)
+
+
+def delete_immutable_handler(key, txid, sig_key_txid, **kw):
+    """
+    Delete by hash (only index is updated) (IPFS does not support delete)
+    """
+    global DVCONF
+
+    name = 'immutable-{}'.format(key)
+    name = name.replace('/', r'-2f')
+    path = '/{}'.format(name)
+
+    return delete_indexed_data(DVCONF, path)
+
+
+def delete_mutable_handler(data_id, signature, **kw):
+    """
+    Delete by data ID (only index is updated)  (IPFS does not support delete)
+    """
+    global DVCONF
+
+    data_id = data_id.replace('/', r'-2f')
+    path = '/{}'.format(data_id)
+
+    return delete_indexed_data(DVCONF, path)
+
+
+if __name__ == "__main__":
+    """
+    Simple test
+    Demo Hash corresponds to the hash of the public key in the ipfs node for the TAG demo.io
+    (the address for IPNS)
+    """
+
+    demo_hash = "QmfYEYcX9KY9PUuwr1a4VgNgtAxJ81ZEsNF4Tid6GTp87z"
+    import ConfigParser, os, shutil
+
+    config = ConfigParser.SafeConfigParser()
+    config.add_section('ipfs')
+    config.set('ipfs', 'server', 'localhost')
+    config.set('ipfs', 'port', '5001')
+    config.set('ipfs', 'compress', '1')
+    with open("temp.config", 'w') as config_file:
+        config.write(config_file)
+    os.mkdir("drivers")
+    os.mkdir("drivers/ipfs")
+    with open("drivers/ipfs/index_manifest_url", 'w') as config_file:
+        config_file.write(DEFAULT_GATEAWAY + "/ipns/%s" % demo_hash)
+    try:
+        storage_init(conf={'path': 'temp.config'}, index=True, force_index=True, fqu='demo.io')
+        data = "ipfs with blockstack is great"
+        print "Put data: %s" % data
+        url = put_immutable_handler("test", data, "txid1")
+        print "Fetch data"
+        out = get_immutable_handler("test")
+        print "Result: %s" % out
+
+        if out == data:
+            print "Success :D"
+        else:
+            print "Failed :("
+    finally:
+        shutil.rmtree("drivers")

--- a/blockstack_client/backend/drivers/ipfsindex.py
+++ b/blockstack_client/backend/drivers/ipfsindex.py
@@ -1,0 +1,450 @@
+import json
+import os
+
+from blockstack_client.backend.drivers.common import index_setup, index_get_page_path, index_get_cached_manifest_url, \
+    log, DEBUG, lookup_index_manifest_url, index_get_manifest_page_path, compress_chunk, \
+    serialize_index_page, index_remove_cached_page, index_remove_cached_manifest_url, index_cached_lookup, \
+    get_chunk_via_http, decompress_chunk, index_set_cached_page, index_set_cached_manifest_url, parse_index_page, \
+    index_settings_get_index_manifest_url, get_index_bucket_names, normpath, index_make_bucket
+
+"""
+Wrapper file for the index implementation in common.py
+IPFS needs some small changes in the index handling, since every write/delete results in 
+new content addresses for the index. 
+"""
+
+
+def ipfs_index_setup(dvconf, force=False):
+    """
+    Set up our index if we haven't already.
+    Return the index manifest URL on success
+    Return the index manifest URL if already setup
+    Return False on error
+    """
+
+    config_path = dvconf['config_path']
+    put_chunk = dvconf['put_chunk']
+    driver_name = dvconf['driver_name']
+    index_stem = dvconf['index_stem']
+    manifest_manipulator = dvconf['driver_info']['manifest_manipulator']
+
+    index_manifest_url = index_settings_get_index_manifest_url(driver_name, config_path)
+    if index_manifest_url is not None and not force:
+        # already set up
+        return index_manifest_url
+
+    index_bucket_names = get_index_bucket_names()
+
+    if index_stem is not None:
+        fq_index_bucket_names = [normpath('/' + os.path.join(index_stem.strip('/'), p)) for p in index_bucket_names]
+    else:
+        fq_index_bucket_names = index_bucket_names
+
+    index_manifest = {}
+    for b in fq_index_bucket_names:
+        bucket_url = index_make_bucket(dvconf, b)
+        if bucket_url is None:
+            log.error("Failed to create bucket {}".format(b))
+            return False
+
+        index_manifest[b] = bucket_url
+
+    # save index manifest
+    manifest_manipulator.cur_manifest_index = index_manifest
+    index_manifest_data = serialize_index_page(index_manifest)
+    index_manifest_url = None
+    try:
+        index_path = index_get_manifest_page_path(index_stem)
+        index_manifest_url = put_chunk(dvconf, index_manifest_data, index_path)
+        assert index_manifest_url
+    except Exception as e:
+        if DEBUG:
+            log.exception(e)
+
+        log.error("Failed to create index manifest")
+        return False
+    return True
+
+
+def ipfs_index_page_find(dvconf, index_stem, name, index_manifest_url=None):
+    manifest_manipulator = dvconf['driver_info']['manifest_manipulator']
+
+    fetched = {}
+    index_manifest_path = index_get_manifest_page_path(index_stem)
+    path = index_get_page_path(name, index_stem)
+
+    log.debug("Get index manifest page ({}, {})".format(index_manifest_url, index_manifest_path))
+    if manifest_manipulator.cur_manifest_index is None:
+        manifest_page = ipfs_index_get_page(dvconf, url=index_manifest_url, path=index_manifest_path)
+        manifest_manipulator.cur_manifest_index = manifest_page
+        if manifest_page is None:
+            log.error("Failed to get manifest page {}".format(index_manifest_url))
+            return None, fetched
+    manifest_page = manifest_manipulator.cur_manifest_index
+    fetched[index_manifest_url] = manifest_page
+
+    if path not in manifest_manipulator.cur_manifest_index.keys():
+        log.error("Bucket {} not in manifest".format(path))
+        if os.environ.get("BLOCKSTACK_TEST") == '1':
+            log.debug("Index manifest:\n{}".format(json.dumps(manifest_page, indent=4, sort_keys=True)))
+
+        return None, fetched
+
+    bucket_url = manifest_page[path]
+    index_page = ipfs_index_get_page(dvconf, url=bucket_url, path=path)
+    if index_page is None:
+        log.error("Failed to get index page {}".format(path))
+        return None, fetched
+
+    return index_page, manifest_page, fetched
+
+
+def ipfs_index_insert(dvconf, name, url, index_manifest_url=None):
+    """
+    Insert a url into the index.
+    and updates the index in the storage
+
+    Return True on success
+    Return False if not.
+    """
+    assert index_setup(dvconf)
+
+    manifest_manipulator = dvconf['driver_info']['manifest_manipulator']
+    index_stem = dvconf['index_stem']
+
+    path = index_get_page_path(name, index_stem)
+    index_page, manifest_page, fetched = ipfs_index_page_find(dvconf, index_stem, name, index_manifest_url=index_manifest_url)
+    if index_page is None:
+        index_page = {}
+    if manifest_page is None:
+        manifest_page = {}
+
+    index_page[name] = url
+
+    put_chunk = dvconf['put_chunk']
+    log.debug("Set index page {}".format(path))
+    new_serialized_index_page = serialize_index_page(index_page)
+
+    rc = put_chunk(dvconf, new_serialized_index_page, path)
+
+    manifest_page[path] = rc
+    new_serialized_manifest_page = serialize_index_page(manifest_page)
+    manifest_manipulator.cur_manifest_index = manifest_page
+    return put_chunk(dvconf, new_serialized_manifest_page, path, use_index_put=True)
+
+
+def ipfs_index_remove(dvconf, name, index_manifest_url=None):
+    """
+    Remove a url from the index.
+    Return True on success
+    Return False if not.
+    """
+    assert index_setup(dvconf)
+
+    manifest_manipulator = dvconf['driver_info']['manifest_manipulator']
+    index_stem = dvconf['index_stem']
+
+    path = index_get_page_path(name, index_stem)
+    index_page, manifest_page, fetched = ipfs_index_page_find(dvconf, index_stem, name,
+                                                              index_manifest_url=index_manifest_url)
+    if index_page is None:
+        log.error("Failed to get index page {}".format(path))
+        return False
+
+    if name not in index_page:
+        # already gone
+        return True
+
+    del index_page[name]
+    put_chunk = dvconf['put_chunk']
+    log.debug("Set index page {}".format(path))
+    new_serialized_index_page = serialize_index_page(index_page)
+
+    rc = put_chunk(dvconf, new_serialized_index_page, path)
+
+    manifest_page[path] = rc
+    new_serialized_manifest_page = serialize_index_page(manifest_page)
+    manifest_manipulator.cur_manifest_index = manifest_page
+    return put_chunk(dvconf, new_serialized_manifest_page, path, use_index_put=True)
+
+
+def ipfs_delete_indexed_data( dvconf, name ):
+    """
+    Delete data from the storage driver,
+    and then delete it from the index.
+
+    Return True on success
+    Return False on error
+    """
+    driver_name = dvconf['driver_name']
+    config_path = dvconf['config_path']
+    delete_chunk = dvconf['delete_chunk']
+
+    log.debug("Delete {}".format(name))
+    res = delete_chunk(dvconf, name)
+    if not res:
+        log.error("Failed to delete {}".format(name))
+        return False
+
+    res = ipfs_index_remove(dvconf, name)
+    if not res:
+        log.error("Failed to delete {} from index".format(name))
+        return False
+
+    return True
+
+
+def ipfs_put_indexed_data( dvconf, name, chunk_buf, raw=False, index=True, index_manifest_url=None):
+    """
+    Put data into the storage system.
+    Compress it (if configured to do so), save it, and then update the index.
+
+    If @raw is True, then do not compress
+    If @index is False, then do not update the index
+
+    Return True on success
+    Return False on error
+    """
+    if dvconf['compress'] and not raw:
+        compressed_chunk = compress_chunk(chunk_buf)
+    else:
+        compressed_chunk = chunk_buf
+
+    put_chunk = dvconf['put_chunk']
+    log.debug("Store {} bytes to {}".format(len(chunk_buf), name))
+
+    # store data
+    new_url = put_chunk(dvconf, compressed_chunk, name)
+    if new_url is None:
+        log.error("Failed to save {}".format(name))
+        return False
+
+    # update index
+    if index:
+        log.debug("Insert ({}, {}) into index".format(name, new_url))
+        rc = ipfs_index_insert( dvconf, name, new_url, index_manifest_url=index_manifest_url)
+        if not rc:
+            log.error("Failed to insert ({}, {}) into index".foramt(name, new_url))
+            return False
+
+    return True
+
+
+def ipfs_index_get_page(dvconf, blockchain_id=None, path=None, url=None):
+    """
+    Get an index page from the storage provider
+    either @path or @url must be given.
+    if @url is given, then @dvconf can be None (but blockchain_id is required)
+
+    Return the dict on success
+    Return None on error
+    """
+    assert url or path
+    if url and not path:
+        assert blockchain_id
+
+    serialized_index_page = None
+    if url and blockchain_id:
+        log.debug("Fetch index page {} via HTTP".format(url))
+        serialized_index_page = get_chunk_via_http(url, blockchain_id=blockchain_id)
+    else:
+        assert path
+        log.debug("Fetch index page {} via driver".format(path))
+        assert dvconf
+        get_chunk = dvconf['get_chunk']
+        serialized_index_page = get_chunk(dvconf, url)
+
+    if serialized_index_page is None:
+        # failed to get index
+        log.error("Failed to get index page {}".format(path))
+        return None
+
+    log.debug("Fetched {} bytes".format(len(serialized_index_page)))
+    index_page = parse_index_page(serialized_index_page)
+    if index_page is None:
+        # invalid
+        log.error("Invalid index page {}".format(path))
+        return None
+
+    return index_page
+
+
+def ipfs_index_lookup(dvconf, index_manifest_url, blockchain_id, name, index_stem='index'):
+    """
+    Given the name, find the URL
+    Return the (URL, {url: page}) on success
+    Return (None, {url: page}) on error
+    """
+    manifest_manipulator = dvconf['driver_info']['manifest_manipulator']
+
+    log.debug("Index lookup on {} from {} via {}".format(name, blockchain_id, index_manifest_url))
+
+    index_manifest_path = index_get_manifest_page_path(index_stem)
+    path = index_get_page_path(name, index_stem)
+
+    fetched = {}
+
+    log.debug("Get index manifest page ({}, {})".format(index_manifest_url, index_manifest_path))
+    #blockchain_id_tmp = blockchain_id if blockchain_id is not None else "dummy"
+    if blockchain_id is not None or manifest_manipulator.cur_manifest_index is None:
+        manifest_page = ipfs_index_get_page(dvconf, blockchain_id=blockchain_id, url=index_manifest_url,
+                                       path=index_manifest_path)
+        if blockchain_id is None:
+            manifest_manipulator.cur_manifest_index = manifest_page
+    else:
+        manifest_page = manifest_manipulator.cur_manifest_index
+
+    if manifest_page is None:
+        log.error("Failed to get manifest page {}".format(index_manifest_url))
+        return None, fetched
+
+    fetched[index_manifest_url] = manifest_page
+
+    if path not in manifest_page.keys():
+        log.error("Bucket {} not in manifest".format(path))
+        if os.environ.get("BLOCKSTACK_TEST") == '1':
+            log.debug("Index manifest:\n{}".format(json.dumps(manifest_page, indent=4, sort_keys=True)))
+
+        return None, fetched
+
+    bucket_url = manifest_page[path]
+    index_page = ipfs_index_get_page(dvconf, blockchain_id=blockchain_id, url=bucket_url, path=path)
+    if index_page is None:
+        log.error("Failed to get index page {}".format(path))
+        return None, fetched
+
+    url = index_page.get(name, None)
+    fetched[bucket_url] = index_page
+    return url, fetched
+
+
+def _ipfs_get_indexed_data_impl(dvconf, blockchain_id, name, raw=False, index_manifest_url=None, data_url=None):
+    """
+    Get data from the storage system via the index.
+    Load it from the index, and decompress it if needed.
+
+    If @raw is True, then do not decompress even if we're configured to do so
+
+    Return (data, None) on success
+    Return (None, None) if we couldn't get data.
+    Return (False, index pages) if we couldn't get index data.
+    """
+    log.debug("get indexed data {} from {}".format(name, blockchain_id))
+
+    driver_name = dvconf['driver_name']
+    config_path = dvconf['config_path']
+    index_stem = dvconf['index_stem']
+    manifest_manipulator = dvconf['driver_info']['manifest_manipulator']
+    index_pages = {}
+    cache_hit = False
+    given_manifest_url = False
+
+    if index_manifest_url is None:
+        # try cache
+        index_manifest_url = index_get_cached_manifest_url(blockchain_id, driver_name)
+        if index_manifest_url is not None:
+            cache_hit = True
+
+    else:
+        given_manifest_url = True
+
+    if index_manifest_url is None:
+        # not cached, or didn't check
+        # go look it up.
+        index_manifest_url = None
+        try:
+            index_manifest_url = lookup_index_manifest_url(blockchain_id, driver_name, config_path)
+        except Exception as e:
+            if DEBUG:
+                log.exception(e)
+
+            log.error("Failed to get index manifest URL for {}".format(blockchain_id))
+            return False, {}
+
+        if index_manifest_url is None:
+            log.error("Profile for {} is not connected to '{}'".format(blockchain_id, driver_name))
+            return False, {}
+
+    if data_url is None:
+        # try the cache first...
+        data_url = index_cached_lookup(index_manifest_url, blockchain_id, name, index_stem)
+        if data_url is not None:
+            cache_hit = True
+
+    if data_url is None:
+        # cache miss
+        # go get the url for this data
+        data_url, index_pages = ipfs_index_lookup(dvconf, index_manifest_url, blockchain_id, name, index_stem=index_stem)
+        if data_url is None:
+            log.error("No data URL from index for '{}'".format(name))
+            return False, {}
+
+    log.debug("Fetch {} via HTTP at {} (cached url: {})".format(name, data_url, cache_hit))
+    data = get_chunk_via_http(data_url, blockchain_id=blockchain_id)
+    if data is None:
+        log.error("Failed to load {} from {}".format(name, data_url))
+
+        if cache_hit:
+            # might be due to stale cached index data
+            return False, index_pages
+
+        else:
+            return None, None
+
+    if dvconf['compress'] and not raw:
+        data = decompress_chunk(data)
+        if data is None:
+            # corrupt
+            return None, None
+
+    # success! cache any index information
+    if blockchain_id is not None:
+        for (url, page) in index_pages.items():
+            index_set_cached_page(blockchain_id, url, page)
+
+        if not given_manifest_url:
+            index_set_cached_manifest_url(blockchain_id, driver_name, index_manifest_url)
+
+    return data, None
+
+
+def ipfs_get_indexed_data(dvconf, blockchain_id, name, raw=False, index_manifest_url=None ):
+    """
+    Get indexed data.
+    Load it from the index, and decompress it if needed.
+
+    Return the data on success.
+    Return None on error
+    """
+    driver_name = dvconf['driver_name']
+
+    # try cache path first
+    data, pages = _ipfs_get_indexed_data_impl(dvconf, blockchain_id, name, raw=raw, index_manifest_url=index_manifest_url)
+    if data == False:
+        if blockchain_id:
+            # reading someone else's datastore
+            log.warning("Failed to load fresh cached data when fetching {} from {}".format(name, blockchain_id))
+
+            # clear index caches for this data and try again
+            for (url, _) in pages.items():
+                index_remove_cached_page(blockchain_id, url)
+
+            index_remove_cached_manifest_url(blockchain_id, driver_name)
+
+            # try again
+            data, pages = _ipfs_get_indexed_data_impl(dvconf, blockchain_id, name, raw=raw, index_manifest_url=index_manifest_url)
+            if data is None or data == False:
+                log.error("Failed to load data for {} from {} when forcing cache misses".format(name, blockchain_id))
+                data = None
+
+            else:
+                log.debug("Loaded {} bytes for {} from {} when forcing cache misses".format(len(data), name, blockchain_id))
+
+        else:
+            # reading our own datastore, and failed.
+            data = None
+
+    if data is None:
+        log.error("Failed to load data for {} from {}".format(name, blockchain_id))
+
+    return data


### PR DESCRIPTION
Experimental indexed storage driver for IPFS in response to [#430](https://github.com/blockstack/blockstack-core/issues/430)

!Not fully tested yet

This IPFS driver uses an index similar to the one in the dropbox.py driver.
Assumptions:
- The writing/deleting user operates on an IPFS node, which contains a public/private key pair tagged with his blockstack id. The driver maps this IPNS (Hash of this public key) address to the current valid index manifest.
 [example index manifest](https://gateway.ipfs.io/ipns/QmfYEYcX9KY9PUuwr1a4VgNgtAxJ81ZEsNF4Tid6GTp87z)

Problems:
- Currently, an IPNS publish operation is **very** slow. In the implementation, the IPNS publish runs asynchronously in the background, which might cause consistency problems.
- On every insert/update/delete the IPNS address has to be republished since the index content has changed.

