### PR TITLE
Change path for index template of the API

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -4,7 +4,7 @@ set -e
 COMMAND=$1
 
 if [ "$1" = "public_api" ]; then
-    aglio -i docs/api-specs.md --theme-template docs/aglio_templates/public.jade -o /tmp/index.html
+    aglio -i docs/api-specs.md --theme-template docs/aglio_templates/public.jade -o api/templates/index.html
 elif [ "$1" = "core_api" ]; then
     aglio -i docs/api-specs.md --theme-template docs/aglio_templates/core.jade -o /tmp/index.html
 elif [ "$1" = "deploy_gh" ]; then


### PR DESCRIPTION
Needed to get moved manually from `/tmp/index.html` to `api/templates/index.html` which can be handled by the script automatically

cc @kantai 