### PR TITLE
Hotfix for Issue 531, Wallet Migration, and command-line `whois`

### DIFF
--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -1013,6 +1013,23 @@ def cli_whois(args, config_path=CONFIG_PATH):
 
     error = check_valid_name(fqu)
     if error:
+        res = subdomains.is_address_subdomain(fqu)
+        if res:
+            subdomain, domain = res[1]
+            try:
+                subdomain_obj = subdomains.get_subdomain_info(subdomain, domain)
+            except subdomains.SubdomainNotFound:
+                return {'error': 'Not found.'}
+
+            ret = {
+                'satus' : 'registered_subdomain',
+                'zonefile_txt' : subdomain_obj.zonefile_str,
+                'zonefile_hash' : storage.get_zonefile_data_hash(subdomain_obj.zonefile_str),
+                'address' : subdomain_obj.address,
+                'blockchain' : 'bitcoin',
+                'last_txid' : subdomain_obj.last_txid,
+            }
+            return ret
         return {'error': error}
 
     try:

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -789,14 +789,15 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
 
         # not pending. get name
         # is this a subdomain?
-        log.debug("let's go!")
         res = subdomains.is_address_subdomain(name)
         if res:
             subdomain, domain = res[1]
-            log.debug("here too!")
-            subdomain_obj = subdomains.get_subdomain_info(subdomain, domain)
-            log.debug("here too!")
-        
+            try:
+                subdomain_obj = subdomains.get_subdomain_info(subdomain, domain)
+            except subdomains.SubdomainNotFound:
+                self._reply_json({"status" : "available"}, status_code=404)
+                return
+
             ret = {
                 'satus' : 'registered_subdomain',
                 'zonefile_txt' : subdomain_obj.zonefile_str,
@@ -804,7 +805,6 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                 'address' : subdomain_obj.address,
                 'blockchain' : 'bitcoin',
                 'last_txid' : subdomain_obj.last_txid,
-                'expire_block': -1,
             }
 
             self._reply_json(ret)

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '14'
 __version_patch__ = '4'
-__version__ = '{}.{}.{}.0'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.1'.format(__version_major__, __version_minor__, __version_patch__)

--- a/blockstack_client/wallet.py
+++ b/blockstack_client/wallet.py
@@ -458,7 +458,15 @@ def inspect_wallet_data(data):
                     return {'error': 'Invalid wallet data'}
 
     any_legacy = (legacy or legacy_013 or legacy_014)
-    
+
+    # wallets with same group number don't need to be migrated
+    # between each other.
+    wallet_version_compatibility_groups = {
+        "0.14.2" : 0,
+        "0.14.3" : 0,
+        "0.14.4" : 0,
+    }
+
     # version check 
     # if the version has changed, we'll need to potentially migrate
     # to e.g. trigger a re-encryption 
@@ -467,7 +475,9 @@ def inspect_wallet_data(data):
         migrated = True
 
     elif data['version'] != SERIES_VERSION:
-        if data['version'] == "0.14.2" and SERIES_VERSION in ("0.14.3", "0.14.4"):
+        if (data['version'] in wallet_version_compatibility_groups and
+            wallet_version_compatibility_groups.get(SERIES_VERSION, None) ==
+            wallet_version_compatibility_groups[data['version']]):
             pass # no migration needed
         else:
             log.debug("Wallet series has changed from {} to {}; triggerring migration".format(

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -1196,6 +1196,12 @@ Fetch a list of all names known to the node.
                        'pattern': '^[0-9a-fA-F]{20}$`,
                    },
                  },
+                 { 'required': 
+                   [
+                     'address', 'blockchain', 'last_txid',
+                     'status', 'zonefile', 'zonefile_hash'
+                   ]
+                 }
                }
                 
 ## Name history [GET /v1/names/{name}/history]


### PR DESCRIPTION
Version bump to 0.14.4.1

includes fix for Issue 531 --> subdomain not found on /v1/names/{}/ now returns 404 + `{'status':'available'}`

Wallet migration path now uses groups to determine when the wallet hasn't changed between series.

Also, now the command line `whois` works for subdomains:

```
$ blockstack whois created_equal.self_evident_truth.id
{
    "address": "1AYddAnfHbw6bPNvnsQFFrEuUdhMhf2XG9", 
    "blockchain": "bitcoin", 
    "last_txid": "0bacfd5a3e0ec68723d5948d6c1a04ad0de1378c872d45fa2276ebbd7be230f7", 
    "satus": "registered_subdomain", 
    "zonefile_hash": "48fc1b351ce81cf0a9fd9b4eae7a3f80e93c0451", 
    "zonefile_txt": "$ORIGIN created_equal\n$TTL 3600\n_https._tcp URI 10 1 \"https://www.cs.princeton.edu/~ablankst/created_equal.json\"\n_file URI 10 1 \"file:///tmp/created_equal.json\"\n"
}
```

(The above endpoint was already enabled for RPCs via `/v1/names/<foo.bar.tld>`)
