### PR TITLE
Verifying `Origin` headers in blockstack-core

### DIFF
--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -64,6 +64,7 @@ import proxy
 from proxy import json_is_error, json_is_exception
 
 DEFAULT_UI_PORT = 8888
+DEVELOPMENT_UI_PORT = 3000
 
 from .constants import BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH, WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION, TX_MAX_FEE
 from .method_parser import parse_methods
@@ -3519,13 +3520,15 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             },
         }
         
-        LOCALHOST = [
-            'http://localhost:{}'.format(DEFAULT_UI_PORT),
-            'http://{}:{}'.format(socket.gethostname(), DEFAULT_UI_PORT),
-            'http://127.0.0.1:{}'.format(DEFAULT_UI_PORT),
-            'http://::1:{}'.format(DEFAULT_UI_PORT)
-        ]
-        
+        LOCALHOST = []
+        for port in [DEFAULT_UI_PORT, DEVELOPMENT_UI_PORT]:
+            LOCALHOST += [
+                'http://localhost:{}'.format(port),
+                'http://{}:{}'.format(socket.gethostname(), port),
+                'http://127.0.0.1:{}'.format(port),
+                'http://::1:{}'.format(port)
+            ]
+
         path_info = self.get_path_and_qs()
         if 'error' in path_info:
             self._send_headers(status_code=401, content_type='text/plain')

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -63,7 +63,9 @@ import backend.drivers as backend_drivers
 import proxy
 from proxy import json_is_error, json_is_exception
 
-from .constants import BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH, WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION, TX_MAX_FEE, DEFAULT_UI_PORT
+DEFAULT_UI_PORT = 8888
+
+from .constants import BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH, WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION, TX_MAX_FEE
 from .method_parser import parse_methods
 from .wallet import make_wallet
 import app

--- a/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
+++ b/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
@@ -111,10 +111,11 @@ class APITestCase(unittest.TestCase):
             traceback.print_exc()
             raise e
 
-def get_auth_header(key = None):
+def get_auth_header(key = None, port = 8888):
     if key is None:
         key = API_PASSWORD
-    return {'Authorization' : 'bearer {}'.format(key)}
+    return {'Authorization' : 'bearer {}'.format(key),
+            'Origin' : 'http://localhost:{}'.format(port)}
 
 def check_data(cls, data, required_keys={}):
     for k in required_keys:
@@ -138,7 +139,8 @@ class AuthInternal(APITestCase):
         privkey = ("a28ea1a6f11fb1c755b1d102990d64d6" +
                    "b4468c10705bbcbdfca8bc4497cf8da8")
 
-        auth_header = get_auth_header()
+        # test support for the development UI port as well (3000)
+        auth_header = get_auth_header(port = 3000)
         request = {
             'app_domain': 'test.com',
             'app_public_key': blockstack_client.keys.get_pubkey_hex(privkey),

--- a/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
+++ b/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
@@ -135,7 +135,7 @@ class PingTest(APITestCase):
         self.assertTrue(data['status'] == 'alive')
 
 class AuthInternal(APITestCase):
-    def test_get_and_use_session_token(self):
+    def test_get_and_use_session_token_domain(self):
         privkey = ("a28ea1a6f11fb1c755b1d102990d64d6" +
                    "b4468c10705bbcbdfca8bc4497cf8da8")
 
@@ -152,12 +152,55 @@ class AuthInternal(APITestCase):
 
         url = "/v1/auth?authRequest={}".format(package)
         data = self.get_request(url, headers = auth_header, status_code=200)
+
         self.assertIn('token', data)
         session = data['token']
 
         auth_header = get_auth_header(session)
+
+        # test wrong origin
+        data = self.get_request('/v1/wallet/payment_address',
+                                headers = auth_header, status_code=403)
+        # test correct origin
+        auth_header['Origin'] = 'http://test.com'
         data = self.get_request('/v1/wallet/payment_address',
                                 headers = auth_header, status_code=200)
+
+        data = self.get_request('/v1/users/muneeb.id',
+                                headers = auth_header, status_code=403)
+        self.assertIn('error', data)
+
+    def test_get_and_use_session_token_url(self):
+        privkey = ("a28ea1a6f11fb1c755b1d102990d64d6" +
+                   "b4468c10705bbcbdfca8bc4497cf8da8")
+
+        # test support for the development UI port as well (3000)
+        auth_header = get_auth_header(port = 3000)
+        request = {
+            'app_domain': 'http://test.com',
+            'app_public_key': blockstack_client.keys.get_pubkey_hex(privkey),
+            'methods': ['wallet_read'],
+        }
+
+        signer = jsontokens.TokenSigner()
+        package = signer.sign(request, privkey)
+
+        url = "/v1/auth?authRequest={}".format(package)
+        data = self.get_request(url, headers = auth_header, status_code=200)
+
+        self.assertIn('token', data)
+        session = data['token']
+
+        auth_header = get_auth_header(session)
+
+        # test wrong origin
+        data = self.get_request('/v1/wallet/payment_address',
+                                headers = auth_header, status_code=403)
+        # test correct origin
+        auth_header['Origin'] = 'http://test.com'
+        data = self.get_request('/v1/wallet/payment_address',
+                                headers = auth_header, status_code=200)
+
         data = self.get_request('/v1/users/muneeb.id',
                                 headers = auth_header, status_code=403)
         self.assertIn('error', data)


### PR DESCRIPTION
This ensures that core checks that on Authorization, one of two things must be satisfied:

1. If the client is authorizing with an API password, the Origin header must be present and either `http://localhost:8888` or `http://localhost:3000`

2. If the client is authorizing with an app session token, the Origin header must be present and equal to the `app_domain` in the session token.