### PR TITLE
Add dockerfile and build/run instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Run in Ubuntu
+FROM ubuntu:xenial
+
+# Create directory for build
+RUN mkdir -p /src/blockstack
+
+# Copy in source files
+COPY . /src/blockstack
+WORKDIR /src/blockstack
+
+# Install Dependancies
+RUN apt-get update && apt-get install -y python-pip python-dev build-essential apt-utils libssl-dev libffi-dev rng-tools libgmp3-dev sudo software-properties-common sqlite3 lsof
+RUN pip2 install --upgrade pip
+RUN pip2 install --upgrade virtualenv
+
+# Build Blockstack
+RUN pip2 install . --upgrade

--- a/README.md
+++ b/README.md
@@ -135,6 +135,28 @@ $ git clone https://github.com/blockstack/blockstack-core.git
 $ blockstack-core/images/scripts/debian-release-candidate.sh
 ```
 
+## Running in Docker
+
+To run the Blockstack API in a docker container requires a couple of steps. Run the following commands from the root of the repo:
+
+```bash
+# Build image
+$ docker build -t myrepo/blockstack:latest .
+
+# Setup wallet and client config using the ./data/blockstack-api directory for your client.
+$ docker run -it -v $(pwd)/data/blockstack-api:/root/.blockstack myrepo/blockstack:latest blockstack setup -y --password PASSWORD
+
+# Start API on top of newly created wallet and configuration // run in terminal window
+$ docker run -it -v $(pwd)/data/blockstack-api:/root/.blockstack -p 6264:6264 myrepo/blockstack:latest blockstack api start-foreground --password PASSWORD --debug
+
+# Start API on top of newly created wallet and configuration // run detached
+$ docker run d -v $(pwd)/data/blockstack-api:/root/.blockstack -p 6264:6264 myrepo/blockstack:latest blockstack api start-foreground --password PASSWORD --debug
+
+# Start detatched API on top of default wallet and configuration
+$ docker run -d -v $HOME/.blockstack:/root/.blockstack -p 6264:6264 myrepo/blockstack:latest blockstack api start-foreground --password PASSWORD --debug
+```
+
+
 ## Community
 
 We have an active community of developers and the best place to interact with the community is:


### PR DESCRIPTION
This PR adds a `Dockerfile` for `blockstack-core`. The image created is simply an Ubuntu VM with blockstack installed and runnable. The major issue with the image is the size (~1GB). Don't know how much of this can be reduced. To run pull down this branch and follow the `Running In Docker` instructions in the README.md.

