### PR TITLE
make the errors component of the info response only appear if there is an error

### DIFF
--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -790,7 +790,8 @@ def cli_get_registrar_info(args, config_path=CONFIG_PATH, queues=None):
 
         new_entry['confirmations'] = confirmations
         new_entry['tx_hash'] = entry['tx_hash']
-        new_entry['errors'] = entry['errors']
+        if 'errors' in entry:
+            new_entry['errors'] = entry['errors']
 
         return new_entry
 

--- a/blockstack_client/backend/queue.py
+++ b/blockstack_client/backend/queue.py
@@ -435,8 +435,9 @@ def get_queue_state(queue_ids=None, limit=None, path=DEFAULT_QUEUE_PATH):
         state += rows
 
     for row in state:
-        row['errors'] = queue_get_error_msgs(row['type'], row['fqu'], path=path)
-
+        errors = queue_get_error_msgs(row['type'], row['fqu'], path=path)
+        if len(errors) > 0:
+            row['errors'] = errors
     return state
 
 

--- a/integration_tests/blockstack_integration_tests/scenarios/name_transfer_not_enough_coin.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/name_transfer_not_enough_coin.py
@@ -28,6 +28,7 @@ import json
 import sys
 import os
 import blockstack_client
+import blockstack_client.backend
 
 wallets = [
     testlib.Wallet( "5JesPiN68qt44Hc2nT8qmyZ1JDwHebfoh9KQ52Lazb1m1LaKNj9", 100000000000 ),
@@ -64,6 +65,9 @@ def scenario( wallets, **kw ):
     # wait for the poller to pick it up
     print >> sys.stderr, "Waiting 10 seconds for the backend to submit the register"
     time.sleep(10)
+
+    r = blockstack_client.actions.cli_get_registrar_info(None)
+    assert 'errors' not in r['register'][0]
 
     # wait for the register to get confirmed 
     for i in xrange(0, 12):
@@ -103,5 +107,8 @@ def check( state_engine ):
     if ns['namespace_id'] != 'id':
         print "wrong namespace"
         return False 
+
+    r = blockstack_client.actions.cli_get_registrar_info(None)
+    assert 'errors' in r['update'][0]
 
     return True


### PR DESCRIPTION
Also makes the integration test check for the proper error returns:

Adds `errors` field to blockstack info responses

```
{
    "advanced_mode": true, 
    "cli_version": "0.14.2.0", 
    "consensus_hash": "de5d6aa94003c5aa6de3f747453ebf80", 
    "last_block_processed": 396, 
    "last_block_seen": 396, 
    "queues": {
        "update": [
            {
                "confirmations": 113, 
                "errors": [
                    "Failed to broadcast transfer transaction: Unable to transfer name:\n  * check \"get_balance\" failed.  "
                ], 
                "name": "foo.id", 
                "tx_hash": "e2cdc0a352e9aab813f950a8c2fab0d6699ac26cd01f6108bbfd78e18aa7018f"
            }
        ]
    }, 
    "server_alive": true, 
    "server_host": "localhost", 
    "server_port": 16264, 
    "server_version": "0.14.2.0"
}
```
For now, the only error supported is the above -- transfer operations failing.
