### PR TITLE
Adds HTTPS support to blockstack proxy

### DIFF
--- a/blockstack_client/client.py
+++ b/blockstack_client/client.py
@@ -40,8 +40,9 @@ STORAGE_IMPL = None
 ANALYTICS_KEY = None
 
 
-def session(conf=None, config_path=CONFIG_PATH, server_host=None, server_port=None, wallet_password=None,
-            storage_drivers=None, metadata_dir=None, spv_headers_path=None, set_global=False):
+def session(conf=None, config_path=CONFIG_PATH, server_host=None, server_port=None,
+            wallet_password=None, storage_drivers=None, metadata_dir=None,
+            spv_headers_path=None, set_global=False, server_protocol = None):
     """
     Create a blockstack session:
     * validate the configuration
@@ -65,7 +66,7 @@ def session(conf=None, config_path=CONFIG_PATH, server_host=None, server_port=No
         conf = get_config(config_path)
         if conf is None:
             log.error("Failed to read configuration file {}".format(config_path))
-            return None 
+            return None
 
         conf_version = conf.get('client_version', '')
         if not semver_match(conf_version, VERSION):
@@ -77,6 +78,8 @@ def session(conf=None, config_path=CONFIG_PATH, server_host=None, server_port=No
             server_host = conf['server']
         if server_port is None:
             server_port = conf['port']
+        if server_protocol is None:
+            server_protocol = conf['protocol']
         if storage_drivers is None:
             storage_drivers = conf['storage_drivers']
         if metadata_dir is None:
@@ -91,8 +94,8 @@ def session(conf=None, config_path=CONFIG_PATH, server_host=None, server_port=No
         sys.exit(1)
 
     # create proxy
-    log.debug('Connect to {}:{}'.format(server_host, server_port))
-    proxy = BlockstackRPCClient(server_host, server_port)
+    log.debug('Connect to {}://{}:{}'.format(server_protocol, server_host, server_port))
+    proxy = BlockstackRPCClient(server_host, server_port, protocol = server_protocol)
 
     # load all storage drivers
     loaded = []

--- a/blockstack_client/config.py
+++ b/blockstack_client/config.py
@@ -284,14 +284,14 @@ def configure(config_file=CONFIG_PATH, force=False, interactive=True, set_migrat
     all_opts = read_config_file(config_path=config_file, set_migrate=set_migrate)
     blockstack_opts = {}
     blockstack_opts_defaults = all_opts['blockstack-client']
-    
+
     migrated = False
     if set_migrate:
         migrated = all_opts['migrated']
         del all_opts['migrated']
 
     blockstack_params = blockstack_opts_defaults.keys()
-    
+
     if not force:
         # defaults
         blockstack_opts = copy.deepcopy(blockstack_opts_defaults)
@@ -694,6 +694,7 @@ def read_config_file(config_path=CONFIG_PATH, set_migrate=False):
 
     BLOCKSTACK_CLI_SERVER_HOST = os.environ.get('BLOCKSTACK_CLI_SERVER_HOST', None)     # overrides config file
     BLOCKSTACK_CLI_SERVER_PORT = os.environ.get('BLOCKSTACK_CLI_SERVER_PORT', None)     # overrides config file
+    BLOCKSTACK_CLI_SERVER_PROTOCOL = os.environ.get('BLOCKSTACK_CLI_SERVER_PROTOCOL', None)
 
     if BLOCKSTACK_CLI_SERVER_PORT is not None:
         try:
@@ -721,6 +722,7 @@ def read_config_file(config_path=CONFIG_PATH, set_migrate=False):
         parser.add_section('blockstack-client')
         parser.set('blockstack-client', 'server', str(BLOCKSTACKD_SERVER))
         parser.set('blockstack-client', 'port', str(BLOCKSTACKD_PORT))
+        parser.set('blockstack-client', 'protocol', 'https')
         parser.set('blockstack-client', 'metadata', METADATA_DIRNAME)
         parser.set('blockstack-client', 'storage_drivers', BLOCKSTACK_DEFAULT_STORAGE_DRIVERS)
         parser.set('blockstack-client', 'storage_drivers_required_write', BLOCKSTACK_REQUIRED_STORAGE_DRIVERS_WRITE)
@@ -817,21 +819,34 @@ def read_config_file(config_path=CONFIG_PATH, set_migrate=False):
         }
     }
 
-    # convert field names
-    renamed_fields_014_subdomains = {}
-    dropped_fields_014_subdomains = {}
-    changed_fields_014_subdomains = {}
-    added_fields_014_subdomains = {
+    renamed_fields_014_4 = {}
+    dropped_fields_014_4 = {}
+    changed_fields_014_4 = {}
+    added_fields_014_4 = {
         'subdomain-resolution': {
             'subdomains_db' : str(config_dir) + "/subdomains.db"
         },
     }
 
+    # add HTTPS support in 0.14.4.3
+    renamed_fields_014_4_3 = {}
+    dropped_fields_014_4_3 = {}
+    changed_fields_014_4_3 = {
+        'blockstack-client': {
+            'port' : str(BLOCKSTACKD_PORT)
+        }
+    }
+    added_fields_014_4_3 = {
+        'blockstack-client': {
+            'protocol' : "https"
+        }
+    }
+
     # grow this list with future releases...
-    renamed_fields = [renamed_fields_014_1, renamed_fields_014_subdomains]
-    removed_fields = [dropped_fields_014_1, dropped_fields_014_subdomains]
-    added_fields = [added_fields_014_1, added_fields_014_subdomains]
-    changed_fields = [changed_fields_014_1, changed_fields_014_subdomains]
+    renamed_fields = [renamed_fields_014_1, renamed_fields_014_4, renamed_fields_014_4_3]
+    removed_fields = [dropped_fields_014_1, dropped_fields_014_4, dropped_fields_014_4_3]
+    added_fields = [added_fields_014_1, added_fields_014_4, added_fields_014_4_3]
+    changed_fields = [changed_fields_014_1, changed_fields_014_4, changed_fields_014_4_3]
 
     migrated = False
 
@@ -857,7 +872,7 @@ def read_config_file(config_path=CONFIG_PATH, set_migrate=False):
 
                         del ret[sec][old_field_name]
                         ret[sec][new_field_name] = value
-                        
+
                         migrated = True
 
         for sec in added_field_set.keys():
@@ -876,10 +891,10 @@ def read_config_file(config_path=CONFIG_PATH, set_migrate=False):
             if ret.has_key(sec):
                 for dropped_field_name in dropped_field_set[sec]:
                     if ret[sec].has_key(dropped_field_name):
-                        
+
                         log.debug("Remove old field {}.{}".format(sec, dropped_field_name))
                         del ret[sec][dropped_field_name]
-                        
+
                         migrated = True
 
         for sec in changed_field_set.keys():
@@ -893,12 +908,13 @@ def read_config_file(config_path=CONFIG_PATH, set_migrate=False):
                     ret[sec][changed_field_name] = changed_field_set[sec][changed_field_name]
 
                     migrated = True
-   
+
     # overrides from the environment
     env_overrides = {
         'blockstack-client': {
             'server': BLOCKSTACK_CLI_SERVER_HOST,
             'port': BLOCKSTACK_CLI_SERVER_PORT,
+            'protocol': BLOCKSTACK_CLI_SERVER_PROTOCOL,
         },
     }
 

--- a/blockstack_client/constants.py
+++ b/blockstack_client/constants.py
@@ -45,7 +45,7 @@ BLOCKSTACK_DRY_RUN = os.environ.get('BLOCKSTACK_DRY_RUN', None)
 
 if BLOCKSTACK_DRY_RUN is not None:
     BLOCKSTACK_DRY_RUN = True
-    
+
 DEBUG = False
 if BLOCKSTACK_TEST is not None and BLOCKSTACK_TEST_NODEBUG is None:
     DEBUG = True
@@ -69,7 +69,7 @@ if os.environ.get("BLOCKSTACK_MIN_CONFIRMATIONS", None) is not None:
 VERSION = __version__
 SERIES_VERSION = "{}.{}.{}".format(__version_major__, __version_minor__, __version_patch__)
 
-DEFAULT_BLOCKSTACKD_PORT = 6264  # blockstack indexer port
+DEFAULT_BLOCKSTACKD_PORT = 6263  # blockstack indexer port
 DEFAULT_BLOCKSTACKD_SERVER = 'node.blockstack.org'
 
 DEFAULT_DEVICE_ID = '.default'
@@ -405,7 +405,7 @@ def serialize_secrets():
 
 
 def parse_secrets(buf):
-    try:    
+    try:
         return json.loads(buf)
     except:
         return {}
@@ -423,7 +423,7 @@ def load_secrets(buf, is_file = False):
     else:
         sec = parse_secrets(buf)
     SECRETS.update(sec)
-   
+
 
 def write_secrets(buf):
     """
@@ -432,7 +432,7 @@ def write_secrets(buf):
     can read and write.
 
     Be careful how we do this---we don't want another
-    process running as the same user 
+    process running as the same user
     to be able to open the file in read mode.
 
     Returns the (integer) file descriptor number on success.

--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -2094,11 +2094,7 @@ def get_zonefiles(hostport, zonefile_hashes, timeout=30, my_hostport=None, proxy
     }
 
     schema = json_response_schema( zonefiles_schema )
-
-    if proxy is None:
-        host, port = url_to_host_port(hostport)
-        assert host is not None and port is not None
-        proxy = BlockstackRPCClient(host, port, timeout=timeout, src=my_hostport)
+    proxy = get_default_proxy() if proxy is None else proxy
 
     zonefiles = None
     try:
@@ -2113,10 +2109,10 @@ def get_zonefiles(hostport, zonefile_hashes, timeout=30, my_hostport=None, proxy
             zf_data = base64.b64decode( zf_data_b64 )
             assert storage.verify_zonefile( zf_data, zf_hash ), "Zonefile data mismatch"
 
-            # valid 
+            # valid
             decoded_zonefiles[ zf_hash ] = zf_data
 
-        # return this 
+        # return this
         zf_payload['zonefiles'] = decoded_zonefiles
         zonefiles = zf_payload
 
@@ -2167,11 +2163,7 @@ def put_zonefiles(hostport, zonefile_data_list, timeout=30, my_hostport=None, pr
     }
 
     schema = json_response_schema( saved_schema )
-
-    if proxy is None:
-        host, port = url_to_host_port(hostport)
-        assert host is not None and port is not None
-        proxy = BlockstackRPCClient(host, port, timeout=timeout, src=my_hostport)
+    proxy = get_default_proxy() if proxy is None else proxy
 
     push_info = None
     try:

--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -68,6 +68,10 @@ class TimeoutHTTPConnection(httplib.HTTPConnection):
     def connect(self):
         httplib.HTTPConnection.connect(self)
         self.sock.settimeout(self.timeout)
+class TimeoutHTTPSConnection(httplib.HTTPSConnection):
+    def connect(self):
+        httplib.HTTPSConnection.connect(self)
+        self.sock.settimeout(self.timeout)
 
 
 class TimeoutHTTP(httplib.HTTP):
@@ -79,24 +83,40 @@ class TimeoutHTTP(httplib.HTTP):
     def getresponse(self, **kw):
         return self._conn.getresponse(**kw)
 
+class TimeoutHTTPS(httplib.HTTP):
+    _connection_class = TimeoutHTTPSConnection
+
+    def set_timeout(self, timeout):
+        self._conn.timeout = timeout
+
+    def getresponse(self, **kw):
+        return self._conn.getresponse(**kw)
+
 
 class TimeoutTransport(Transport):
-    def __init__(self, *l, **kw):
+    def __init__(self, protocol, *l, **kw):
         self.timeout = kw.pop('timeout', 10)
+        self.protocol = protocol
+        if protocol not in ['http', 'https']:
+            raise Exception("Protocol {} not supported".format(protocol))
         Transport.__init__(self, *l, **kw)
 
     def make_connection(self, host):
-        conn = TimeoutHTTP(host)
+        if self.protocol == 'http':
+            conn = TimeoutHTTP(host)
+        elif self.protocol == 'https':
+            conn = TimeoutHTTPS(host)
         conn.set_timeout(self.timeout)
 
         return conn
 
 
 class TimeoutServerProxy(ServerProxy):
-    def __init__(self, uri, *l, **kw):
+    def __init__(self, uri, protocol, *l, **kw):
         timeout = kw.pop('timeout', 10)
         use_datetime = kw.get('use_datetime', 0)
-        kw['transport'] = TimeoutTransport(timeout=timeout, use_datetime=use_datetime)
+        kw['transport'] = TimeoutTransport(
+            protocol, timeout=timeout, use_datetime=use_datetime)
         ServerProxy.__init__(self, uri, *l, **kw)
 
 
@@ -110,10 +130,12 @@ class BlockstackRPCClient(object):
     """
 
     def __init__(self, server, port, max_rpc_len=MAX_RPC_LEN,
-                 timeout=DEFAULT_TIMEOUT, debug_timeline=False, **kw):
+                 timeout=DEFAULT_TIMEOUT, debug_timeline=False, protocol=None, **kw):
 
-        self.url = 'http://{}:{}'.format(server, port)
-        self.srv = TimeoutServerProxy(self.url, timeout=timeout, allow_none=True)
+        if protocol is None:
+            raise Exception("RPC constructor must be passed a protocol")
+        self.url = '{}://{}:{}'.format(protocol, server, port)
+        self.srv = TimeoutServerProxy(self.url, protocol, timeout=timeout, allow_none=True)
         self.server = server
         self.port = port
         self.debug_timeline = debug_timeline
@@ -179,10 +201,12 @@ def get_default_proxy(config_path=CONFIG_PATH):
     assert conf is not None, 'Failed to get config from "{}"'.format(config_path)
 
     blockstack_server, blockstack_port = conf['server'], conf['port']
+    protocol = conf['protocol']
 
-    log.debug('Default proxy to {}:{}'.format(blockstack_server, blockstack_port))
+    log.debug('Default proxy to {}://{}:{}'.format(protocol, blockstack_server, blockstack_port))
 
-    proxy = client.session(conf=conf, server_host=blockstack_server, server_port=blockstack_port)
+    proxy = client.session(conf=conf, server_host=blockstack_server, server_port=blockstack_port,
+                           server_protocol=protocol)
 
     return proxy
 
@@ -313,7 +337,7 @@ def json_response_schema( expected_object_schema ):
         ],
     }
 
-    # fold in the given object schema 
+    # fold in the given object schema
     schema['properties'].update( expected_object_schema['properties'] )
     schema['required'] = list(set( schema['required'] + expected_object_schema['required'] ))
 
@@ -388,7 +412,7 @@ def getinfo(proxy=None):
     except Exception as ee:
         if BLOCKSTACK_DEBUG:
             log.exception(ee)
-        
+
         log.error("Caught exception while connecting to Blockstack node: {}".format(ee))
         resp = {'error': 'Failed to contact Blockstack node.  Try again with `--debug`.'}
         return resp
@@ -432,7 +456,7 @@ def ping(proxy=None):
             log.exception(e)
 
         resp = json_traceback(resp.get('error'))
-    
+
     except Exception as ee:
         if BLOCKSTACK_DEBUG:
             log.exception(ee)

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -800,7 +800,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                 return
 
             ret = {
-                'satus' : 'registered_subdomain',
+                'status' : 'registered_subdomain',
                 'zonefile_txt' : subdomain_obj.zonefile_str,
                 'zonefile_hash' : storage.get_zonefile_data_hash(subdomain_obj.zonefile_str),
                 'address' : subdomain_obj.address,

--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -64,7 +64,7 @@ regtest = True
 spv_path = @CLIENT_BLOCKCHAIN_HEADERS@
 
 [blockstack]
-server_version = 0.14.2
+server_version = 0.14.4
 rpc_port = %s
 backup_frequency = 1
 backup_max_age = 30
@@ -89,9 +89,10 @@ DEFAULT_CLIENT_INI_TEMPLATE = """
 accounts = @CLIENT_ACCOUNTS_PATH@
 users = @CLIENT_USERS_PATH@
 datastores = @CLIENT_DATASTORES_PATH@
-client_version = 0.14.2
+client_version = 0.14.4
 server = localhost
 port = %s
+protocol = http
 metadata = @CLIENT_METADATA@
 storage_drivers = @CLIENT_STORAGE_DRIVERS@
 storage_drivers_required_write = @CLIENT_STORAGE_DRIVERS_REQUIRED_WRITE@

--- a/integration_tests/blockstack_integration_tests/scenarios/testlib.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/testlib.py
@@ -21,7 +21,7 @@
     along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
 """
 
-# test lib to bind a test scenario to blockstack 
+# test lib to bind a test scenario to blockstack
 
 import os
 import sys
@@ -108,9 +108,10 @@ class TestAPIProxy(object):
         assert client_path is not None
 
         client_config = blockstack_client.get_config(client_path)
-        
+
         log.debug("Connect to Blockstack node at {}:{}".format(client_config['server'], client_config['port']))
-        self.client = blockstack_client.BlockstackRPCClient( client_config['server'], client_config['port'] )
+        self.client = blockstack_client.BlockstackRPCClient(
+            client_config['server'], client_config['port'], protocol = client_config['protocol'])
         self.config_path = client_path
         self.conf = {
             "start_block": blockstack.FIRST_BLOCK_MAINNET,

--- a/subdomain_registrar/subdomains_registrar.py
+++ b/subdomain_registrar/subdomains_registrar.py
@@ -90,12 +90,12 @@ class SubdomainOpsQueue(object):
             raise subdomains.SubdomainAlreadyExists(subdomain_name, self.domain)
 
     def _get_queued_rows(self):
-        sql = """SELECT received_at, subdomain FROM {} 
+        sql = """SELECT received_at, subdomain FROM {}
         WHERE in_tx ISNULL ORDER BY received_at ASC LIMIT {};
         """.format(self.queue_table, self.entries_per_tx_hint)
         out = list(self._execute(sql, ()).fetchall())
-        return [ (received_at, 
-                  subdomains.Subdomain.parse_subdomain_record(self.domain, json.loads(packed_subdomain))) 
+        return [ (received_at,
+                  subdomains.Subdomain.parse_subdomain_record(self.domain, json.loads(packed_subdomain)))
                  for received_at, packed_subdomain in out ]
 
     def _set_in_tx(self, subds, txid):
@@ -117,7 +117,7 @@ class SubdomainOpsQueue(object):
         if not status:
             return {"status" : "Subdomain is queued for update and should be announced within the next few blocks."}
         if status.startswith("ERR"):
-            return {"error" : 
+            return {"error" :
                     "There was a problem propagating your subdomain registration. The" +
                     " server experience an {} error while trying to issue the update.".format(status)}
         return {"status" :
@@ -139,7 +139,7 @@ class SubdomainOpsQueue(object):
         zf_init = get_zonefile(self.domain)
         for slice_sz in range(len(queued_rows), -1, -1):
             if slice_sz == 0:
-                return {'error' : 
+                return {'error' :
                         "Failed to construct small enough zonefile (size < {})".format(self.zonefile_limit)}
             cur_queued_rows = queued_rows[:slice_sz]
             indexes, entries = zip(* cur_queued_rows)


### PR DESCRIPTION
Adds HTTPS support to blockstack proxy.

Requires new config variable `blockstack-client.protocol` to specify either `HTTP` or `HTTPS`.

Default configures (and migrates node.blockstack.org-pointed configs) to using `https://node.blockstack.org:6263`