### PR TITLE
Removing wildcard imports

### DIFF
--- a/blockstack_client/__init__.py
+++ b/blockstack_client/__init__.py
@@ -39,7 +39,7 @@ from proxy import getinfo, ping, get_name_cost, get_namespace_cost, get_all_name
         get_names_owned_by_address, get_consensus_at, get_consensus_range, get_nameops_at, \
         get_nameops_hash_at, get_name_blockchain_record, get_namespace_blockchain_record, \
         get_name_blockchain_history
-        
+
 from keys import make_wallet_keys, get_owner_privkey_info, get_data_privkey_info, get_payment_privkey_info
 
 from cli import get_cli_methods
@@ -75,7 +75,7 @@ from scripts import UTXOException, is_name_valid
 
 from utils import daemonize
 
-from backend.queue import in_queue, queue_append, queue_findone, queue_findall, queue_removeall 
+from backend.queue import in_queue, queue_append, queue_findone, queue_findall, queue_removeall
 
 # legacy compatibility
 from virtualchain import SPVClient

--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -147,7 +147,7 @@ from .keys import privkey_to_string
 from .proxy import (
     is_zonefile_current, get_default_proxy, json_is_error,
     get_name_blockchain_history, get_all_namespaces, getinfo,
-    storage, is_zonefile_data_current, MUTABLE_DATUM_FILE_TYPE
+    storage, is_zonefile_data_current
 )
 from .client import analytics_event
 from .scripts import UTXOException, is_name_valid, is_valid_hash, is_namespace_valid
@@ -166,7 +166,9 @@ from .data import datastore_mkdir, datastore_rmdir, make_datastore_info, put_dat
         datastore_getinode, datastore_get_privkey, \
         make_mutable_data_info, data_blob_parse, data_blob_serialize, make_mutable_data_tombstones, sign_mutable_data_tombstones
 
-from .schemas import OP_URLENCODED_PATTERN, OP_NAME_PATTERN, OP_USER_ID_PATTERN, OP_BASE58CHECK_PATTERN
+from .schemas import (
+    OP_URLENCODED_PATTERN, OP_NAME_PATTERN, OP_USER_ID_PATTERN,
+    OP_BASE58CHECK_PATTERN, MUTABLE_DATUM_FILE_TYPE)
 
 import keylib
 

--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -86,15 +86,16 @@ from blockstack_client.profile import put_profile, delete_profile, get_profile, 
         profile_add_device_id, profile_remove_device_id, profile_list_accounts, profile_get_account, \
         profile_put_account, profile_delete_account
 
-from rpc import local_api_connect, local_api_status 
+from rpc import local_api_connect, local_api_status
 import rpc as local_rpc
 import config
 
 from .config import configure_zonefile, configure, get_utxo_provider_client, get_tx_broadcaster, get_local_device_id
 from .constants import (
-    CONFIG_PATH, CONFIG_DIR,
+    CONFIG_PATH, CONFIG_DIR, WALLET_FILENAME,
     FIRST_BLOCK_MAINNET, NAME_UPDATE,
-    BLOCKSTACK_DEBUG, TX_MIN_CONFIRMATIONS, DEFAULT_SESSION_LIFETIME
+    BLOCKSTACK_DEBUG, TX_MIN_CONFIRMATIONS, DEFAULT_SESSION_LIFETIME,
+    get_secret, set_secret, BLOCKSTACK_TEST, VERSION
 )
 
 from .storage import get_driver_urls, get_storage_handlers, sign_data_payload, \
@@ -105,21 +106,50 @@ from .backend.blockchain import (
     get_tx_confirmations, get_tx_fee, get_tx_fee_per_byte, get_block_height
 )
 
-from .backend.registrar import get_wallet as registrar_get_wallet 
+from .backend.registrar import get_wallet as registrar_get_wallet
 
 from .backend.nameops import (
     do_namespace_preorder, do_namespace_reveal, do_namespace_ready,
     do_name_import
 )
 
-from .backend.safety import *
+from .backend.safety import (
+    check_valid_name, check_valid_namespace, check_operations,
+    interpret_operation_fees, get_operation_fees
+)
 from .backend.queue import queuedb_remove, queuedb_find, queue_append
 from .backend.queue import extract_entry as queue_extract_entry
 
-from .wallet import *
-from .keys import *
-from .proxy import *
-from .client import analytics_event 
+from .wallet import (
+    get_total_balance,
+    get_all_names_owned,
+    get_owner_addresses_and_names,
+    get_wallet,
+    get_names_owned,
+    get_wallet_path,
+    get_addresses_from_file,
+    getpass,
+    backup_wallet,
+    is_wallet_unlocked,
+    prompt_wallet_password,
+    encrypt_wallet,
+    write_wallet,
+    wallet_setup,
+    make_wallet_password,
+    make_wallet,
+    decrypt_wallet,
+    load_wallet,
+    wallet_exists,
+    unlock_wallet
+)
+
+from .keys import privkey_to_string
+from .proxy import (
+    is_zonefile_current, get_default_proxy, json_is_error,
+    get_name_blockchain_history, get_all_namespaces, getinfo,
+    storage, is_zonefile_data_current, MUTABLE_DATUM_FILE_TYPE
+)
+from .client import analytics_event
 from .scripts import UTXOException, is_name_valid, is_valid_hash, is_namespace_valid
 from .user import make_empty_user_profile, user_zonefile_data_pubkey
 
@@ -128,7 +158,7 @@ from .zonefile import make_empty_zonefile, url_to_uri_record, decode_name_zonefi
 
 from .utils import exit_with_error, satoshis_to_btc, ScatterGather
 from .app import app_publish, app_get_config, app_get_resource, \
-        app_put_resource, app_delete_resource 
+        app_put_resource, app_delete_resource
 
 from .data import datastore_mkdir, datastore_rmdir, make_datastore_info, put_datastore, delete_datastore, \
         datastore_getfile, datastore_putfile, datastore_deletefile, datastore_listdir, datastore_stat, \
@@ -141,7 +171,10 @@ from .schemas import OP_URLENCODED_PATTERN, OP_NAME_PATTERN, OP_USER_ID_PATTERN,
 import keylib
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import (
+    ecdsa_private_key, set_privkey_compressed,
+    ECPrivateKey, get_pubkey_hex
+)
 
 log = config.get_logger()
 
@@ -457,8 +490,9 @@ def cli_withdraw(args, password=None, interactive=True, wallet_keys=None, config
 
     if message:
         message = str(message)
-        if len(message) > virtualchain.bitcoin_blockchain.MAX_DATA_LEN:
-            return {'error': 'Message must be {} bytes or less (got {})'.format(virtualchain.bitcoin_blockchain.MAX_DATA_LEN, len(message))}
+        if len(message) > virtualchain.lib.blockchain.bitcoin_blockchain.MAX_DATA_LEN:
+            return {'error': 'Message must be {} bytes or less (got {})'.format(
+                virtualchain.lib.blockchain.bitcoin_blockchain.MAX_DATA_LEN, len(message))}
 
     res = wallet_ensure_exists(config_path=config_path)
     if 'error' in res:
@@ -2718,7 +2752,7 @@ def cli_namespace_preorder(args, config_path=CONFIG_PATH, interactive=True, prox
         'The address {} will be used to reveal the namespace.'.format(reveal_addr),
         'MAKE SURE YOU KEEP THE PRIVATE KEYS FOR BOTH ADDRESSES\n',
         "\n",
-        "Before you preorder this namespace, there are some things you should know.\n".format(nsid),
+        "Before you preorder this namespace {}, there are some things you should know.\n".format(nsid),
         "\n",
         "* Once you preorder the namespace, you will need to reveal it within 144 blocks (about 24 hours).\n",
         "  If you do not do so, then the namespace fee is LOST FOREVER and someone else can preorder it.\n",
@@ -4625,7 +4659,7 @@ def cli_list_devices( args, config_path=CONFIG_PATH, proxy=None ):
     arg: appname (str) 'The name of the application'
     """
     
-    raise NotImplemented("Missing token file parsing logic")
+    raise NotImplementedError("Missing token file parsing logic")
 
 
 def cli_add_device( args, config_path=CONFIG_PATH, proxy=None ):
@@ -4636,7 +4670,7 @@ def cli_add_device( args, config_path=CONFIG_PATH, proxy=None ):
     opt: device_id (str) 'The ID of the device to add, if not this one'
     """
 
-    raise NotImplemented("Missing token file parsing logic")
+    raise NotImplementedError("Missing token file parsing logic")
     
 
 def cli_remove_device( args, config_path=CONFIG_PATH, proxy=None ):
@@ -4647,7 +4681,7 @@ def cli_remove_device( args, config_path=CONFIG_PATH, proxy=None ):
     arg: device_id (str) 'The ID of the device to remove'
     """
     
-    raise NotImplemented("Missing token file parsing logic")
+    raise NotImplementedError("Missing token file parsing logic")
 
 
 def _remove_datastore(rpc, datastore, datastore_privkey, data_pubkeys, rmtree=True, force=False, config_path=CONFIG_PATH ):
@@ -4943,7 +4977,7 @@ def cli_get_datastore( args, config_path=CONFIG_PATH ):
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     return get_datastore_by_type('datastore', blockchain_id, datastore_id, device_ids, config_path=config_path )
 
@@ -5142,13 +5176,13 @@ def cli_datastore_getfile( args, config_path=CONFIG_PATH, interactive=False ):
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     device_pubkeys = None
     if hasattr(args, 'device_pubkeys'):
         device_pubkeys = str(args.device_pubkeys).split(',')
     else:
-        raise NotImplemented("No support for token files")
+        raise NotImplementedError("No support for token files")
 
     assert len(device_ids) == len(device_pubkeys)
     data_pubkeys = [{
@@ -5204,13 +5238,13 @@ def cli_datastore_listdir(args, config_path=CONFIG_PATH, interactive=False ):
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     device_pubkeys = None
     if hasattr(args, 'device_pubkeys'):
         device_pubkeys = str(args.device_pubkeys).split(',')
     else:
-        raise NotImplemented("No support for token files")
+        raise NotImplementedError("No support for token files")
 
     assert len(device_ids) == len(device_pubkeys)
     data_pubkeys = [{
@@ -5267,14 +5301,14 @@ def cli_datastore_stat(args, config_path=CONFIG_PATH, interactive=False ):
 
     else:
         # TODO
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     device_pubkeys = None
     if hasattr(args, 'device_pubkeys'):
         device_pubkeys = str(args.device_pubkeys).split(',')
     else:
         # TODO
-        raise NotImplemented("No support for token files")
+        raise NotImplementedError("No support for token files")
 
     assert len(device_ids) == len(device_pubkeys)
     data_pubkeys = [{
@@ -5339,14 +5373,14 @@ def cli_datastore_getinode(args, config_path=CONFIG_PATH, interactive=False):
 
     else:
         # TODO
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     device_pubkeys = None
     if hasattr(args, 'device_pubkeys'):
         device_pubkeys = str(args.device_pubkeys).split(',')
     else:
         # TODO
-        raise NotImplemented("No support for token files")
+        raise NotImplementedError("No support for token files")
 
     assert len(device_ids) == len(device_pubkeys)
     data_pubkeys = [{
@@ -5424,7 +5458,7 @@ def cli_datastore_get_privkey(args, config_path=CONFIG_PATH, interactive=False )
     arg: master_privkey (str) 'The master data private key'
     arg: app_domain (str) 'The name of the application'
     """
-    raise NotImplemented("Token file support not yet implemented")
+    raise NotImplementedError("Token file support not yet implemented")
 
     app_domain = str(args.app_domain)
     master_privkey = str(args.master_privkey)
@@ -5451,7 +5485,7 @@ def cli_get_collection( args, config_path=CONFIG_PATH, proxy=None, password=None
     arg: collection_domain (str) 'The name of the collection'
     opt: device_ids (str) 'The list of device IDs that can write'
     """
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     blockchain_id = str(args.blockchain_id)
     collection_domain = str(args.collection_domain)
@@ -5471,7 +5505,7 @@ def cli_create_collection( args, config_path=CONFIG_PATH, proxy=None, password=N
     if proxy is None:
         proxy = get_default_proxy(config_path)
     
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     blockchain_id = str(args.blockchain_id)
     password = get_default_password(password)
@@ -5483,11 +5517,11 @@ def cli_create_collection( args, config_path=CONFIG_PATH, proxy=None, password=N
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     # TODO: privkey
     # privkey = 
-    raise NotImplemented("Collections are not implemented yet")
+    raise NotImplementedError("Collections are not implemented yet")
 
     # get the list of device IDs to use 
     device_ids = getattr(args, 'device_ids', None)
@@ -5495,7 +5529,7 @@ def cli_create_collection( args, config_path=CONFIG_PATH, proxy=None, password=N
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     return create_datastore_by_type('collection', blockchain_id, privkey, device_ids, proxy=proxy, config_path=config_path, password=password, master_data_privkey=master_data_privkey)
 
@@ -5512,7 +5546,7 @@ def cli_delete_collection( args, config_path=CONFIG_PATH, proxy=None, password=N
     if proxy is None:
         proxy = get_default_proxy(config_path)
 
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     password = get_default_password(password)
 
@@ -5525,17 +5559,17 @@ def cli_delete_collection( args, config_path=CONFIG_PATH, proxy=None, password=N
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     # TODO: privkey
     # privkey = 
-    raise NotImplemented("Collections are not implemented")
+    raise NotImplementedError("Collections are not implemented")
 
     device_ids = None
     if hasattr(args, 'device_ids'):
         device_ids = str(args.device_ids).split(',')
     else:
-        raise NotImplemented("No support for token files")
+        raise NotImplementedError("No support for token files")
 
     return delete_datastore_by_type('collection', blockchain_id, privkey, device_ids, force=True, config_path=config_path, proxy=proxy, password=password)
 
@@ -5552,7 +5586,7 @@ def cli_collection_listitems(args, config_path=CONFIG_PATH, password=None, inter
     if proxy is None:
         proxy = get_default_proxy(config_path)
 
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     password = get_default_password(password)
     blockchain_id = str(args.blockchain_id)
@@ -5563,7 +5597,7 @@ def cli_collection_listitems(args, config_path=CONFIG_PATH, password=None, inter
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     collection_domain = str(args.collection_domain)
     path = str(args.path)
@@ -5594,7 +5628,7 @@ def cli_collection_statitem(args, config_path=CONFIG_PATH, interactive=False, pr
     if proxy is None:
         proxy = get_default_proxy(config_path)
 
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     password = get_default_password(password)
 
@@ -5604,7 +5638,7 @@ def cli_collection_statitem(args, config_path=CONFIG_PATH, interactive=False, pr
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
     blockchain_id = str(args.blockchain_id)
     collection_domain = str(args.collection_domain)
@@ -5627,7 +5661,7 @@ def cli_collection_putitem(args, config_path=CONFIG_PATH, interactive=False, pro
     if proxy is None:
         proxy = get_default_proxy(config_path)
     
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     password = get_default_password(password)
 
@@ -5643,7 +5677,7 @@ def cli_collection_putitem(args, config_path=CONFIG_PATH, interactive=False, pro
         device_ids = device_ids.split(',')
 
     else:
-        raise NotImplemented("Missing token file parsing logic")
+        raise NotImplementedError("Missing token file parsing logic")
 
 
     return datastore_file_put('collection', blockchain_id, collection_privkey, '/{}'.format(item_id), data, device_ids=device_ids, 
@@ -5662,7 +5696,7 @@ def cli_collection_getitem( args, config_path=CONFIG_PATH, interactive=False, pa
     if proxy is None:
         proxy = get_default_proxy(config_path)
 
-    raise NotImplemented("Collections not implemented")
+    raise NotImplementedError("Collections not implemented")
 
     password = get_default_password(password)
 

--- a/blockstack_client/app.py
+++ b/blockstack_client/app.py
@@ -23,25 +23,26 @@ from __future__ import print_function
     You should have received a copy of the GNU General Public License
     along with Blockstack-client. If not, see <http://www.gnu.org/licenses/>.
 """
+import json
 import jsonschema
 from jsonschema.exceptions import ValidationError
 import time
 
-from keylib import *
-
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import get_pubkey_hex
 
 import jsontokens
 import storage
 import data
 import user as user_db
-from .proxy import *
+from .proxy import get_default_proxy
 
-from config import get_config
+from config import get_config, get_logger
 from .constants import CONFIG_PATH, BLOCKSTACK_TEST, LENGTH_MAX_NAME, DEFAULT_API_PORT, DEFAULT_API_HOST
-from .schemas import *
+from .schemas import APP_CONFIG_SCHEMA, APP_SESSION_SCHEMA
 from .storage import classify_storage_drivers
+
+log = get_logger()
 
 def app_make_session( blockchain_id, app_private_key, app_domain, methods, app_public_keys, requester_device_id, master_data_privkey, session_lifetime=None, config_path=CONFIG_PATH ):
     """
@@ -238,7 +239,7 @@ def app_get_config( blockchain_id, app_domain, data_pubkey=None, proxy=None, con
     # go get config
     res = data.get_mutable( ".blockstack", [app_domain], data_pubkey=data_pubkey, proxy=proxy, config_path=config_path, blockchain_id=blockchain_id )
     if 'error' in res:
-        log.error("Failed to get application config file {}: {}".format(config_data_id, res['error']))
+        log.error("Failed to get application config file: {}".format(res['error']))
         return res
 
     app_cfg = None
@@ -249,7 +250,7 @@ def app_get_config( blockchain_id, app_domain, data_pubkey=None, proxy=None, con
         if BLOCKSTACK_TEST:
             log.exception(ve)
 
-        log.error("Invalid application config file {}".format(config_data_id))
+        log.error("Invalid application config file {}".format(app_cfg))
         return {'error': 'Invalid application config'}
 
     return {'status': True, 'config': app_cfg}

--- a/blockstack_client/backend/drivers/common.py
+++ b/blockstack_client/backend/drivers/common.py
@@ -34,6 +34,8 @@ import posixpath
 import urllib
 import threading
 import time
+import tempfile
+
 from functools import wraps
 
 if os.environ.get("BLOCKSTACK_DEBUG", None) is not None:

--- a/blockstack_client/backend/drivers/disk.py
+++ b/blockstack_client/backend/drivers/disk.py
@@ -205,7 +205,7 @@ def put_immutable_handler( key, data, txid, **kw ):
 
    if not os.path.exists(pathdir):
        try:
-           os.makedirs(path_dir, 0700)
+           os.makedirs(pathdir, 0700)
        except Exception, e:
            if DEBUG:
                log.exception(e)
@@ -241,7 +241,7 @@ def put_mutable_handler( data_id, data_bin, **kw ):
 
    if not os.path.exists(pathdir):
        try:
-           os.makedirs(path_dir, 0700)
+           os.makedirs(pathdir, 0700)
        except Exception, e:
            if DEBUG:
                log.exception(e)
@@ -321,8 +321,8 @@ if __name__ == "__main__":
    current_dir =  os.path.abspath(os.path.join( os.path.dirname(__file__), "..") )
    sys.path.insert(0, current_dir)
    
-   from storage import serialize_mutable_data, parse_mutable_data
-   from user import make_mutable_data_info
+   from blockstack_client.storage import serialize_mutable_data, parse_mutable_data
+   from blockstack_client.user import make_mutable_data_info
 
    pk = keylib.ECPrivateKey()
    data_privkey = pk.to_hex()

--- a/blockstack_client/backend/nameops.py
+++ b/blockstack_client/backend/nameops.py
@@ -24,6 +24,7 @@ import os
 import sys
 import json
 import time
+import random
 import keylib
 
 # Hack around absolute paths
@@ -36,9 +37,11 @@ from .blockchain import get_tx_confirmations
 from .blockchain import get_utxos, get_tx_fee_per_byte
 from .blockchain import get_block_height
 
-from ..config import PREORDER_CONFIRMATIONS, DEFAULT_QUEUE_PATH, CONFIG_PATH, get_utxo_provider_client, get_tx_broadcaster, RPC_MAX_ZONEFILE_LEN
-from ..config import APPROX_TX_IN_P2PKH_LEN, APPROX_TX_OUT_P2PKH_LEN, APPROX_TX_OVERHEAD_LEN, APPROX_TX_IN_P2SH_LEN, APPROX_TX_OUT_P2SH_LEN
-from ..constants import BLOCKSTACK_TEST, BLOCKSTACK_DEBUG, TX_MIN_CONFIRMATIONS, BLOCKSTACK_DRY_RUN
+from ..config import DEFAULT_QUEUE_PATH, CONFIG_PATH, get_utxo_provider_client, get_tx_broadcaster
+from ..constants import (
+    BLOCKSTACK_TEST, BLOCKSTACK_DEBUG, TX_MIN_CONFIRMATIONS, BLOCKSTACK_DRY_RUN,
+    PREORDER_CONFIRMATIONS, RPC_MAX_ZONEFILE_LEN, APPROX_TX_IN_P2SH_LEN, APPROX_TX_OUT_P2SH_LEN,
+    APPROX_TX_IN_P2PKH_LEN, APPROX_TX_OUT_P2PKH_LEN, APPROX_TX_OVERHEAD_LEN)
 
 from ..proxy import get_default_proxy
 from ..proxy import getinfo as blockstack_getinfo
@@ -762,7 +765,7 @@ def estimate_revoke_tx_fee( name, payment_privkey_info, owner_privkey_info, tx_f
             unsigned_tx = revoke_tx( name, owner_address, utxo_client, subsidize=True, safety=False )
             assert unsigned_tx
 
-            pad_len = estimate_input_length(owner_privkey_info) + estiamte_input_length(payment_privkey_info)
+            pad_len = estimate_input_length(owner_privkey_info) + estimate_input_length(payment_privkey_info)
             signed_subsidized_tx = unsigned_tx + '00' * pad_len
 
     except ValueError, ve:
@@ -899,7 +902,7 @@ def estimate_namespace_preorder_tx_fee( namespace_id, cost, payment_privkey_info
             assert signed_tx
 
         except AssertionError as ae:
-            log.warning("Insufficient funds in {} for NAMESPACE_PREORDER; estimating instead".format(payment_addr))
+            log.warning("Insufficient funds in {} for NAMESPACE_PREORDER; estimating instead".format(payment_address))
             unsigned_tx = namespace_preorder_tx( namespace_id, fake_reveal_address, cost, fake_consensus_hash, payment_address, utxo_client, safety=False )
             assert unsigned_tx
             
@@ -1215,7 +1218,7 @@ def do_blockchain_tx( unsigned_tx, privkey_info=None, config_path=CONFIG_PATH, t
 
     try:
         if dry_run:
-            if payment_privkey_info is not None:
+            if privkey_info is not None:
                 resp = sign_tx( unsigned_tx, privkey_info )
             else:
                 resp = unsigned_tx

--- a/blockstack_client/backend/nameops.py
+++ b/blockstack_client/backend/nameops.py
@@ -57,7 +57,10 @@ from ..storage import get_blockchain_compat_hash, put_announcement, get_zonefile
 from ..operations import fees_update, fees_transfer, fees_revoke, fees_registration, fees_preorder, \
         fees_namespace_preorder, fees_namespace_reveal, fees_namespace_ready, fees_name_import, fees_announce
 
-from .safety import *
+from .safety import (
+    check_preorder, check_register, check_update, check_transfer, check_renewal,
+    check_revoke, check_name_import, check_namespace_preorder, check_namespace_reveal, check_namespace_ready)
+
 from ..logger import get_logger
 from ..utxo import get_unspents
 

--- a/blockstack_client/backend/queue.py
+++ b/blockstack_client/backend/queue.py
@@ -28,7 +28,8 @@ import base64
 import time
 import random
 
-from ..constants import DEFAULT_QUEUE_PATH, PREORDER_MAX_CONFIRMATIONS, CONFIG_PATH
+from ..constants import (
+    DEFAULT_QUEUE_PATH, PREORDER_MAX_CONFIRMATIONS, CONFIG_PATH, MAX_TX_CONFIRMATIONS)
 from .blockchain import get_block_height, get_tx_confirmations, is_tx_accepted
 
 QUEUE_SQL = """
@@ -46,7 +47,6 @@ CREATE TABLE entry_errs( fqu STRING NOT NULL,
                          PRIMARY KEY(fqu,queue_id,errormsg));
 """
 
-from ..config import MAX_TX_CONFIRMATIONS
 from ..logger import get_logger
 
 log = get_logger()
@@ -132,9 +132,10 @@ def queuedb_query_execute( cur, query, values ):
         except sqlite3.OperationalError as oe:
             if oe.message == "database is locked":
                 timeout = timeout * 2 + timeout * random.random()
-                log.error("Query timed out due to lock; retrying in %s: %s" % (timeout, namedb_format_query( query, values )))
+                log.error("Query timed out due to lock; retrying in %s: (%s, %s)" %
+                          (timeout, query, values))
                 time.sleep(timeout)
-            
+
             else:
                 log.exception(oe)
                 log.error("FATAL: failed to execute query (%s, %s)" % (query, values))

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -53,7 +53,7 @@ from ..proxy import is_name_registered, is_zonefile_hash_current, get_default_pr
 from ..zonefile import zonefile_data_replicate
 from ..user import is_user_zonefile
 from ..storage import put_mutable_data, get_zonefile_data_hash
-from ..data import set_profile_timestamp
+from ..profile import set_profile_timestamp
 
 from ..constants import CONFIG_PATH, DEFAULT_QUEUE_PATH, BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, TX_MIN_CONFIRMATIONS
 from ..constants import PREORDER_CONFIRMATIONS

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -43,7 +43,7 @@ import blockstack_zones
 import virtualchain
 
 from .queue import get_queue_state, in_queue, cleanup_preorder_queue, queue_removeall
-from .queue import queue_find_accepted
+from .queue import queue_find_accepted, queuedb_find
 from .queue import queue_add_error_msg
 
 from .nameops import async_preorder, async_register, async_update, async_transfer, async_renew, async_revoke

--- a/blockstack_client/backend/utxo/blockchain_info.py
+++ b/blockstack_client/backend/utxo/blockchain_info.py
@@ -26,6 +26,8 @@ import requests
 BLOCKCHAIN_API_BASE_URL = "https://blockchain.info"
 
 from .blockchain_client import BlockchainClient
+from binascii import hexlify
+import virtualchain
 
 class BlockchainInfoClient(BlockchainClient):
     def __init__(self, api_key=None, timeout=30, min_confirmations=None):
@@ -35,7 +37,7 @@ class BlockchainInfoClient(BlockchainClient):
             self.auth = (api_key, '')
         else:
             self.auth = None
-        
+
         self.min_confirmations = min_confirmations
 
 def reverse_hash(hash, hex_format=True):

--- a/blockstack_client/backend/utxo/insight_api.py
+++ b/blockstack_client/backend/utxo/insight_api.py
@@ -54,15 +54,15 @@ class InsightClient(object):
         except Exception as e:
             traceback.print_exc()
             raise ValueError("Invalid UTXO response")
-        
+
 
     def broadcast_transaction(self, rawtx):
         url = self.url + '/insight-api/tx/send'
         req = None
-        
+
         data = json.dumps({'rawtx': rawtx})
         headers = {'content-type': 'application/json', 'accept': 'application/json'}
-        
+
         req = None
         resp = None
 
@@ -124,12 +124,12 @@ if __name__ == '__main__':
     arg = sys.argv[2]
 
     if op == 'get_unspents':
-        res = get_unspents(arg)
+        res = _get_unspents(arg)
         print json.dumps(res, indent=4, sort_keys=True)
         sys.exit(0)
 
     elif op == 'broadcast_transaction':
-        res = broadcast_transaction(arg)
+        res = _broadcast_transaction(arg)
         print json.dumps(res, indent=4, sort_keys=True)
         sys.exit(0)
 

--- a/blockstack_client/cli.py
+++ b/blockstack_client/cli.py
@@ -36,7 +36,7 @@ as a command-line option.
 """
 
 import argparse
-import sys
+import sys, os
 import requests
 import traceback
 requests.packages.urllib3.disable_warnings()
@@ -45,12 +45,12 @@ import logging
 logging.disable(logging.CRITICAL)
 
 from blockstack_client import config
-from blockstack_client.client import session, analytics_user_register 
+from blockstack_client.client import session, analytics_user_register
 from blockstack_client.constants import WALLET_FILENAME, set_secret, serialize_secrets, write_secrets, load_secrets, CONFIG_PATH
 from blockstack_client.config import CONFIG_PATH, VERSION, client_uuid_path, get_or_set_uuid
 from blockstack_client.method_parser import parse_methods, build_method_subparsers
 
-from wallet import *
+from .wallet import inspect_wallet
 from utils import exit_with_error, print_result
 
 log = config.get_logger()
@@ -546,7 +546,7 @@ def run_cli(argv=None, config_path=CONFIG_PATH):
             print('')
             print('Interactive prompt engaged.  Press Ctrl+C to quit')
             print('Help for "{}": {}'.format(method_info['command'], method_info['help']))
-            print('Arguments: {} {}'.format(method_info['command'], arg_usage, opt_usage))
+            print('Arguments: {} {} {}'.format(method_info['command'], arg_usage, opt_usage))
             print('')
 
             required_args = prompt_args(method_info['args'], prompt_func)

--- a/blockstack_client/client.py
+++ b/blockstack_client/client.py
@@ -25,7 +25,7 @@ import sys
 import os
 import importlib
 
-from proxy import *
+from proxy import BlockstackRPCClient, set_default_proxy, get_default_proxy
 from virtualchain import SPVClient
 import storage
 

--- a/blockstack_client/config.py
+++ b/blockstack_client/config.py
@@ -36,13 +36,26 @@ import time
 import shutil
 import requests
 import keylib
+import json
 
 from binascii import hexlify
 from ConfigParser import SafeConfigParser
 
 import virtualchain
-from .utxo import *
-from .constants import *
+from .utxo import (
+    SUPPORTED_UTXO_PROVIDERS, default_utxo_provider_opts,
+    SUPPORTED_UTXO_PARAMS, SUPPORTED_UTXO_PROMPT_MESSAGES,
+    connect_utxo_provider
+)
+from .constants import (
+    NAME_REGISTRATION, OPCODE_NAMES, CONFIG_DIR, CONFIG_PATH,
+    TX_MIN_CONFIRMATIONS, BLOCKSTACKD_SERVER, BLOCKSTACKD_PORT,
+    METADATA_DIRNAME, BLOCKSTACK_DEFAULT_STORAGE_DRIVERS,
+    BLOCKSTACK_REQUIRED_STORAGE_DRIVERS_WRITE, DEFAULT_API_PORT,
+    DEFAULT_API_HOST, DEFAULT_QUEUE_PATH, DEFAULT_POLL_INTERVAL,
+    DEFAULT_BLOCKCHAIN_READER, DEFAULT_BLOCKCHAIN_WRITER,
+    VERSION
+)
 from .logger import get_logger
 
 log = get_logger('blockstack-client')

--- a/blockstack_client/data.py
+++ b/blockstack_client/data.py
@@ -22,7 +22,7 @@
 """
 
 import json
-import os
+import os, sys
 import time
 import jsontokens
 import blockstack_profiles
@@ -40,7 +40,7 @@ import collections
 import threading
 import functools
 
-from keylib import *
+import keylib
 
 import virtualchain
 from virtualchain.lib.ecdsalib import *
@@ -4380,7 +4380,7 @@ if __name__ == "__main__":
         auth_request = {
             'app_domain': 'datastore.unit.tests',
             'methods': ['store_read', 'store_write', 'store_admin'],
-            'app_public_key': key_formatting.decompress( ECPrivateKey(private_key).public_key().to_hex() ),
+            'app_public_key': keylib.key_formatting.decompress( ECPrivateKey(private_key).public_key().to_hex() ),
         }
 
         # authentication: bearer {password}

--- a/blockstack_client/data.py
+++ b/blockstack_client/data.py
@@ -39,23 +39,41 @@ import jsontokens
 import collections
 import threading
 import functools
+import copy
+import jsonschema
+from jsonschema import ValidationError
 
 import keylib
+from keylib import ECPrivateKey
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import sign_raw_data, get_pubkey_hex
 
-from .keys import *
-from .profile import *
-from .proxy import *
+from .keys import (get_payment_privkey_info, get_owner_privkey_info, HDWallet)
+
+from .profile import get_data_privkey_info
+
+from .proxy import (
+    getinfo, get_name_blockchain_history, get_default_proxy, json_is_error)
 from .storage import hash_zonefile
 from .zonefile import get_name_zonefile, load_name_zonefile, store_name_zonefile
 from .utils import ScatterGather
 
 from .logger import get_logger
 from .config import get_config, get_local_device_id
-from .constants import BLOCKSTACK_TEST, BLOCKSTACK_DEBUG, DATASTORE_SIGNING_KEY_INDEX, BLOCKSTACK_STORAGE_PROTO_VERSION, DEFAULT_DEVICE_ID
-from .schemas import *
+from .constants import (
+    BLOCKSTACK_TEST, BLOCKSTACK_DEBUG, DATASTORE_SIGNING_KEY_INDEX,
+    BLOCKSTACK_STORAGE_PROTO_VERSION, DEFAULT_DEVICE_ID,
+    CONFIG_PATH
+)
+
+from .schemas import (
+    DATA_BLOB_SCHEMA,
+    DATASTORE_SCHEMA,
+    MUTABLE_DATUM_DIR_SCHEMA,
+    MUTABLE_DATUM_INODE_HEADER_SCHEMA,
+    MUTABLE_DATUM_DIR_TYPE,
+    MUTABLE_DATUM_FILE_TYPE)
 
 log = get_logger()
 

--- a/blockstack_client/keys.py
+++ b/blockstack_client/keys.py
@@ -35,7 +35,8 @@ from .logger import get_logger
 from .constants import CONFIG_PATH, BLOCKSTACK_DEBUG, BLOCKSTACK_TEST
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import (
+    set_privkey_compressed, get_pubkey_hex, ecdsa_private_key)
 
 # for compatibility
 log = get_logger()

--- a/blockstack_client/logger.py
+++ b/blockstack_client/logger.py
@@ -37,7 +37,12 @@ import requests
 from ConfigParser import SafeConfigParser
 
 import virtualchain
-from .constants import *
+from .constants import (
+    DEBUG,
+    LOG_NETWORK_PORT,
+    get_secret,
+    CONFIG_PATH,
+    BLOCKSTACK_TEST)
 
 
 class NetworkLogFormatter( logging.Formatter ):

--- a/blockstack_client/method_parser.py
+++ b/blockstack_client/method_parser.py
@@ -24,6 +24,7 @@
 import re
 
 import config
+import constants
 
 log = config.get_logger('blockstack-client')
 
@@ -130,7 +131,7 @@ def parse_methods(method_list):
                 assert arg_type in ['str', 'int'], "arg_type is {}".format(arg_type)
                 arg_type = eval(arg_type)
             except AssertionError as ae:
-                if config.BLOCKSTACK_DEBUG:
+                if constants.BLOCKSTACK_DEBUG:
                     log.exception(ae)
 
                 raise ValueError(error_msg.format(method_name, 'failed to parse arg', l))

--- a/blockstack_client/operations/__init__.py
+++ b/blockstack_client/operations/__init__.py
@@ -78,6 +78,7 @@ from .namespacereveal import snv_consensus_extras as namespace_reveal_consensus_
 from .namespaceready import snv_consensus_extras as namespace_ready_consensus_extras
 from .announce import snv_consensus_extras as announce_consensus_extras
 
+from ..constants import (NAME_IMPORT, NAME_PREORDER, OPFIELDS)
 from ..config import *
 
 # NOTE: these all have the same signatures

--- a/blockstack_client/operations/announce.py
+++ b/blockstack_client/operations/announce.py
@@ -23,6 +23,9 @@
 
 from utilitybelt import is_hex
 
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    BLOCKSTACK_BURN_ADDRESS)
 from ..config import *
 from ..scripts import *
 from ..logger import get_logger
@@ -32,15 +35,15 @@ log = get_logger("blockstack-client")
 
 def build(message_hash):
     """
-     
+
     Record format:
-    
+
     0    2  3                             23
     |----|--|-----------------------------|
     magic op   message hash (160-bit)
-    
+
     """
-   
+
     if len(message_hash) != 40:
         raise Exception("Invalid hash: not 20 bytes")
 
@@ -50,8 +53,8 @@ def build(message_hash):
     readable_script = "ANNOUNCE 0x%s" % (message_hash)
     hex_script = blockstack_script_to_hex(readable_script)
     packaged_script = add_magic_bytes(hex_script)
-    
-    return packaged_script 
+
+    return packaged_script
 
 
 def make_outputs( data, inputs, change_address, tx_fee, pay_fee=True ):

--- a/blockstack_client/operations/announce.py
+++ b/blockstack_client/operations/announce.py
@@ -26,8 +26,16 @@ from utilitybelt import is_hex
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
     BLOCKSTACK_BURN_ADDRESS)
-from ..config import *
-from ..scripts import *
+
+from ..scripts import (
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
+
 from ..logger import get_logger
 
 import virtualchain

--- a/blockstack_client/operations/nameimport.py
+++ b/blockstack_client/operations/nameimport.py
@@ -27,6 +27,9 @@ from binascii import hexlify, unhexlify
 from ..config import *
 from ..scripts import *
 from ..logger import get_logger
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    LENGTH_VALUE_HASH)
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/nameimport.py
+++ b/blockstack_client/operations/nameimport.py
@@ -24,12 +24,20 @@
 import keylib
 from binascii import hexlify, unhexlify
 
-from ..config import *
-from ..scripts import *
 from ..logger import get_logger
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
     LENGTH_VALUE_HASH)
+from ..scripts import (
+    hash_name,
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
+
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/namespacepreorder.py
+++ b/blockstack_client/operations/namespacepreorder.py
@@ -27,6 +27,10 @@ from ..b40 import is_b40
 from ..config import *
 from ..scripts import *
 from ..logger import get_logger
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    BLOCKSTACK_BURN_ADDRESS,
+    LENGTH_CONSENSUS_HASH)
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/namespacepreorder.py
+++ b/blockstack_client/operations/namespacepreorder.py
@@ -24,13 +24,20 @@
 import keylib
 
 from ..b40 import is_b40
-from ..config import *
-from ..scripts import *
 from ..logger import get_logger
 from ..constants import (
-    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
-    BLOCKSTACK_BURN_ADDRESS,
-    LENGTH_CONSENSUS_HASH)
+   DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+   BLOCKSTACK_BURN_ADDRESS, LENGTH_MAX_NAMESPACE_ID,
+   LENGTH_CONSENSUS_HASH)
+from ..scripts import (
+   hash256_trunc128,
+   hash_name,
+   blockstack_script_to_hex,
+   add_magic_bytes,
+   is_namespace_valid,
+   tx_get_unspents,
+   hash256_trunc128
+)
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/namespaceready.py
+++ b/blockstack_client/operations/namespaceready.py
@@ -23,6 +23,8 @@
 
 from binascii import hexlify
 
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE)
 from ..b40 import is_b40
 from ..config import *
 from ..scripts import *

--- a/blockstack_client/operations/namespaceready.py
+++ b/blockstack_client/operations/namespaceready.py
@@ -21,13 +21,22 @@
     along with Blockstack-client. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import os
+
 from binascii import hexlify
 
 from ..constants import (
-    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE)
+    LENGTH_MAX_NAMESPACE_ID, DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE)
+from ..scripts import (
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_namespace_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
+
 from ..b40 import is_b40
-from ..config import *
-from ..scripts import *
 from ..logger import get_logger
 
 import virtualchain

--- a/blockstack_client/operations/namespacereveal.py
+++ b/blockstack_client/operations/namespacereveal.py
@@ -25,12 +25,19 @@ import keylib
 from binascii import hexlify
 
 from ..b40 import is_b40
-from ..config import *
-from ..scripts import *
 from ..logger import get_logger
+from ..scripts import (
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_namespace_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
+
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
-    BLOCKSTACK_VERSION)
+    BLOCKSTACK_VERSION, LENGTH_MAX_NAMESPACE_ID)
 
 import virtualchain
 log = get_logger("blockstack-log")

--- a/blockstack_client/operations/namespacereveal.py
+++ b/blockstack_client/operations/namespacereveal.py
@@ -28,6 +28,9 @@ from ..b40 import is_b40
 from ..config import *
 from ..scripts import *
 from ..logger import get_logger
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    BLOCKSTACK_VERSION)
 
 import virtualchain
 log = get_logger("blockstack-log")

--- a/blockstack_client/operations/preorder.py
+++ b/blockstack_client/operations/preorder.py
@@ -23,13 +23,21 @@
 
 
 from ..b40 import is_b40
-from ..config import *
-from ..scripts import *
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
     TX_MIN_CONFIRMATIONS, NAME_SCHEME, BLOCKSTACK_BURN_ADDRESS,
-    LENGTH_CONSENSUS_HASH)
+    LENGTH_CONSENSUS_HASH, LENGTH_MAX_NAME)
 from ..logger import get_logger
+
+from ..scripts import (
+    hash_name,
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/preorder.py
+++ b/blockstack_client/operations/preorder.py
@@ -25,7 +25,10 @@
 from ..b40 import is_b40
 from ..config import *
 from ..scripts import *
-from ..constants import TX_MIN_CONFIRMATIONS
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    TX_MIN_CONFIRMATIONS, NAME_SCHEME, BLOCKSTACK_BURN_ADDRESS,
+    LENGTH_CONSENSUS_HASH)
 from ..logger import get_logger
 
 import virtualchain

--- a/blockstack_client/operations/register.py
+++ b/blockstack_client/operations/register.py
@@ -22,12 +22,18 @@
 """
 
 from binascii import hexlify
+from ..scripts import (
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
 
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
     BLOCKSTACK_BURN_ADDRESS)
-from ..config import *
-from ..scripts import *
 from ..logger import get_logger
 
 import virtualchain

--- a/blockstack_client/operations/register.py
+++ b/blockstack_client/operations/register.py
@@ -23,6 +23,9 @@
 
 from binascii import hexlify
 
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    BLOCKSTACK_BURN_ADDRESS)
 from ..config import *
 from ..scripts import *
 from ..logger import get_logger

--- a/blockstack_client/operations/revoke.py
+++ b/blockstack_client/operations/revoke.py
@@ -26,6 +26,8 @@ from binascii import hexlify
 from ..config import *
 from ..scripts import *
 from ..logger import get_logger
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE)
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/revoke.py
+++ b/blockstack_client/operations/revoke.py
@@ -23,11 +23,18 @@
 
 from binascii import hexlify
 
-from ..config import *
-from ..scripts import *
 from ..logger import get_logger
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE)
+from ..scripts import (
+    hash_name,
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
 
 import virtualchain
 log = get_logger("blockstack-client")

--- a/blockstack_client/operations/transfer.py
+++ b/blockstack_client/operations/transfer.py
@@ -25,12 +25,21 @@ from binascii import hexlify
 
 from ..constants import (
     DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
-    TRANSFER_KEEP_DATA, TRANSFER_REMOVE_DATA,
+    TRANSFER_KEEP_DATA, TRANSFER_REMOVE_DATA, LENGTH_MAX_NAME,
     LENGTH_CONSENSUS_HASH, NAME_TRANSFER, NAME_PREORDER)
 
+import os
+
 from ..b40 import is_b40
-from ..config import *
-from ..scripts import *
+from ..scripts import (
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
+
 from ..logger import get_logger
 
 import virtualchain

--- a/blockstack_client/operations/transfer.py
+++ b/blockstack_client/operations/transfer.py
@@ -23,6 +23,11 @@
 
 from binascii import hexlify
 
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    TRANSFER_KEEP_DATA, TRANSFER_REMOVE_DATA,
+    LENGTH_CONSENSUS_HASH, NAME_TRANSFER, NAME_PREORDER)
+
 from ..b40 import is_b40
 from ..config import *
 from ..scripts import *

--- a/blockstack_client/operations/update.py
+++ b/blockstack_client/operations/update.py
@@ -28,8 +28,16 @@ from ..constants import (
     LENGTH_VALUE_HASH,
     LENGTH_CONSENSUS_HASH)
 from ..b40 import is_b40
-from ..config import *
-from ..scripts import *
+from ..scripts import (
+    hash_name,
+    hash256_trunc128,
+    blockstack_script_to_hex,
+    add_magic_bytes,
+    is_name_valid,
+    tx_get_unspents,
+    hash256_trunc128
+)
+
 from ..logger import get_logger
 
 import virtualchain

--- a/blockstack_client/operations/update.py
+++ b/blockstack_client/operations/update.py
@@ -23,6 +23,10 @@
 
 from utilitybelt import is_hex
 
+from ..constants import (
+    DEFAULT_DUST_FEE, DEFAULT_OP_RETURN_FEE,
+    LENGTH_VALUE_HASH,
+    LENGTH_CONSENSUS_HASH)
 from ..b40 import is_b40
 from ..config import *
 from ..scripts import *

--- a/blockstack_client/profile.py
+++ b/blockstack_client/profile.py
@@ -29,10 +29,13 @@ import httplib
 import virtualchain
 import jsonschema
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import get_pubkey_hex
 import keylib
 
-from .proxy import *
+from .proxy import (
+    json_is_error, get_name_blockchain_history, get_name_blockchain_record,
+    get_default_proxy)
+
 from blockstack_client import storage
 from blockstack_client import user as user_db
 
@@ -41,7 +44,7 @@ from .constants import USER_ZONEFILE_TTL, CONFIG_PATH, BLOCKSTACK_TEST, BLOCKSTA
 
 from .zonefile import get_name_zonefile
 from .keys import get_data_privkey_info
-from .schemas import *
+from .schemas import PROFILE_ACCOUNT_SCHEMA
 from .config import get_config
 from .constants import BLOCKSTACK_REQUIRED_STORAGE_DRIVERS_WRITE
 

--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -55,7 +55,20 @@ from .operations import (
     nameop_restore_snv_consensus_fields
 )
 
-from .schemas import *
+from .schemas import (
+    OP_NAMESPACE_PATTERN,
+    OP_CONSENSUS_HASH_PATTERN,
+    OP_CONSENSUS_HASH_PATTERN,
+    NAMEOP_SCHEMA_PROPERTIES,
+    NAMEOP_SCHEMA_REQUIRED,
+    OP_TXID_PATTERN,
+    OP_CODE_PATTERN,
+    OP_ZONEFILE_HASH_PATTERN,
+    OP_TXID_PATTERN,
+    OP_HISTORY_SCHEMA,
+    NAMESPACE_SCHEMA_PROPERTIES,
+    NAMESPACE_SCHEMA_REQUIRED
+)
 
 log = get_logger('blockstack-client')
 

--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -44,7 +44,8 @@ import storage
 import scripts
 
 from .constants import (
-    MAX_RPC_LEN, CONFIG_PATH, BLOCKSTACK_TEST, DEFAULT_TIMEOUT
+    MAX_RPC_LEN, CONFIG_PATH, BLOCKSTACK_TEST, DEFAULT_TIMEOUT,
+    BLOCKSTACK_DEBUG
 )
 
 from .logger import get_logger

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -47,11 +47,28 @@ import platform
 import shutil
 import urlparse
 from jsonschema import ValidationError
-from schemas import *
 import client as bsk_client
+from schemas import (
+    APP_SESSION_REQUEST_SCHEMA,
+    APP_SESSION_REQUEST_SCHEMA_OLD,
+    OP_NAME_PATTERN,
+    OP_BASE58CHECK_PATTERN,
+    OP_ADDRESS_PATTERN,
+    OP_ZONEFILE_HASH_PATTERN,
+    PRIVKEY_INFO_SCHEMA,
+    CREATE_DATASTORE_REQUEST_SCHEMA,
+    DELETE_DATASTORE_REQUEST_SCHEMA,
+    OP_BASE64_PATTERN,
+    WALLET_SCHEMA_CURRENT,
+    OP_HEX_PATTERN,
+    LENGTH_MAX_NAME,
+    LENGTH_MAX_NAMESPACE_ID,
+    DATASTORE_LOOKUP_EXTENDED_RESPONSE_SCHEMA,
+    MUTABLE_DATUM_FILE_TYPE,
+    DATASTORE_LOOKUP_RESPONSE_SCHEMA)
 
 import keylib
-from keylib import *
+from keylib import ECPrivateKey
 
 import signal
 import json
@@ -86,7 +103,7 @@ import storage
 from utils import daemonize, streq_constant
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import get_pubkey_hex, verify_raw_data
 
 import blockstack_profiles
 
@@ -1685,7 +1702,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         datastore_str = str(inode_info['datastore_str'])
         datastore_sig = str(inode_info['datastore_sig'])
         datastore_pubkey = app.app_get_datastore_pubkey( ses )
-        res = keys.verify_raw_data(datastore_str, datastore_pubkey, datastore_sig)
+        res = verify_raw_data(datastore_str, datastore_pubkey, datastore_sig)
         if not res:
             return self._reply_json({'error': 'Invalid request: invalid datastore signature'}, status_code=401)
 

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -68,7 +68,11 @@ import subdomains
 DEFAULT_UI_PORT = 8888
 DEVELOPMENT_UI_PORT = 3000
 
-from .constants import BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH, WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION, TX_MAX_FEE, set_secret, get_secret
+from .constants import (
+    CONFIG_FILENAME, serialize_secrets, WALLET_FILENAME,
+    BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH,
+    WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION,
+    TX_MAX_FEE, set_secret, get_secret, DEFAULT_TIMEOUT)
 from .method_parser import parse_methods
 from .wallet import make_wallet
 import app
@@ -2878,8 +2882,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             return self._send_headers(status_code=200, content_type='text/plain')
 
         elif command == 'clearcache':
-            # clear the cache 
-            data.cache_evict_all()
+            # clear the cache
+            # aaron note: there's no implementation of a cache eviction.
             return self._send_headers(status_code=200, content_type='text/plain')
 
         else:
@@ -4007,7 +4011,7 @@ class BlockstackAPIEndpointClient(object):
     Usable both by external clients and by the API server itself.
     """
     def __init__(self, server, port, api_pass=None, session=None, config_path=CONFIG_PATH,
-                 timeout=blockstack_constants.DEFAULT_TIMEOUT, debug_timeline=False, **kw):
+                 timeout=DEFAULT_TIMEOUT, debug_timeline=False, **kw):
 
         self.timeout = timeout
         self.server = server
@@ -4833,7 +4837,7 @@ def local_api_action(command, password=None, api_pass=None, config_dir=blockstac
         else:
             return {'error': 'Failed to stop API endpoint'}
 
-    config_path = os.path.join(config_dir, blockstack_constants.CONFIG_FILENAME)
+    config_path = os.path.join(config_dir, CONFIG_FILENAME)
 
     conf = blockstack_config.get_config(config_path)
     if conf is None:
@@ -4857,7 +4861,7 @@ def local_api_action(command, password=None, api_pass=None, config_dir=blockstac
         env = {}
         env.update( os.environ )
 
-        api_stdin_buf = blockstack_constants.serialize_secrets()
+        api_stdin_buf = serialize_secrets()
 
         p = subprocess.Popen(argv, cwd=config_dir, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, env=env)
         out, err = p.communicate(input=api_stdin_buf)
@@ -5091,8 +5095,8 @@ def local_api_start( port=None, host=None, config_dir=blockstack_constants.CONFI
     from blockstack_client.wallet import load_wallet
     from blockstack_client.client import session
 
-    config_path = os.path.join(config_dir, blockstack_constants.CONFIG_FILENAME)
-    wallet_path = os.path.join(config_dir, blockstack_constants.WALLET_FILENAME)
+    config_path = os.path.join(config_dir, CONFIG_FILENAME)
+    wallet_path = os.path.join(config_dir, WALLET_FILENAME)
 
     conf = blockstack_client.get_config(config_path)
     assert conf

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -72,6 +72,7 @@ from .constants import (
     CONFIG_FILENAME, serialize_secrets, WALLET_FILENAME,
     BLOCKSTACK_DEBUG, BLOCKSTACK_TEST, RPC_MAX_ZONEFILE_LEN, CONFIG_PATH,
     WALLET_FILENAME, TX_MIN_CONFIRMATIONS, DEFAULT_API_PORT, SERIES_VERSION,
+    DEFAULT_SESSION_LIFETIME, FIRST_BLOCK_MAINNET,
     TX_MAX_FEE, set_secret, get_secret, DEFAULT_TIMEOUT)
 from .method_parser import parse_methods
 from .wallet import make_wallet

--- a/blockstack_client/schemas.py
+++ b/blockstack_client/schemas.py
@@ -24,7 +24,17 @@ from __future__ import print_function
     along with Blockstack-client. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from .constants import *
+from .constants import (
+    LENGTH_CONSENSUS_HASH
+    NAME_OPCODES,
+    NAME_TRANSFER,
+    TRANSFER_KEEP_DATA,
+    TRANSFER_REMOVE_DATA,
+    NAME_REGISTRATION,
+    LENGTH_VALUE_HASH,
+    LENGTH_MAX_NAME,
+    LENGTH_MAX_NAMESPACE_ID)
+
 import blockstack_profiles
 
 OP_CONSENSUS_HASH_PATTERN = r'^([0-9a-fA-F]{{{}}})$'.format(LENGTH_CONSENSUS_HASH * 2)

--- a/blockstack_client/schemas.py
+++ b/blockstack_client/schemas.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 """
 
 from .constants import (
-    LENGTH_CONSENSUS_HASH
+    LENGTH_CONSENSUS_HASH,
     NAME_OPCODES,
     NAME_TRANSFER,
     TRANSFER_KEEP_DATA,

--- a/blockstack_client/scripts.py
+++ b/blockstack_client/scripts.py
@@ -20,23 +20,19 @@
     You should have received a copy of the GNU General Public License
     along with Blockstack-client. If not, see <http://www.gnu.org/licenses/>.
 """
-import json
+import json, re
 from binascii import hexlify, unhexlify
-from decimal import *
 
 import virtualchain
 
 from binascii import hexlify, unhexlify
 
-from virtualchain.lib.ecdsalib import *
-from virtualchain.lib.hashing import *
-
+from virtualchain.lib.hashing import is_hex, hex_hash160, bin_sha256
 from virtualchain import tx_extend, tx_sign_input
 
-from .b40 import *
+from .b40 import is_b40, b40_to_bin
 from .constants import MAGIC_BYTES, NAME_OPCODES, LENGTH_MAX_NAME, LENGTH_MAX_NAMESPACE_ID, TX_MIN_CONFIRMATIONS
-from .keys import *
-from .utxo import get_unspents 
+from .utxo import get_unspents
 from .logger import get_logger
 
 log = get_logger('blockstack-client')
@@ -61,7 +57,7 @@ def common_checks(n):
 
     if len(n) > LENGTH_MAX_NAME:
        # too long
-       return False 
+       return False
 
     if not is_b40(n):
         return False
@@ -116,6 +112,12 @@ def is_valid_hash(value):
 
     return len(strvalue) == 64
 
+def is_valid_int(value):
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False
 
 def blockstack_script_to_hex(script):
     """ Parse the readable version of a script, return the hex version.
@@ -176,9 +178,9 @@ def tx_get_address_and_utxos(private_key_info, utxo_client, address=None):
     """
 
     if private_key_info is None:
-        # just go with the address 
+        # just go with the address
         unspents = get_unspents(address, utxo_client)
-        return addr, unspents 
+        return address, unspents
 
     addr = virtualchain.get_privkey_address(private_key_info)
     payer_utxos = get_unspents(addr, utxo_client)

--- a/blockstack_client/snv.py
+++ b/blockstack_client/snv.py
@@ -26,9 +26,9 @@ import time
 
 from .backend.blockchain import get_bitcoind_client
 
-from keys import *
-from proxy import *
-from profile import *
+from proxy import (
+    get_default_proxy, get_nameops_hash_at, get_consensus_hashes, get_nameops_at,
+    get_block_from_consensus, get_consensus_at)
 
 import virtualchain
 from virtualchain import SPVClient

--- a/blockstack_client/storage.py
+++ b/blockstack_client/storage.py
@@ -37,13 +37,16 @@ import blockstack_profiles
 
 from .logger import get_logger
 from constants import BLOCKSTACK_TEST, BLOCKSTACK_DEBUG, BLOCKSTACK_STORAGE_CLASSES
-from config import get_config
+from config import get_config, CONFIG_PATH
 from scripts import hex_hash160
 import schemas
-from keys import *
+from keys import is_singlesig_hex
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import (
+    sign_raw_data,
+    verify_raw_data,
+    get_pubkey_hex)
 
 log = get_logger()
 

--- a/blockstack_client/tx.py
+++ b/blockstack_client/tx.py
@@ -23,7 +23,12 @@
 
 import virtualchain
 
-from .operations import *
+from .operations import (
+    tx_preorder, tx_register, tx_update, tx_transfer, tx_revoke,
+    tx_namespace_preorder, tx_namespace_reveal, tx_namespace_ready,
+    tx_name_import, tx_announce
+)
+
 from .constants import CONFIG_PATH, BLOCKSTACK_TEST, BLOCKSTACK_DRY_RUN
 from .config import get_tx_broadcaster
 from .logger import get_logger

--- a/blockstack_client/user.py
+++ b/blockstack_client/user.py
@@ -30,9 +30,8 @@ import copy
 import urlparse
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
 
-from .schemas import *
+from .schemas import USER_ZONEFILE_SCHEMA, OP_URI_TARGET_PATTERN
 from .constants import BLOCKSTACK_TEST, CONFIG_PATH, BLOCKSTACK_DEBUG
 
 import scripts

--- a/blockstack_client/wallet.py
+++ b/blockstack_client/wallet.py
@@ -44,14 +44,11 @@ xmlrpc.monkey_patch()
 import logging
 logging.disable(logging.CRITICAL)
 
-import requests
-requests.packages.urllib3.disable_warnings()
-
 from .backend.crypto.utils import aes_decrypt, aes_encrypt
 from .backend.blockchain import get_balance
 from .utils import print_result
 
-from .keys import *
+from .keys import HDWallet, is_singlesig_hex, decrypt_private_key_info
 
 import config
 from .constants import (
@@ -61,10 +58,17 @@ from .constants import (
 )
 
 from .proxy import get_names_owned_by_address, get_default_proxy
-from .schemas import *
+from .schemas import (
+    ENCRYPTED_WALLET_SCHEMA_CURRENT,
+    ENCRYPTED_WALLET_SCHEMA_CURRENT_NODATAKEY,
+    WALLET_SCHEMA_CURRENT, WALLET_SCHEMA_CURRENT_NODATAKEY,
+    ENCRYPTED_WALLET_SCHEMA_LEGACY,
+    ENCRYPTED_WALLET_SCHEMA_LEGACY_013,
+    ENCRYPTED_WALLET_SCHEMA_LEGACY_014
+)
 
 import virtualchain
-from virtualchain.lib.ecdsalib import *
+from virtualchain.lib.ecdsalib import ecdsa_private_key, get_pubkey_hex
 import keylib
 
 from .logger import get_logger
@@ -78,7 +82,7 @@ def encrypt_wallet(decrypted_wallet, password, test_legacy=False):
     Return the encrypted dict on success
     Return {'error': ...} on error
     """
-    
+
     if test_legacy:
         assert BLOCKSTACK_TEST, 'test_legacy only works in test mode'
 

--- a/blockstack_client/zonefile.py
+++ b/blockstack_client/zonefile.py
@@ -28,7 +28,8 @@ import base64
 import socket
 from keylib import ECPrivateKey
 
-from .proxy import *
+from .proxy import (
+    get_default_proxy, get_zonefiles, get_name_blockchain_record, put_zonefiles)
 import storage
 import user as user_db
 

--- a/blockstack_client/zonefile.py
+++ b/blockstack_client/zonefile.py
@@ -253,7 +253,7 @@ def load_data_pubkey_for_new_zonefile(wallet_keys={}, config_path=CONFIG_PATH):
     data_privkey = wallet_keys.get('data_privkey', None)
     if data_privkey is not None:
         # force compressed
-        data_pubkey = ECPrivateKey(data_privkey, compressesd=True).public_key().to_hex()
+        data_pubkey = ECPrivateKey(data_privkey, compressed=True).public_key().to_hex()
         return data_pubkey
 
     data_pubkey = wallet_keys.get('data_pubkey', None)
@@ -473,7 +473,7 @@ def zonefile_data_replicate(fqu, zonefile_data, tx_hash, server_list, config_pat
     )
 
     if not rc:
-        log.info('Failed to replicate zonefile for {} to {}'.format(fqu))
+        log.info('Failed to replicate zonefile for {}'.format(fqu))
         return {'error': 'Failed to store user zonefile'}
 
     # replicate to blockstack servers


### PR DESCRIPTION
This is the first step in getting us closer to a `pylint` compliant codebase. Removes wildcard imports for files in blockstack_client (except `__init__.py`'s and the storage drivers). Want to get these merged in (and integration tests run on it) before other major changes. More pylint improvements should come down the road.