### PR TITLE
Update search index with new profiles

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -64,6 +64,7 @@ NEW_NAMES_FILE = os.path.join(CURRENT_DIR, NEW_NAMES_FILENAME)
 SEARCH_API_ENDPOINT_ENABLED = True
 SEARCH_BLOCKCHAIN_DATA_FILE = "/var/blockstack-search/blockchain_data.json"
 SEARCH_PROFILE_DATA_FILE = "/var/blockstack-search/profile_data.json"
+SEARCH_LAST_INDEX_DATA_FILE = "/var/blockstack-search/last_indexed.json"
 SEARCH_BULK_INSERT_LIMIT = 1000
 SEARCH_DEFAULT_LIMIT = 50
 SEARCH_LUCENE_ENABLED = False

--- a/api/config.py
+++ b/api/config.py
@@ -65,6 +65,7 @@ SEARCH_API_ENDPOINT_ENABLED = True
 SEARCH_BLOCKCHAIN_DATA_FILE = "/var/blockstack-search/blockchain_data.json"
 SEARCH_PROFILE_DATA_FILE = "/var/blockstack-search/profile_data.json"
 SEARCH_LAST_INDEX_DATA_FILE = "/var/blockstack-search/last_indexed.json"
+SEARCH_LOCKFILE = "/var/blockstack-search/indexer_lockfile.json"
 SEARCH_BULK_INSERT_LIMIT = 1000
 SEARCH_DEFAULT_LIMIT = 50
 SEARCH_LUCENE_ENABLED = False

--- a/api/search/fetch_data.py
+++ b/api/search/fetch_data.py
@@ -70,7 +70,11 @@ def update_profiles():
         last_block_processed = json.load(fin)
 
     info_resp = proxy.getinfo()
-    new_block_height = info_resp['last_block_processed']
+    try:
+        new_block_height = info_resp['last_block_processed']
+    except:
+        print info_resp
+        raise
 
     if last_block_processed - 1 > new_block_height:
         return {'status' : True, 'message' : 'No new blocks since last indexing'}
@@ -111,6 +115,8 @@ def update_profiles():
 
     with open(SEARCH_PROFILE_DATA_FILE, 'w') as fout:
         json.dump(all_profiles, fout)
+    with open(SEARCH_LAST_INDEX_DATA_FILE, 'w') as fout:
+        json.dump(new_block_height, fout)
 
     return {'status' : True, 'message' : 'Indexed {} profiles'.format(len(names_updated))}
 

--- a/api/search/fetch_data.py
+++ b/api/search/fetch_data.py
@@ -92,7 +92,7 @@ def update_profiles():
     actually_updated_names = set()
     print "Updating {} entries...".format(len(names_updated))
     for ix, name in enumerate(names_updated):
-        print_status_bar(ix, len(names_updated))
+        print_status_bar(ix+1, len(names_updated))
         profile_entry = {}
         profile_entry['fqu'] = name
 


### PR DESCRIPTION
Adds a new flag for "fetch_data" which only fetches profiles for names that had zonefile updates since the last indexing. This allows us to quickly index new names. (Core currently configured to do this fast update every 12 minutes).

Closes issue #554 
