### PR TITLE
Fixes a handful of integration tests

### DIFF
--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_update.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_update.py
@@ -254,13 +254,13 @@ def scenario( wallets, **kw ):
         return False
 
     # get the latest zonefile
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(last_zonefile_hash), ses )
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}?raw=1".format(last_zonefile_hash), ses )
     if 'error' in res or res['http_status'] != 200:
         res['test'] = 'Failed to get last zonefile'
         print json.dumps(res)
         return False
 
-    if res['response']['zonefile'] != 'hello world':
+    if res['raw'] != 'hello world':
         res['test'] = 'Failed to set zonefile data'
         print json.dumps(res)
         return False

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_update_zf.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_update_zf.py
@@ -225,13 +225,13 @@ def scenario( wallets, **kw ):
     for i in xrange(0, 6):
         testlib.next_block( **kw )
 
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/", ses )
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/?raw=1", ses )
     if 'error' in res or res['http_status'] != 200:
         res['test'] = 'Failed to get name zonefile'
         print json.dumps(res)
         return False
 
-    if res['response']['zonefile'] != zf_str:
+    if res['raw'] != zf_str:
         print "Zonefile wasn't updated."
         print "Expected: {}".format(zf_str)
         print "Received: {}".format(res['response']['zonefile'])

--- a/integration_tests/blockstack_integration_tests/scenarios/rpc_register_sync_zonefile.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rpc_register_sync_zonefile.py
@@ -127,9 +127,7 @@ def scenario( wallets, **kw ):
 
     # stop endpoint
     print >> sys.stderr, "\nstopping RPC daemon\n"
-    config_dir = os.path.dirname(test_proxy.config_path)
-
-    blockstack_client.rpc.local_api_stop(config_dir=config_dir)
+    testlib.stop_api()
     time.sleep(3)
 
     # store to queue


### PR DESCRIPTION
Per issue #525, we had about 6-8 failing integration tests for functionality which should work and be correctly tested. There were two causes

1. Change in the response format of improperly formatted zonefiles.
2. Tests which required restarting the API endpoint were also closing the blockstackd RPC socket. Solved with sending a SIGKILL (the underlying problem, that the test runner's forking pattern leaves the RPC socket open for listening in the API endpoint, isn't solved, but the tests work now and this isn't an issue in production, where the forking pattern is different).

 