### PR TITLE
Registrar tracking owner address

### DIFF
--- a/blockstack_client/backend/nameops.py
+++ b/blockstack_client/backend/nameops.py
@@ -61,6 +61,10 @@ from ..utxo import get_unspents
 import virtualchain
 from virtualchain.lib.ecdsalib import ecdsa_private_key
 
+from ..constants import get_secret
+from .crypto.utils import aes_decrypt
+from binascii import hexlify
+
 log = get_logger("blockstack-client")
 
 
@@ -2118,6 +2122,8 @@ def async_preorder(fqu, payment_privkey_info, owner_privkey_info, cost, name_dat
         additionals['confirmations_needed'] = 4
     if 'min_payment_confs' in name_data:
         additionals['min_payment_confs'] = name_data['min_payment_confs']
+    if 'owner_privkey' in name_data:
+        additionals['owner_privkey'] = name_data['owner_privkey']
     if 'transaction_hash' in resp:
         if not BLOCKSTACK_DRY_RUN:
             # watch this preorder, and register it when it gets queued
@@ -2137,6 +2143,18 @@ def async_preorder(fqu, payment_privkey_info, owner_privkey_info, cost, name_dat
 
     return resp
 
+def check_owner_privkey_info(owner_privkey_info, name_data):
+    owner_address = virtualchain.get_privkey_address(owner_privkey_info)
+    if 'owner_address' in name_data and owner_address != name_data['owner_address']:
+       log.debug("Registrar owner address changed since beginning registration : from {} to {}".format(
+           name_data['owner_address'], owner_address))
+       owner_address = name_data['owner_address']
+       passwd = get_secret('BLOCKSTACK_CLIENT_WALLET_PASSWORD')
+       owner_privkey_info = aes_decrypt(
+           str(name_data['owner_privkey']), hexlify( passwd ))
+       if not virtualchain.get_privkey_address(owner_privkey_info) == owner_address:
+           raise Exception("Attempting to correct registrar address to {}, but failed!".format(owner_address))
+    return owner_address, owner_privkey_info
 
 def async_register(fqu, payment_privkey_info, owner_privkey_info, name_data={},
                    proxy=None, config_path=CONFIG_PATH, queue_path=DEFAULT_QUEUE_PATH, safety_checks=True):
@@ -2164,7 +2182,8 @@ def async_register(fqu, payment_privkey_info, owner_privkey_info, name_data={},
 
     tx_broadcaster = get_tx_broadcaster( config_path=config_path )
 
-    owner_address = virtualchain.get_privkey_address( owner_privkey_info )
+    owner_address, owner_privkey_info = check_owner_privkey_info( owner_privkey_info, name_data )
+
     payment_address = virtualchain.get_privkey_address( payment_privkey_info )
 
     # check register_queue first
@@ -2201,6 +2220,8 @@ def async_register(fqu, payment_privkey_info, owner_privkey_info, name_data={},
         force_register = True
     if 'min_payment_confs' in name_data:
         additionals['min_payment_confs'] = name_data['min_payment_confs']
+    if 'owner_privkey' in name_data:
+        additionals['owner_privkey'] = name_data['owner_privkey']
 
     try:
         resp = do_register( fqu, payment_privkey_info, owner_privkey_info, utxo_client, tx_broadcaster,
@@ -2286,7 +2307,7 @@ def async_update(fqu, zonefile_data, profile, owner_privkey_info, payment_privke
 
     tx_broadcaster = get_tx_broadcaster(config_path=config_path)
 
-    owner_address = virtualchain.get_privkey_address( owner_privkey_info )
+    owner_address, owner_privkey_info = check_owner_privkey_info( owner_privkey_info, name_data )
 
     if in_queue("update", fqu, path=queue_path):
         log.error("Already in update queue: %s" % fqu)
@@ -2301,6 +2322,9 @@ def async_update(fqu, zonefile_data, profile, owner_privkey_info, payment_privke
         additionals['unsafe_reg'] = register_data['unsafe_reg']
         additionals['confirmations_needed'] = 1
         force_update = True
+
+    if 'owner_privkey' in name_data:
+        additionals['owner_privkey'] = name_data['owner_privkey']
 
     resp = {}
     try:
@@ -2333,7 +2357,7 @@ def async_update(fqu, zonefile_data, profile, owner_privkey_info, payment_privke
 
 
 def async_transfer(fqu, transfer_address, owner_privkey_info, payment_privkey_info, 
-                   config_path=CONFIG_PATH, proxy=None, queue_path=DEFAULT_QUEUE_PATH):
+                   config_path=CONFIG_PATH, proxy=None, queue_path=DEFAULT_QUEUE_PATH, name_data = {}):
     """
         Transfer a previously registered fqu, using a different payment address.
         Preserves the zonefile.
@@ -2353,7 +2377,7 @@ def async_transfer(fqu, transfer_address, owner_privkey_info, payment_privkey_in
     utxo_client = get_utxo_provider_client(config_path=config_path)
     tx_broadcaster = get_tx_broadcaster(config_path=config_path)
 
-    owner_address = virtualchain.get_privkey_address( owner_privkey_info )
+    owner_address, owner_privkey_info = check_owner_privkey_info( owner_privkey_info, name_data )
 
     if in_queue("transfer", fqu, path=queue_path):
         log.error("Already in transfer queue: %s" % fqu)
@@ -2366,13 +2390,17 @@ def async_transfer(fqu, transfer_address, owner_privkey_info, payment_privkey_in
         log.exception(e)
         return {'error': 'Failed to sign and broadcast transfer transaction'}
 
+    additionals = {}
+    if 'owner_privkey' in name_data:
+        additionals['owner_privkey'] = name_data['owner_privkey']
+
     if 'transaction_hash' in resp:
         if not BLOCKSTACK_DRY_RUN:
             queue_append("transfer", fqu, resp['transaction_hash'],
                          owner_address=owner_address,
                          transfer_address=transfer_address,
                          config_path=config_path,
-                         path=queue_path)
+                         path=queue_path, **additionals)
     else:
         assert 'error' in resp
         log.error("Error transferring: %s" % fqu)

--- a/blockstack_client/backend/queue.py
+++ b/blockstack_client/backend/queue.py
@@ -319,6 +319,7 @@ def queue_append(queue_id, fqu, tx_hash, payment_address=None,
                  config_path=CONFIG_PATH, block_height=None,
                  zonefile_data=None, profile=None, zonefile_hash=None,
                  unsafe_reg = None, confirmations_needed = None,
+                 owner_privkey=None,
                  min_payment_confs = None, path=DEFAULT_QUEUE_PATH):
 
     """
@@ -348,6 +349,8 @@ def queue_append(queue_id, fqu, tx_hash, payment_address=None,
         new_entry['confirmations_needed'] = confirmations_needed
     if min_payment_confs is not None:
         new_entry['min_payment_confs'] = min_payment_confs
+    if owner_privkey is not None:
+        new_entry['owner_privkey'] = owner_privkey
 
     if zonefile_data is not None:
         new_entry['zonefile_b64'] = base64.b64encode(zonefile_data)

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -857,12 +857,14 @@ class RegistrarWorker(threading.Thread):
 
                     # try exponential backoff
                     failed = True
-                    poll_interval = 1.0
+                    if poll_interval >= self.poll_interval:
+                        poll_interval = 1.0
 
             except Exception, e:
                 log.exception(e)
                 failed = True
-                poll_interval = 1.0
+                if poll_interval >= self.poll_interval:
+                    poll_interval = 1.0
 
             try:
                 # see if we can put any zonefiles
@@ -874,12 +876,14 @@ class RegistrarWorker(threading.Thread):
 
                     # try exponential backoff 
                     failed = True
-                    poll_interval = 1.0
+                    if poll_interval >= self.poll_interval:
+                        poll_interval = 1.0
 
             except Exception, e:
                 log.exception(e)
                 failed = True
-                poll_interval = 1.0
+                if poll_interval >= self.poll_interval:
+                    poll_interval = 1.0
 
             try:
                 # see if we can replicate any zonefiles and profiles
@@ -891,13 +895,15 @@ class RegistrarWorker(threading.Thread):
 
                     # try exponential backoff
                     failed = True
-                    poll_interval = 1.0
+                    if poll_interval >= self.poll_interval:
+                        poll_interval = 1.0
                     failed_names += res['names']
 
             except Exception, e:
                 log.exception(e)
                 failed = True
-                poll_interval = 1.0
+                if poll_interval >= self.poll_interval:
+                    poll_interval = 1.0
 
             try:
                 # see if we can transfer any names to their new owners
@@ -908,13 +914,15 @@ class RegistrarWorker(threading.Thread):
 
                     # try exponential backoff
                     failed = True
-                    poll_interval = 1.0
+                    if poll_interval >= self.poll_interval:
+                        poll_interval = 1.0
                     failed_names += res['names']
 
             except Exception as e:
                 log.exception(e)
                 failed = True
-                poll_interval = 1.0
+                if poll_interval >= self.poll_interval:
+                    poll_interval = 1.0
 
             try:
                 # see if we can replicate any zonefiles for name imports
@@ -926,13 +934,15 @@ class RegistrarWorker(threading.Thread):
 
                     # try exponential backoff
                     failed = True
-                    poll_interval = 1.0
+                    if poll_interval >= self.poll_interval:
+                        poll_interval = 1.0
                     failed_names += res['names']
 
             except Exception, e:
                 log.exception(e)
                 failed = True
-                poll_interval = 1.0
+                if poll_interval >= self.poll_interval:
+                    poll_interval = 1.0
 
             try:
                 # see if we can remove any other confirmed operations, besides preorders, registers, and updates
@@ -943,16 +953,19 @@ class RegistrarWorker(threading.Thread):
 
                     # try exponential backoff
                     failed = True
-                    poll_interval = 1.0
+                    if poll_interval >= self.poll_interval:
+                        poll_interval = 1.0
 
             except Exception, e:
                 log.exception(e)
                 failed = True
-                poll_interval = 1.0
+                if poll_interval >= self.poll_interval:
+                    poll_interval = 1.0
 
             # if we failed a step, then try again quickly with exponential backoff
             if failed:
                 poll_interval = 2 * poll_interval + random.random() * poll_interval
+                poll_interval = min( poll_interval, self.poll_interval )
 
             else:
                 # succeeded. resume normal polling 

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -62,7 +62,7 @@ import backend.drivers as backend_drivers
 import proxy
 from proxy import json_is_error, json_is_exception
 
-from .constants import BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH, WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION, TX_MAX_FEE
+from .constants import BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH, WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION, TX_MAX_FEE, set_secret, get_secret
 from .method_parser import parse_methods
 from .wallet import make_wallet
 import app
@@ -4812,6 +4812,9 @@ def local_api_start( port=None, host=None, config_dir=blockstack_constants.CONFI
     """
 
     global rpc_pidpath, rpc_srv, running
+
+    if password:
+        set_secret("BLOCKSTACK_CLIENT_WALLET_PASSWORD", password)
 
     p = subprocess.Popen("pip freeze", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_set_key.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_set_key.py
@@ -58,6 +58,8 @@ resource_data = "hello world"
 new_key = "cPo24qGYz76xSbUCug6e8LzmzLGJPZoowQC7fCVPLN2tzCUJgfcW"
 new_addr = "mqnupoveYRrSHmrxFT9nQQEZt3RLsetbBQ"
 
+insanity_key = "cSCyE5Q1AFVyDAL8LkHo1sFMVqmwdvFcCbGJ71xEvto2Nrtzjm67"
+
 def scenario( wallets, **kw ):
 
     global wallet_keys, wallet_keys_2, error, index_file_data, resource_data
@@ -263,6 +265,104 @@ def scenario( wallets, **kw ):
         print json.dumps(res)
         return False
 
+
+    ### Now, we'll do it again, but this time, we're going to CHANGE THE KEY in the middle of registrations.
+    ### to test the different paths, I'll start 3 registrations:
+    # 1 has submitted preorder
+    # 1 has submitted register
+    # 1 has submitted update
+    ### And then I'll issue a change-key
+
+
+    # make zonefile for recipients
+    zonefiles = []
+    for i in [1,2,3]:
+        name = "tricky{}.test".format(i)
+        driver_urls = blockstack_client.storage.make_mutable_data_urls(name, use_only=['dht', 'disk'])
+        zonefile = blockstack_client.zonefile.make_empty_zonefile(name, wallets[4].pubkey_hex, urls=driver_urls)
+        zonefiles.append(blockstack_zones.make_zone_file( zonefile, origin=name, ttl=3600 ))
+
+    # leaving the call format of this one the same to make sure that our registrar correctly
+    #   detects that the requested TRANSFER is superfluous
+    res = testlib.blockstack_REST_call(
+        'POST', '/v1/names', ses, data={'name':'tricky1.test', 'zonefile':zonefiles[0], 'owner_address':new_addr})
+    if 'error' in res:
+        res['test'] = 'Failed to register tricky1.test'
+        print json.dumps(res)
+        error = True
+        return False
+
+    tx_hash = res['response']['transaction_hash']
+    # wait for preorder to get confirmed...
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.blockstack_REST_call(
+        'POST', '/v1/names', ses, data={'name':'tricky2.test', 'zonefile':zonefiles[1], 'owner_address':new_addr})
+    if 'error' in res:
+        res['test'] = 'Failed to register tricky2.test'
+        print json.dumps(res)
+        error = True
+        return False
+
+    # wait for the preorder to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    # wait for register to go through
+    print 'Wait for register to be submitted'
+    time.sleep(10)
+
+    # wait for the register to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.blockstack_REST_call(
+        'POST', '/v1/names', ses, data={'name':'tricky3.test', 'zonefile':zonefiles[2], 'owner_address':new_addr})
+    if 'error' in res:
+        res['test'] = 'Failed to register tricky3.test'
+        print json.dumps(res)
+        error = True
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for update to be submitted'
+    time.sleep(10)
+
+    for i in xrange(0, 1):
+        testlib.next_block( **kw )
+
+
+
+    res = testlib.verify_in_queue(ses, 'tricky1.test', 'update', None)
+    res = testlib.verify_in_queue(ses, 'tricky2.test', 'register', None)
+    res = testlib.verify_in_queue(ses, 'tricky3.test', 'preorder', None)
+
+    # let's go crazy.
+    res = testlib.blockstack_REST_call('PUT', '/v1/wallet/keys/owner', None, api_pass=api_pass,
+                                       data=insanity_key)
+    if res['http_status'] != 200 or 'error' in res:
+        print 'failed to set owner key'
+        print res
+        return False
+
+
+    # wait for preorder to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+    # wake up registrar, submit register
+    time.sleep(10)
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+    # wake up registrar, submit update
+    time.sleep(10)
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+    # wake up registrar, propogate zonefile
+    time.sleep(10)
+
 def check( state_engine ):
 
     global wallet_keys, error, index_file_data, resource_data
@@ -289,9 +389,8 @@ def check( state_engine ):
         print "wrong namespace"
         return False 
 
-    names = ['foo.test', 'bar.test']
-    owners = [ wallets[3].addr , new_addr ]
-    wallet_keys_list = [wallet_keys, wallet_keys]
+    names = ['foo.test', 'bar.test', 'tricky1.test', 'tricky2.test', 'tricky3.test']
+    owners = [ wallets[3].addr , new_addr, new_addr, new_addr, new_addr ]
     test_proxy = testlib.TestAPIProxy()
 
     for i in xrange(0, len(names)):


### PR DESCRIPTION
Registrar now tracks the owner address of the multi-op registration. The owner's private key is scrypted using the wallet password (which was already stored in registrar memory using our secrets passing mechanism), and then stored in the registrar's queue.db. When the registrar's owner key has changed over the course of a registration (from either a call to `/v1/wallet/keys/` or the registrar restarting), the registrar detects this, and uses the encrypted key to proceed with registration. If the wallet password changes, however, the registrar will be SOL. 