### PR TITLE
Fix Broken Slack Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Blockstack Core
 
 [![PyPI](https://img.shields.io/pypi/v/blockstack.svg)](https://pypi.python.org/pypi/blockstack/)
-[![Slack](http://slack.blockstack.org/badge.svg)](http://slack.blockstack.org/)
+[Join our Slack Channel!](http://slack.blockstack.org)
 
 Blockstack is a new decentralized internet where you own your data and your apps run locally without remote servers. 
 


### PR DESCRIPTION
The image badge for our slack is currently broken. This PR replaces with just a call to action link.