### PR TITLE
Support for setting minimum confirmations for wallet balance

### DIFF
--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -361,6 +361,7 @@ def cli_balance(args, config_path=CONFIG_PATH):
     """
     command: balance
     help: Get the account balance
+    opt: min_confs (int) 'The minimum confirmations of transactions to include in balance'
     """
 
     config_dir = os.path.dirname(config_path)
@@ -370,10 +371,13 @@ def cli_balance(args, config_path=CONFIG_PATH):
     if 'error' in res:
         return res
 
+    min_confs = getattr(args, 'min_confs', None)
+
     result = {}
     addresses = []
     satoshis = 0
-    satoshis, addresses = get_total_balance(wallet_path=wallet_path, config_path=config_path)
+    satoshis, addresses = get_total_balance(
+        wallet_path=wallet_path, config_path=config_path, min_confs = min_confs)
 
     if satoshis is None:
         log.error('Failed to get balance')

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -1926,14 +1926,23 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             return self._reply_json(res)
 
 
-    def GET_wallet_balance( self, ses, path_info ):
+    def GET_wallet_balance( self, ses, path_info, min_confs = None ):
         """
         Get the wallet balance
         Return 200 with the balance
         Return 500 on error
         """
         internal = self.server.get_internal_proxy()
-        res = internal.cli_balance(config_path=self.server.config_path)
+        if min_confs is None:
+            res = internal.cli_balance(config_path=self.server.config_path)
+        else:
+            try:
+                min_confs = int(min_confs)
+            except:
+                log.warn("Couldn't parse argument to min_confs of wallet_balance.")
+                min_confs = None
+            res = internal.cli_balance(min_confs,
+                                       config_path=self.server.config_path)
         if 'error' in res:
             log.debug("Failed to query wallet balance: {}".format(res['error']))
             return self._reply_json({'error': 'Failed to query wallet balance'}, status_code=503)
@@ -3022,6 +3031,20 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                     'POST': {
                         'name': 'wallet_write',
                         'desc': 'transfer the node wallet\'s funds',
+                        'auth_session': True,
+                        'auth_pass': True,
+                        'need_data_key': False,
+                    },
+                },
+            },
+            r'^/v1/wallet/balance/([0-9]{1,3})$': {
+                'routes': {
+                    'GET': self.GET_wallet_balance,
+                },
+                'whitelist': {
+                    'GET': {
+                        'name': 'wallet_read',
+                        'desc': 'get the node wallet\'s balance',
                         'auth_session': True,
                         'auth_pass': True,
                         'need_data_key': False,

--- a/blockstack_client/wallet.py
+++ b/blockstack_client/wallet.py
@@ -1049,7 +1049,7 @@ def get_addresses_from_file(config_dir=CONFIG_DIR, wallet_path=None):
     return payment_address, owner_address, data_pubkey
 
 
-def get_payment_addresses_and_balances(config_path=CONFIG_PATH, wallet_path=None):
+def get_payment_addresses_and_balances(config_path=CONFIG_PATH, wallet_path=None, min_confs=None):
     """
     Get payment addresses and balances.
     Each payment address will have a balance in satoshis.
@@ -1068,7 +1068,7 @@ def get_payment_addresses_and_balances(config_path=CONFIG_PATH, wallet_path=None
     )
 
     if payment_address is not None:
-        balance = get_balance(payment_address, config_path=config_path)
+        balance = get_balance(payment_address, config_path=config_path, min_confirmations=min_confs)
         if balance is None:
             payment_addresses.append( {'error': 'Failed to get balance for {}'.format(payment_address)} )
 
@@ -1124,7 +1124,7 @@ def get_all_names_owned(wallet_path=WALLET_PATH):
     return names_owned
 
 
-def get_total_balance(config_path=CONFIG_PATH, wallet_path=WALLET_PATH):
+def get_total_balance(config_path=CONFIG_PATH, wallet_path=WALLET_PATH, min_confs=None):
     """
     Get the total balance for the wallet's payment address.
     Units will be in satoshis.
@@ -1132,7 +1132,8 @@ def get_total_balance(config_path=CONFIG_PATH, wallet_path=WALLET_PATH):
     Returns units, addresses on success
     Returns None, {'error': ...} on error
     """
-    payment_addresses = get_payment_addresses_and_balances(wallet_path=wallet_path, config_path=config_path)
+    payment_addresses = get_payment_addresses_and_balances(
+        wallet_path=wallet_path, config_path=config_path, min_confs=min_confs)
     total_balance = 0.0
 
     for entry in payment_addresses:

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -40,6 +40,7 @@ Each application specifies in advance which family of API calls it will need to 
 | Get the wallet | GET /v1/wallet/keys | - | Requires a pre-shared secret in the `Authorization:` header |
 | - | - | - | - |
 | Get the wallet balance | GET /v1/wallet/balance | wallet_read | - |
+| Get the wallet balance, specifying the minconfs for txns included | GET /v1/wallet/balance/{minconfs} | wallet_read | - |
 | Withdraw funds from the wallet | POST /v1/wallet/balance | wallet_write | Payload: `{'address': str, 'amount': int, 'min_confs': int, 'tx_only':  bool} |
 | - | - | - | - |
 | Change wallet password | PUT /v1/wallet/password | wallet_write | Payload: `{'password': ..., 'new_password': ...}`|

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_minconfs.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_minconfs.py
@@ -182,7 +182,7 @@ def scenario( wallets, **kw ):
 
     # make a session 
     datastore_pk = keylib.ECPrivateKey(wallets[-1].privkey).to_hex()
-    res = testlib.blockstack_cli_app_signin("foo.test", datastore_pk, 'register.app', ['names', 'register', 'prices', 'zonefiles', 'blockchain', 'node_read'])
+    res = testlib.blockstack_cli_app_signin("foo.test", datastore_pk, 'register.app', ['names', 'register', 'prices', 'zonefiles', 'blockchain', 'node_read', 'wallet_read'])
     if 'error' in res:
         print json.dumps(res, indent=4, sort_keys=True)
         error = True
@@ -197,6 +197,22 @@ def scenario( wallets, **kw ):
 
     # register the name bar.test (no zero-conf, should fail)
     res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data={'name': 'bar.test', 'zonefile': zonefile_txt, 'owner_address': wallets[4].addr})
+    if res['http_status'] == 200:
+        print 'accidentally succeeded to register bar.test'
+        print res
+        return False
+
+    # let's test /v1/wallet/balance
+    res = testlib.blockstack_REST_call('GET', '/v1/wallet/balance', ses)
+    if res['http_status'] != 200:
+        print '/v1/wallet/balance returned ERR'
+        print json.dumps(res)
+        return False
+    print "FIND: {}".format(json.dumps(res))
+    return False
+
+    # register the name bar.test (1-conf, should fail)
+    res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data={'name': 'bar.test', 'zonefile': zonefile_txt, 'owner_address': wallets[4].addr, 'min_confs' : 1})
     if res['http_status'] == 200:
         print 'accidentally succeeded to register bar.test'
         print res

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_minconfs.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_minconfs.py
@@ -208,8 +208,21 @@ def scenario( wallets, **kw ):
         print '/v1/wallet/balance returned ERR'
         print json.dumps(res)
         return False
-    print "FIND: {}".format(json.dumps(res))
-    return False
+    if res['response']['balance']['satoshis'] > 0:
+        print '/v1/wallet/balance accidentally incorporated 0-conf txns in balance register bar.test'
+        print json.dumps(res['response'])
+        return False
+
+    # let's test /v1/wallet/balance with minconfs=0
+    res = testlib.blockstack_REST_call('GET', '/v1/wallet/balance/0', ses)
+    if res['http_status'] != 200:
+        print '/v1/wallet/balance/0 returned ERR'
+        print json.dumps(res)
+        return False
+    if res['response']['balance']['satoshis'] < 1e6:
+        print "/v1/wallet/balance/0 didn't incorporate 0-conf txns"
+        print json.dumps(res['response'])
+        return False
 
     # register the name bar.test (1-conf, should fail)
     res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data={'name': 'bar.test', 'zonefile': zonefile_txt, 'owner_address': wallets[4].addr, 'min_confs' : 1})


### PR DESCRIPTION
```
GET /v1/wallet/balance/<minconfs>
```

will return a balance that includes txns with the specified number of minimum confirmations (integration test checks that it works with zero)

```
GET /v1/wallet/balance
```

is unchanged.