### PR TITLE
Add explicitely Python to uwsgi config

### DIFF
--- a/api/nginx/blockstack_api.ini
+++ b/api/nginx/blockstack_api.ini
@@ -1,4 +1,5 @@
 [uwsgi]
+plugins = python
 module = api.server:app
 master = true
 processes = 9


### PR DESCRIPTION
I installed the APT version of uwsgi because the pip one didn't work on Debian 9. This version seems to need the info that this uwsgi is a Python one.
I didn't test this against the pip version, but I hope that it continues to work with this config directive :D

cc @kantai 