### PR TITLE
Use newest version in API documentation

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -5,6 +5,8 @@ COMMAND=$1
 
 if [ "$1" = "public_api" ]; then
     aglio -i docs/api-specs.md --theme-template docs/aglio_templates/public.jade -o api/templates/index.html
+    version=$(python2 -c 'from blockstack.version import __version_major__, __version_minor__, __version_patch__; print("%s.%s.%s" % (__version_major__, __version_minor__, __version_patch__))')
+    sed -i "s/###version###/$version/g" docs/api-specs.md
 elif [ "$1" = "core_api" ]; then
     aglio -i docs/api-specs.md --theme-template docs/aglio_templates/core.jade -o /tmp/index.html
 elif [ "$1" = "deploy_gh" ]; then

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -40,7 +40,7 @@ Ping the blockstack node to see if it's alive.
   
             {
              "status": "alive", 
-             "version": "0.14.2"
+             "version": "###version###"
             }
   + Schema
 


### PR DESCRIPTION
This PR adds functionality to automatically put the current version number into the API examples.
(uses `sed -i <regex>`, don't know how portable this is)

cc @kantai 