### PR TITLE
Support for issuing updates with an owner key

### DIFF
--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -1497,6 +1497,7 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
     arg: name (str) 'The name to update.'
     opt: data (str) 'A path to a file with the zone file data.'
     opt: nonstandard (str) 'If true, then do not validate or parse the zone file.'
+    opt: ownerkey (str) 'A private key string to be used for the update.'
     """
 
     # NOTE: if force_data == True, then the zonefile will be the zonefile text itself, not a path.
@@ -1587,12 +1588,13 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
 
 
     # open the zonefile editor
-    _, _, data_pubkey = get_addresses_from_file(config_dir=config_dir)
-    
-    if data_pubkey is None:
-        return {'error': 'No data public key set in the wallet.  Please use `blockstack setup_wallet` to fix this.'}
-
     if interactive and not nonstandard:
+        _, _, data_pubkey = get_addresses_from_file(config_dir=config_dir)
+    
+        if data_pubkey is None:
+            return {'error': 'No data public key set in the wallet. ' +
+                    ' Please use `blockstack setup_wallet` to fix this.'}
+
         # configuration wizard!
         if user_zonefile_dict is None:
             user_zonefile_dict = make_empty_zonefile(fqu, data_pubkey)

--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -3772,7 +3772,7 @@ def cli_set_zonefile_hash(args, config_path=CONFIG_PATH, password=None):
     help: Directly set the hash associated with the name in the blockchain.
     arg: name (str) 'The name to update'
     arg: zonefile_hash (str) 'The RIPEMD160(SHA256(zonefile)) hash'
-    arg: ownerkey (str) 'The key to be used if not the wallet's ownerkey'
+    arg: ownerkey (str) 'The key to be used if not the wallets ownerkey'
     """
     password = get_default_password(password)
 

--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -1511,7 +1511,7 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
 
     proxy = get_default_proxy() if proxy is None else proxy
     password = get_default_password(password)
-    
+
     if hasattr(args, 'nonstandard') and not nonstandard:
         if args.nonstandard is not None and args.nonstandard.lower() in ['yes', '1', 'true']:
             nonstandard = True
@@ -1532,7 +1532,7 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
     downloaded = False
     if getattr(args, 'data', None) is not None:
         zonefile_data_path_or_string = str(args.data)
- 
+
     if not local_rpc.is_api_server(config_dir=config_dir):
         # verify that we own the name before trying to edit its zonefile
         _, owner_address, _ = get_addresses_from_file(config_dir=config_dir)
@@ -1568,7 +1568,7 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
         if not interactive:
             if zonefile_data is None or nonstandard:
                 log.warning('Using non-zonefile data')
-            
+
             else:
                 return {'error': 'Zone file not updated (invalid)'}
 
@@ -1590,7 +1590,7 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
     # open the zonefile editor
     if interactive and not nonstandard:
         _, _, data_pubkey = get_addresses_from_file(config_dir=config_dir)
-    
+
         if data_pubkey is None:
             return {'error': 'No data public key set in the wallet. ' +
                     ' Please use `blockstack setup_wallet` to fix this.'}
@@ -1618,7 +1618,11 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
 
     try:
         # NOTE: already did safety checks
-        resp = rpc.backend_update(fqu, user_data_txt, None, None )
+        if len(args.ownerkey) == 0:
+            owner_key = None
+        else:
+            owner_key = args.ownerkey
+        resp = rpc.backend_update(fqu, user_data_txt, None, None, owner_key = owner_key )
     except Exception as e:
         log.exception(e)
         return {'error': 'Error talking to server, try again.'}

--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -1479,7 +1479,7 @@ def cli_register(args, config_path=CONFIG_PATH, force_data=False,
         return {'error': resp['message']}
 
     result = resp
-   
+
     if local_rpc.is_api_server(config_dir):
         # log this
         total_estimated_cost = {'total_estimated_cost': opchecks['total_estimated_cost']}
@@ -1487,7 +1487,7 @@ def cli_register(args, config_path=CONFIG_PATH, force_data=False,
 
     return result
 
-    
+
 
 def cli_update(args, config_path=CONFIG_PATH, password=None,
                interactive=True, proxy=None, nonstandard=False,
@@ -1620,7 +1620,7 @@ def cli_update(args, config_path=CONFIG_PATH, password=None,
 
     try:
         # NOTE: already did safety checks
-        if len(args.ownerkey) == 0:
+        if args.ownerkey is None or len(args.ownerkey) == 0:
             owner_key = None
         else:
             owner_key = args.ownerkey
@@ -3747,7 +3747,7 @@ def cli_get_names_in_namespace(args, config_path=CONFIG_PATH):
     arg: namespace_id (str) 'The ID of the namespace to query'
     arg: page (int) 'The page of names to fetch (groups of 100)'
     """
-    
+
     offset = int(args.page) * 100
     count = 100
 
@@ -3772,6 +3772,7 @@ def cli_set_zonefile_hash(args, config_path=CONFIG_PATH, password=None):
     help: Directly set the hash associated with the name in the blockchain.
     arg: name (str) 'The name to update'
     arg: zonefile_hash (str) 'The RIPEMD160(SHA256(zonefile)) hash'
+    arg: ownerkey (str) 'The key to be used if not the wallet's ownerkey'
     """
     password = get_default_password(password)
 
@@ -3795,7 +3796,11 @@ def cli_set_zonefile_hash(args, config_path=CONFIG_PATH, password=None):
     assert rpc
 
     try:
-        resp = rpc.backend_update(fqu, None, None, zonefile_hash )
+        if args.ownerkey is None or len(args.ownerkey) == 0:
+            owner_key = None
+        else:
+            owner_key = args.ownerkey
+        resp = rpc.backend_update(fqu, None, None, zonefile_hash, owner_key = owner_key )
     except Exception as e:
         log.exception(e)
         return {'error': 'Error talking to server, try again.'}

--- a/blockstack_client/backend/nameops.py
+++ b/blockstack_client/backend/nameops.py
@@ -1429,7 +1429,7 @@ def do_update( fqu, zonefile_hash, owner_privkey_info, payment_privkey_info, utx
 
     fqu = str(fqu)
 
-    # wrap UTXO client so we remember UTXOs 
+    # wrap UTXO client so we remember UTXOs
     utxo_client = build_utxo_client(utxo_client)
 
     owner_address = virtualchain.get_privkey_address( owner_privkey_info )
@@ -1439,7 +1439,7 @@ def do_update( fqu, zonefile_hash, owner_privkey_info, payment_privkey_info, utx
 
     if not dry_run and (safety_checks or tx_fee_per_byte is None):
         # find tx fee, and do sanity checks
-        res = check_update(fqu, owner_privkey_info, payment_privkey_info, 
+        res = check_update(fqu, owner_privkey_info, payment_privkey_info,
                            config_path=config_path, proxy=proxy, min_payment_confs=min_confirmations,
                            force_it = force_update)
         if 'error' in res and safety_checks:

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -1222,7 +1222,7 @@ def preorder(fqu, cost_satoshis, zonefile_data, profile, transfer_address, min_p
 
 # RPC method: backend_update
 def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_path=CONFIG_PATH, proxy=None,
-            prior_name_data = None ):
+            prior_name_data = None, owner_key = None ):
     """
     Send a new zonefile hash.  Queue the zonefile data for subsequent replication.
     zonefile_txt_b64 must be b64-encoded so we can send it over RPC sanely
@@ -1249,7 +1249,10 @@ def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_
     resp = None
 
     payment_privkey_info = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
-    owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
+    if owner_key is None:
+        owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
+    else:
+        owner_privkey_info = owner_key
 
     replication_error = None
 

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -48,7 +48,7 @@ from .queue import queue_add_error_msg
 
 from .nameops import async_preorder, async_register, async_update, async_transfer, async_renew, async_revoke
 
-from ..keys import get_data_privkey_info, is_singlesig_hex 
+from ..keys import get_data_privkey_info, is_singlesig_hex
 from ..proxy import is_name_registered, is_zonefile_hash_current, get_default_proxy, get_name_blockchain_record, get_atlas_peers, json_is_error
 from ..zonefile import zonefile_data_replicate
 from ..user import is_user_zonefile
@@ -195,14 +195,14 @@ class RegistrarWorker(threading.Thread):
                     # was preordered but not registered
                     # send the registration
                     log.debug("async_register({}, zonefile={}, profile={}, transfer_address={})".format(
-                        name_data['fqu'], name_data.get('zonefile'), name_data.get('profile'), 
-                        name_data.get('transfer_address'))) 
-                    res = async_register( name_data['fqu'], payment_privkey_info, owner_privkey_info, 
+                        name_data['fqu'], name_data.get('zonefile'), name_data.get('profile'),
+                        name_data.get('transfer_address')))
+                    res = async_register( name_data['fqu'], payment_privkey_info, owner_privkey_info,
                                           name_data=name_data, proxy=proxy, config_path=config_path,
                                           queue_path=queue_path )
                     return res
                 else:
-                    # already queued 
+                    # already queued
                     reg_result = queuedb_find( "register", name_data['fqu'], limit=1, path=queue_path )
                     if len(reg_result) == 1:
                         log.debug('Already queued for register: {}'.format(name_data['fqu']))
@@ -516,7 +516,7 @@ class RegistrarWorker(threading.Thread):
         Return {'status': True} on success
         Return {'error': ..., 'names': [...]} on failure.  'names' refers to the list of names that failed
         """
-        ret = {'status': True} 
+        ret = {'status': True}
         failed_names = []
 
         atlas_servers = cls.get_atlas_server_list( config_path )
@@ -536,12 +536,12 @@ class RegistrarWorker(threading.Thread):
                 queue_add_error_msg('update', update['fqu'], res['error'], path=queue_path)
                 ret = {'error': 'Failed to finish an update'}
                 failed_names.append( update['fqu'] )
-                
+
         if 'error' in ret:
             ret['names'] = failed_names
 
         return ret
-      
+
 
     @classmethod
     def replicate_update_data( cls, queue_path, wallet_data, storage_drivers, skip=[], config_path=CONFIG_PATH, proxy=None ):
@@ -590,7 +590,7 @@ class RegistrarWorker(threading.Thread):
         """
         if proxy is None:
             proxy = get_default_proxy(config_path=config_path)
-    
+
         failed = []
         ret = {'status': True}
         conf = get_config(config_path)
@@ -625,14 +625,14 @@ class RegistrarWorker(threading.Thread):
                     queue_removeall( [update], path=queue_path )
 
                 else:
-                    # will try again 
+                    # will try again
                     log.error("Failed to transfer {} to {}: {}".format(update['fqu'], update['transfer_address'], res.get('error')))
                     queue_add_error_msg('update', update['fqu'], res.get('error'), path=queue_path)
                     ret = {'error': 'Not all names transferred'}
                     failed.append(update['fqu'])
 
             else:
-                # nothing more to do 
+                # nothing more to do
                 log.debug("Done working on {}".format(update['fqu']))
                 log.debug("Final name output: {}".format(update))
                 queue_removeall( [update], path=queue_path )
@@ -643,7 +643,7 @@ class RegistrarWorker(threading.Thread):
         return ret
 
 
-    @classmethod 
+    @classmethod
     def get_atlas_server_list( cls, config_path ):
         """
         Get the list of atlas servers to which to replicate zonefiles
@@ -658,7 +658,7 @@ class RegistrarWorker(threading.Thread):
         try:
             atlas_peers_res = get_atlas_peers( server_hostport )
             assert 'error' not in atlas_peers_res
-           
+
             servers += atlas_peers_res['peers']
 
         except AssertionError as ae:
@@ -672,7 +672,7 @@ class RegistrarWorker(threading.Thread):
         except Exception as e:
             log.exception(e)
             return {'error': 'Failed to contact atlas peer'}
-            
+
         servers = list(set([str(hp) for hp in servers]))
 
         if 'node.blockstack.org:6264' not in servers and not BLOCKSTACK_TEST:
@@ -710,7 +710,7 @@ class RegistrarWorker(threading.Thread):
         """
         Is the given lockfile stale?
         """
-    
+
         with open(path, "r") as f:
             dat = f.read()
             try:
@@ -729,7 +729,7 @@ class RegistrarWorker(threading.Thread):
         Return True on success
         Return False on error
         """
-        
+
         buf = "%s\n" % os.getpid()
         nw = 0
         while nw < len(buf):
@@ -751,7 +751,7 @@ class RegistrarWorker(threading.Thread):
         return os.path.join( os.path.dirname(config_path), "registrar.lock" )
 
 
-    @classmethod 
+    @classmethod
     def is_lockfile_valid( cls, config_path ):
         """
         Does the lockfile exist and does it correspond
@@ -797,7 +797,7 @@ class RegistrarWorker(threading.Thread):
         try:
             fd, path = tempfile.mkstemp(prefix=".registrar.lock.", dir=os.path.dirname(self.config_path))
             os.link( path, self.lockfile_path )
-            
+
             try:
                 os.unlink(path)
             except:
@@ -833,12 +833,12 @@ class RegistrarWorker(threading.Thread):
             try:
                 wallet_data = get_wallet( config_path=self.config_path, proxy=proxy )
 
-                # wait until the owner address is set 
+                # wait until the owner address is set
                 while ('error' in wallet_data or wallet_data['owner_address'] is None) and self.running:
                     log.debug("Owner address not set... (%s)" % wallet_data.get("error", ""))
                     wallet_data = get_wallet( config_path=self.config_path, proxy=proxy )
                     time.sleep(1.0)
-                
+
                 # preemption point
                 if not self.running:
                     break
@@ -1102,7 +1102,7 @@ def get_wallet_data_privkey_info(config_path=None, proxy=None):
     """
     state, config_path, proxy = get_registrar_state(config_path=config_path, proxy=proxy)
     if state.data_privkey_info is None:
-        return None 
+        return None
 
     return state.data_privkey_info
 
@@ -1118,7 +1118,7 @@ def get_wallet(config_path=None, proxy=None):
 
     state, config_path, proxy = get_registrar_state(config_path=config_path, proxy=proxy)
     data = {}
-    
+
     data['payment_address'] = state.payment_address
     data['owner_address'] = state.owner_address
     data['data_pubkey'] = state.data_pubkey
@@ -1232,10 +1232,10 @@ def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_
     data = {}
 
     assert zonefile_txt is not None or zonefile_hash is not None, "need zonefile or zonefile hash"
-    
+
     if zonefile_hash is None:
         zonefile_hash = get_zonefile_data_hash( zonefile_txt )
-        
+
     if state.payment_address is None or state.owner_address is None:
         data['success'] = False
         data['error'] = "Wallet is not unlocked."

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -1039,9 +1039,6 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
 
         res = None
         privkey_info = request.get('owner_key', None)
-        kwargs = {}
-        if privkey_info:
-            kwargs['owner_key'] = privkey_info
 
         if zonefile_str is not None:
             res = internal.cli_update(name, str(zonefile_str), "false", privkey_info, interactive=False,

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -995,6 +995,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                     'minimum': 0,
                     'maximum': TX_MAX_FEE
                 },
+                'owner_key': PRIVKEY_INFO_SCHEMA
             },
             'additionalProperties': False,
         }
@@ -1037,11 +1038,16 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             return
 
         res = None
-        if zonefile_str is not None:
-            res = internal.cli_update(name, str(zonefile_str), "false", interactive=False, nonstandard=True, force_data=True)
+        privkey_info = request.get('owner_key', None)
+        kwargs = {}
+        if privkey_info:
+            kwargs['owner_key'] = privkey_info
 
+        if zonefile_str is not None:
+            res = internal.cli_update(name, str(zonefile_str), "false", privkey_info, interactive=False,
+                                      nonstandard=True, force_data=True)
         else:
-            res = internal.cli_set_zonefile_hash(name, str(zonefile_hash))
+            res = internal.cli_set_zonefile_hash(name, str(zonefile_hash), privkey_info)
 
         if 'error' in res:
             log.error("Failed to update {}: {}".format(name, res['error']))
@@ -4156,13 +4162,15 @@ class BlockstackAPIEndpointClient(object):
             return self.get_response(req)
 
 
-    def backend_update(self, fqu, zonefile_txt, profile, zonefile_hash):
+    def backend_update(self, fqu, zonefile_txt, profile, zonefile_hash, owner_key = None):
         """
         Queue an update
         """
         if is_api_server(self.config_dir):
             # directly invoke the registrar
-            return backend.registrar.update(fqu, zonefile_txt,  profile, zonefile_hash, None, config_path=self.config_path)
+            return backend.registrar.update(
+                fqu, zonefile_txt,  profile, zonefile_hash,
+                None, config_path = self.config_path, owner_key = owner_key)
 
         else:
             res = self.check_version()
@@ -4183,6 +4191,9 @@ class BlockstackAPIEndpointClient(object):
 
             if zonefile_hash is not None:
                 data['zonefile_hash'] = zonefile_hash
+
+            if owner_key is not None:
+                data['owner_key'] = owner_key
 
             headers = self.make_request_headers()
             req = requests.put( 'http://{}:{}/v1/names/{}/zonefile'.format(self.server, self.port, fqu), data=json.dumps(data), timeout=self.timeout, headers=headers)

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -999,13 +999,13 @@ Transfers a name to a different owner.
                 },
               ],
             }
-                
+
 
 ## Set zone file [PUT /v1/names/{name}/zonefile]
 Sets the user's zonefile hash, and, if supplied, propagates the
 zonefile. If you supply the zonefile, the hash will be calculated from
 that. Ultimately, your requests should only supply one of `zonefile`,
-`zonefile_b64`, or `zonefile_hash`.  
+`zonefile_b64`, or `zonefile_hash`.
 
 The value for `zonefile_b64` is a base64-encoded string.
 New clients _should_ use the `zonefile_b64` field when specifying a zone file.
@@ -1036,6 +1036,55 @@ The `zonefile` field is preserved for legacy compatibility.
                                 'minimum': 0,
                                 'maximum': 500000
                             },
+                            'owner_key': {
+                                'anyOf': [
+                                    {
+                                        'anyOf': [
+                                            {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'properties': {
+                                            'address': {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            'private_keys': {
+                                                'items': {
+                                                    'anyOf': [
+                                                        {
+                                                            'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                            'type': 'string'
+                                                        },
+                                                        {
+                                                            'pattern': '^([0-9a-fA-F]+)$',
+                                                            'type': 'string'
+                                                        }
+                                                    ]
+                                                },
+                                                'type': 'array'
+                                            },
+                                            'redeem_script': {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        },
+                                        'required': [
+                                            'address',
+                                            'redeem_script',
+                                            'private_keys'
+                                        ],
+                                        'type': 'object'
+                                    }
+                                ]
+                            }
                         },
                         'additionalProperties': False,
                     }
@@ -1119,8 +1168,8 @@ Fetch a list of all names known to the node.
 + Response 200 (application/json)
   + Body
 
-               [ "aldenquimby.id", "aldeoryn.id", 
-                 "alderete.id", "aldert.id", 
+               [ "aldenquimby.id", "aldeoryn.id",
+                 "alderete.id", "aldert.id",
                  "aldi.id", "aldighieri.id", ... ]
 
   + Schema

--- a/integration_tests/bin/blockstack-test-all-junit
+++ b/integration_tests/bin/blockstack-test-all-junit
@@ -48,8 +48,18 @@ while IFS= read SCENARIO_FILE; do
       echo -n "$SCENARIO_MODULE ... "
 
       mkdir -p "$TESTDIR"
-      "$RUN_SCENARIO" "$SCENARIO_MODULE" "$TESTDIR" > "$OUTPUTS/$SCENARIO_MODULE_BASE.log" 2>&1
+      "$RUN_SCENARIO" "$SCENARIO_MODULE" "$TESTDIR" > "$OUTPUTS/$SCENARIO_MODULE_BASE.log" 2>&1 &
+      TEST_PID=$!
+      while ps -p $TEST_PID > /dev/null; do
+          etime=$(ps -p $TEST_PID -o etimes | tail -n 1 | awk '{ print $1 }')
+          if [ "etime" -ge 1200 ]; then
+              echo -n " KILL for time "
+              kill -s INT $TEST_PID
+          fi
+          sleep 10
+      done
 
+      grep -q "SUCCESS" "$OUTPUTS/$SCENARIO_MODULE_BASE.log"
       RC=$?
 
       # make the xunit file

--- a/integration_tests/bin/blockstack-test-all-junit
+++ b/integration_tests/bin/blockstack-test-all-junit
@@ -52,7 +52,7 @@ while IFS= read SCENARIO_FILE; do
       TEST_PID=$!
       while ps -p $TEST_PID > /dev/null; do
           etime=$(ps -p $TEST_PID -o etimes | tail -n 1 | awk '{ print $1 }')
-          if [ "etime" -ge 1200 ]; then
+          if [ $etime -ge 1200 ]; then
               echo -n " KILL for time "
               kill -s INT $TEST_PID
           fi

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_update_with_key.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_update_with_key.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    Blockstack
+    ~~~~~
+    copyright: (c) 2014-2015 by Halfmoon Labs, Inc.
+    copyright: (c) 2016 by Blockstack.org
+
+    This file is part of Blockstack
+
+    Blockstack is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Blockstack is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+"""
+import os
+import testlib
+import pybitcoin
+import urllib2
+import json
+import blockstack_client
+import blockstack_profiles
+import blockstack_zones
+import sys
+import keylib
+import time
+
+from keylib import ECPrivateKey, ECPublicKey
+
+wallets = [
+    testlib.Wallet( "5JesPiN68qt44Hc2nT8qmyZ1JDwHebfoh9KQ52Lazb1m1LaKNj9", 100000000000 ),
+    testlib.Wallet( "5KHqsiU9qa77frZb6hQy9ocV7Sus9RWJcQGYYBJJBb2Efj1o77e", 100000000000 ),
+    testlib.Wallet( "5Kg5kJbQHvk1B64rJniEmgbD83FpZpbw2RjdAZEzTefs9ihN3Bz", 100000000000 ),
+    testlib.Wallet( "5JuVsoS9NauksSkqEjbUZxWwgGDQbMwPsEfoRBSpLpgDX1RtLX7", 100000000000 ),
+    testlib.Wallet( "5KEpiSRr1BrT8vRD7LKGCEmudokTh1iMHbiThMQpLdwBwhDJB1T", 100000000000 ),
+    testlib.Wallet( "5K5hDuynZ6EQrZ4efrchCwy6DLhdsEzuJtTDAf3hqdsCKbxfoeD", 100000000000 ),
+    testlib.Wallet( "5J39aXEeHh9LwfQ4Gy5Vieo7sbqiUMBXkPH7SaMHixJhSSBpAqz", 100000000000 ),
+    testlib.Wallet( "5K9LmMQskQ9jP1p7dyieLDAeB6vsAj4GK8dmGNJAXS1qHDqnWhP", 100000000000 ),
+    testlib.Wallet( "5KcNen67ERBuvz2f649t9F2o1ddTjC5pVUEqcMtbxNgHqgxG2gZ", 100000000000 ),
+    testlib.Wallet( "5KMbNjgZt29V6VNbcAmebaUT2CZMxqSridtM46jv4NkKTP8DHdV", 100000000000 ),
+]
+
+consensus = "17ac43c1d8549c3181b200f1bf97eb7d"
+wallet_keys = None
+wallet_keys_2 = None
+error = False
+
+index_file_data = "<html><head></head><body>foo.test hello world</body></html>"
+resource_data = "hello world"
+
+new_key = "cPo24qGYz76xSbUCug6e8LzmzLGJPZoowQC7fCVPLN2tzCUJgfcW"
+new_addr = "mqnupoveYRrSHmrxFT9nQQEZt3RLsetbBQ"
+
+insanity_key = "cSCyE5Q1AFVyDAL8LkHo1sFMVqmwdvFcCbGJ71xEvto2Nrtzjm67"
+
+def scenario( wallets, **kw ):
+
+    global wallet_keys, wallet_keys_2, error, index_file_data, resource_data
+
+    wallet_keys = testlib.blockstack_client_initialize_wallet( "0123456789abcdef", wallets[5].privkey, wallets[3].privkey, wallets[4].privkey )
+    test_proxy = testlib.TestAPIProxy()
+    blockstack_client.set_default_proxy( test_proxy )
+
+    testlib.blockstack_namespace_preorder( "test", wallets[1].addr, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_reveal( "test", wallets[1].addr, 52595, 250, 4, [6,5,4,3,2,1,0,0,0,0,0,0,0,0,0,0], 10, 10, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_ready( "test", wallets[1].privkey )
+    testlib.next_block( **kw )
+
+    # tell serialization-checker that value_hash can be ignored here
+    print "BLOCKSTACK_SERIALIZATION_CHECK_IGNORE value_hash"
+    sys.stdout.flush()
+
+    testlib.next_block( **kw )
+
+    config_path = os.environ.get("BLOCKSTACK_CLIENT_CONFIG", None)
+
+    # let's set the key to skip the transfer.
+    config_dir = os.path.dirname(config_path)
+    conf = blockstack_client.get_config(config_path)
+    assert conf
+
+    api_pass = conf['api_password']
+
+    res = testlib.blockstack_REST_call('PUT', '/v1/wallet/keys/owner', None, api_pass=api_pass,
+                                       data=new_key)
+    if res['http_status'] != 200 or 'error' in res:
+        print 'failed to set owner key'
+        print res
+        return False
+
+    # make zonefile for recipient
+    driver_urls = blockstack_client.storage.make_mutable_data_urls('bar.test', use_only=['dht', 'disk'])
+    zonefile = blockstack_client.zonefile.make_empty_zonefile('bar.test', wallets[4].pubkey_hex, urls=driver_urls)
+    zonefile_txt = blockstack_zones.make_zone_file( zonefile, origin='bar.test', ttl=3600 )
+
+    # leaving the call format of this one the same to make sure that our registrar correctly
+    #   detects that the requested TRANSFER is superfluous
+    # register the name bar.test
+    res = testlib.blockstack_REST_call(
+        'POST', '/v1/names', ses, data={
+            'name': 'bar.test', 'zonefile': zonefile_txt, 'owner_address': new_addr
+        })
+    if 'error' in res:
+        res['test'] = 'Failed to register user'
+        print json.dumps(res)
+        error = True
+        return False
+
+    print res
+    tx_hash = res['response']['transaction_hash']
+
+    # wait for preorder to get confirmed...
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'preorder', tx_hash )
+    if not res:
+        return False
+
+    # wait for the preorder to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    # wait for register to go through
+    print 'Wait for register to be submitted'
+    time.sleep(10)
+
+    # wait for the register to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'register', None )
+    if not res:
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for update to be submitted'
+    time.sleep(10)
+
+    # wait for update to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'update', None )
+    if not res:
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for transfer to be submitted'
+    time.sleep(10)
+
+    # wait for transfer to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'transfer', None )
+    if res:
+        print "Wrongly issued a TRANSFER"
+        return False
+
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test", ses)
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = 'Failed to get name bar.test'
+        print json.dumps(res)
+        return False
+
+    zonefile_hash = res['response']['zonefile_hash']
+
+    # should still be registered
+    if res['response']['status'] != 'registered':
+        print "register not complete"
+        print json.dumps(res)
+        return False
+
+    # do we have the history for the name?
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/history", ses )
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = "Failed to get name history for foo.test"
+        print json.dumps(res)
+        return False
+
+    # valid history?
+    hist = res['response']
+    if len(hist.keys()) != 3:
+        res['test'] = 'Failed to get update history'
+        res['history'] = hist
+        print json.dumps(res, indent=4, sort_keys=True)
+        return False
+
+    # get the zonefile
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash), ses )
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = 'Failed to get name zonefile'
+        print json.dumps(res)
+        return False
+
+    # same zonefile we put?
+    if res['response']['zonefile'] != zonefile_txt:
+        res['test'] = 'mismatched zonefile, expected\n{}\n'.format(zonefile_txt)
+        print json.dumps(res)
+        return False
+
+    # okay, now let's try to do an update.
+    # FIRST, I want to change the key to a key that
+    #  doesn't own the name.
+    res = testlib.blockstack_REST_call('PUT', '/v1/wallet/keys/owner', None, api_pass=api_pass,
+                                       data=insanity_key)
+    if res['http_status'] != 200 or 'error' in res:
+        print 'failed to set owner key'
+        print res
+        return False
+
+    # make zonefile for recipient
+    driver_urls = blockstack_client.storage.make_mutable_data_urls('bar.test', use_only=['http', 'disk'])
+    zonefile = blockstack_client.zonefile.make_empty_zonefile('bar.test', wallets[3].pubkey_hex, urls=driver_urls)
+    zonefile_txt = blockstack_zones.make_zone_file( zonefile, origin='bar.test', ttl=3600 )
+
+    # let's do this update.
+    res = testlib.blockstack_REST_call(
+        'POST', '/v1/names/bar.test/zonefile', ses, data={
+            'zonefile': zonefile_txt, 'owner_key' : new_key
+        })
+    if 'error' in res:
+        res['test'] = 'Failed to register user'
+        print json.dumps(res)
+        error = True
+        return False
+
+    print 'Wait for update to be submitted'
+    time.sleep(10)
+
+    # wait for update to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'update', None )
+    if not res:
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    # wait for zonefile to propagate
+    time.sleep(10)
+
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test", ses)
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = 'Failed to get name bar.test'
+        print json.dumps(res)
+        return False
+
+    zonefile_hash = res['response']['zonefile_hash']
+    # get the zonefile
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash), ses )
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = 'Failed to get name zonefile'
+        print json.dumps(res)
+        return False
+
+    # same zonefile we put?
+    if res['response']['zonefile'] != zonefile_txt:
+        res['test'] = 'mismatched zonefile, expected\n{}\n'.format(zonefile_txt)
+        print json.dumps(res)
+        return False
+
+def check( state_engine ):
+
+    global wallet_keys, error, index_file_data, resource_data
+
+    config_path = os.environ.get("BLOCKSTACK_CLIENT_CONFIG")
+    assert config_path
+
+    if error:
+        print "Key operation failed."
+        return False
+
+    # not revealed, but ready
+    ns = state_engine.get_namespace_reveal( "test" )
+    if ns is not None:
+        print "namespace not ready"
+        return False
+
+    ns = state_engine.get_namespace( "test" )
+    if ns is None:
+        print "no namespace"
+        return False
+
+    if ns['namespace_id'] != 'test':
+        print "wrong namespace"
+        return False
+
+    names = ['bar.test']
+    owners = [ new_addr ]
+    test_proxy = testlib.TestAPIProxy()
+
+    for i in xrange(0, len(names)):
+        name = names[i]
+        wallet_payer = 5
+        wallet_owner = 3 + i
+        wallet_data_pubkey = 4
+
+        # not preordered
+        preorder = state_engine.get_name_preorder( name, pybitcoin.make_pay_to_address_script(wallets[wallet_payer].addr), wallets[wallet_owner].addr )
+        if preorder is not None:
+            print "still have preorder"
+            return False
+
+        # registered
+        name_rec = state_engine.get_name( name )
+        if name_rec is None:
+            print "name does not exist"
+            return False
+
+        # owned
+        if name_rec['address'] != owners[i]:
+            print "name {} has wrong owner".format(name)
+            return False
+
+    return True

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_update_with_key.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_update_with_key.py
@@ -108,7 +108,7 @@ def scenario( wallets, **kw ):
     #   detects that the requested TRANSFER is superfluous
     # register the name bar.test
     res = testlib.blockstack_REST_call(
-        'POST', '/v1/names', ses, data={
+        'POST', '/v1/names', None, api_pass=api_pass, data={
             'name': 'bar.test', 'zonefile': zonefile_txt, 'owner_address': new_addr
         })
     if 'error' in res:
@@ -124,7 +124,7 @@ def scenario( wallets, **kw ):
     for i in xrange(0, 6):
         testlib.next_block( **kw )
 
-    res = testlib.verify_in_queue(ses, 'bar.test', 'preorder', tx_hash )
+    res = testlib.verify_in_queue(None, 'bar.test', 'preorder', tx_hash, api_pass = api_pass )
     if not res:
         return False
 
@@ -140,7 +140,7 @@ def scenario( wallets, **kw ):
     for i in xrange(0, 6):
         testlib.next_block( **kw )
 
-    res = testlib.verify_in_queue(ses, 'bar.test', 'register', None )
+    res = testlib.verify_in_queue(None, 'bar.test', 'register', None, api_pass = api_pass )
     if not res:
         return False
 
@@ -154,8 +154,10 @@ def scenario( wallets, **kw ):
     for i in xrange(0, 6):
         testlib.next_block( **kw )
 
-    res = testlib.verify_in_queue(ses, 'bar.test', 'update', None )
+    res = testlib.verify_in_queue(None, 'bar.test', 'update', None, api_pass = api_pass )
     if not res:
+        print res
+        print "update error in first update"
         return False
 
     for i in xrange(0, 6):
@@ -168,12 +170,13 @@ def scenario( wallets, **kw ):
     for i in xrange(0, 6):
         testlib.next_block( **kw )
 
-    res = testlib.verify_in_queue(ses, 'bar.test', 'transfer', None )
+    res = testlib.verify_in_queue(None, 'bar.test', 'transfer', None, api_pass = api_pass )
     if res:
         print "Wrongly issued a TRANSFER"
         return False
 
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test", ses)
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test",
+                                       None, api_pass=api_pass)
     if 'error' in res or res['http_status'] != 200:
         res['test'] = 'Failed to get name bar.test'
         print json.dumps(res)
@@ -188,7 +191,8 @@ def scenario( wallets, **kw ):
         return False
 
     # do we have the history for the name?
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/history", ses )
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/history",
+                                       None, api_pass=api_pass )
     if 'error' in res or res['http_status'] != 200:
         res['test'] = "Failed to get name history for foo.test"
         print json.dumps(res)
@@ -203,7 +207,8 @@ def scenario( wallets, **kw ):
         return False
 
     # get the zonefile
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash), ses )
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash),
+                                       None, api_pass=api_pass )
     if 'error' in res or res['http_status'] != 200:
         res['test'] = 'Failed to get name zonefile'
         print json.dumps(res)
@@ -232,14 +237,17 @@ def scenario( wallets, **kw ):
 
     # let's do this update.
     res = testlib.blockstack_REST_call(
-        'POST', '/v1/names/bar.test/zonefile', ses, data={
+        'PUT', '/v1/names/bar.test/zonefile', None, api_pass=api_pass, data={
             'zonefile': zonefile_txt, 'owner_key' : new_key
         })
-    if 'error' in res:
+    if 'error' in res or res['http_status'] != 202:
         res['test'] = 'Failed to register user'
         print json.dumps(res)
         error = True
         return False
+    else:
+        print "Submitted update!"
+        print res
 
     print 'Wait for update to be submitted'
     time.sleep(10)
@@ -248,8 +256,10 @@ def scenario( wallets, **kw ):
     for i in xrange(0, 6):
         testlib.next_block( **kw )
 
-    res = testlib.verify_in_queue(ses, 'bar.test', 'update', None )
+    res = testlib.verify_in_queue(None, 'bar.test', 'update', None, api_pass = api_pass )
     if not res:
+        print "update error in second update"
+        print res
         return False
 
     for i in xrange(0, 6):
@@ -258,7 +268,8 @@ def scenario( wallets, **kw ):
     # wait for zonefile to propagate
     time.sleep(10)
 
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test", ses)
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test",
+                                       None, api_pass=api_pass)
     if 'error' in res or res['http_status'] != 200:
         res['test'] = 'Failed to get name bar.test'
         print json.dumps(res)
@@ -266,7 +277,8 @@ def scenario( wallets, **kw ):
 
     zonefile_hash = res['response']['zonefile_hash']
     # get the zonefile
-    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash), ses )
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash),
+                                       None, api_pass=api_pass )
     if 'error' in res or res['http_status'] != 200:
         res['test'] = 'Failed to get name zonefile'
         print json.dumps(res)

--- a/integration_tests/blockstack_integration_tests/scenarios/testlib.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/testlib.py
@@ -3467,12 +3467,12 @@ def make_client_device( index ):
     return {'status': True}
 
 
-def verify_in_queue( ses, name, queue_name, tx_hash, expected_length=1 ):
+def verify_in_queue( ses, name, queue_name, tx_hash, expected_length=1, api_pass=None ):
     """
     Verify that a name (optionally with the given tx hash) is in the given queue
     """
-    # verify that it's in the queue 
-    res = blockstack_REST_call('GET', '/v1/blockchains/bitcoin/pending', ses )
+    # verify that it's in the queue
+    res = blockstack_REST_call('GET', '/v1/blockchains/bitcoin/pending', ses, api_pass = api_pass )
     if 'error' in res:
         res['test'] = 'Failed to get queues'
         print json.dumps(res)
@@ -3481,7 +3481,7 @@ def verify_in_queue( ses, name, queue_name, tx_hash, expected_length=1 ):
 
     res = res['response']
 
-    # needs to be in the queue 
+    # needs to be in the queue
     if not res.has_key('queues'):
         res['test'] = 'Missing queues'
         print json.dumps(res)
@@ -3493,7 +3493,7 @@ def verify_in_queue( ses, name, queue_name, tx_hash, expected_length=1 ):
         print json.dumps(res)
         error = True
         return False
-    
+
     if len(res['queues'][queue_name]) != expected_length:
         res['test'] = 'invalid preorder queue'
         print json.dumps(res)
@@ -3520,8 +3520,8 @@ def verify_in_queue( ses, name, queue_name, tx_hash, expected_length=1 ):
         print json.dumps(res)
         return False
 
-    # verify that it's name resolves to the right queue state 
-    res = blockstack_REST_call("GET", "/v1/names/{}".format(name), ses)
+    # verify that it's name resolves to the right queue state
+    res = blockstack_REST_call("GET", "/v1/names/{}".format(name), ses, api_pass = api_pass)
     if 'error' in res:
         res['test'] = 'Failed to query name'
         print json.dumps(res)
@@ -3534,7 +3534,7 @@ def verify_in_queue( ses, name, queue_name, tx_hash, expected_length=1 ):
         error = True
         return False
 
-    # should be in the preorder queue at some point 
+    # should be in the preorder queue at some point
     if res['response']['operation'] != queue_name:
         return False
 


### PR DESCRIPTION
This adds support for issuing updates with a specified owner key. This will allow browser to submit a zonefile UPDATE for a name owned by an address in browser but *not* in the core wallet.

The api specification includes a new property for the `PUT /v1/names/{name}/zonefile` endpoint for setting the `owner_key`, this is tested in the new integration test `rest_update_with_key.py`

(Issue #538)