### PR TITLE
Remove the explicit domain

### DIFF
--- a/docs/aglio_templates/mixins.jade
+++ b/docs/aglio_templates/mixins.jade
@@ -8,7 +8,7 @@ mixin TryMe(action)
          div
          div
            span.method(class="badge get",style="float:left")
-             a.method(href="https://core.blockstack.org" + myUri, style="color:rgb(51, 122, 183);font-size:12pt")
+             a.method(href=myUri, style="color:rgb(51, 122, 183);font-size:12pt")
                = "Try It!"
              | &nbsp;
          p


### PR DESCRIPTION
Now the link automatically points to the current server that serves the API doc.
Needs an environment variable `NOCHACE=1` for `aglio` to don't cache the page when not edited `public.jade` or `api-specs.md`.

cc @kantai 