### PR TITLE
Added browser install to the docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,15 @@ COPY . /src/blockstack
 WORKDIR /src/blockstack
 
 # Install Dependancies
-RUN apt-get update && apt-get install -y python-pip python-dev build-essential apt-utils libssl-dev libffi-dev rng-tools libgmp3-dev sudo software-properties-common sqlite3 lsof
+RUN apt-get update && apt-get install -y python-pip python-dev build-essential apt-utils libssl-dev libffi-dev rng-tools libgmp3-dev sudo software-properties-common sqlite3 lsof curl wget
+
+# Lets add blockstack-browser to the mix
+RUN wget -qO - https://raw.githubusercontent.com/blockstack/packaging/master/repo-key.pub | apt-key add -
+RUN echo 'deb http://packages.blockstack.com/repositories/ubuntu/ xenial main' > /etc/apt/sources.list.d/blockstack.list
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update
+RUN apt-get install -y blockstack-browser
+
 RUN pip2 install --upgrade pip
 RUN pip2 install --upgrade virtualenv
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Setting this up requires setting the corsproxy to bind to `0.0.0.0` and starting
 
 ```bash
 # Start API with browser ports forwarded // run detached
-$ docker run -d -it -e CORSPROXY_HOST=0.0.0.0 -v /tmp/blockstack_docker/blockstack-api:/root/.blockstack -v /tmp/blockstack_docker/tmp/:/tmp/ -p 8888:8888 -p 1337:1337 --name blockstack-browser blockstack-with-browser blockstack api start-foreground --debug --password PASSWORD
+$ docker run -d -it -e CORSPROXY_HOST=0.0.0.0 -v /tmp/blockstack_docker/blockstack-api:/root/.blockstack -v /tmp/blockstack_docker/tmp/:/tmp/ -p 8888:8888 -p 1337:1337 -p 6270:6270 --name blockstack-browser blockstack-with-browser blockstack api start-foreground --debug --password PASSWORD
 # Exec browser and corsproxy
 $ docker exec -dt blockstack-browser blockstack-cors-proxy
 $ docker exec -dt blockstack-browser blockstack-browser

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ $ docker run -it -v $(pwd)/data/blockstack-api:/root/.blockstack -v /tmp/:/tmp/ 
 $ docker run -d -v $(pwd)/data/blockstack-api:/root/.blockstack -v /tmp/:/tmp/ -p 6270:6270 myrepo/blockstack:latest blockstack api start-foreground --password PASSWORD --debug
 ```
 
+### Running Browser in Docker
+
+The Docker container is capable of running a browser+cors proxy for end-users.
+Setting this up requires setting the corsproxy to bind to `0.0.0.0` and starting all the processes.
+
+```bash
+# Start API with browser ports forwarded // run detached
+$ docker run -d -it -e CORSPROXY_HOST=0.0.0.0 -v /tmp/blockstack_docker/blockstack-api:/root/.blockstack -v /tmp/blockstack_docker/tmp/:/tmp/ -p 8888:8888 -p 1337:1337 --name blockstack-browser blockstack-with-browser blockstack api start-foreground --debug --password PASSWORD
+# Exec browser and corsproxy
+$ docker exec -dt blockstack-browser blockstack-cors-proxy
+$ docker exec -dt blockstack-browser blockstack-browser
+```
+
 ## Community
 
 We have an active community of developers and the best place to interact with the community is:


### PR DESCRIPTION
Included browser install (from the apt repo) in the docker.

Added instructions on how to start the browser proxy and corsproxy and connecting to them.

In the near term, this is probably going to be the easiest way to distribute blockstack for Windows users.

Questions:

Is installing from apt the best way to do this?
 - the apt package for the browser makes the startup much faster and simpler than running the browser using `npm run`, but this does make the distribution of the dockerfile depend on the distribution of the dpkg

Should a single docker image contain both blockstack-api and browser?
 - I think it's simple enough, but maybe this is supposed to be a docker compose use case?

Where should the instructions for this docker live?
 - This repo *probably* isn't the right place for install/usage instructions of browser -- relatedly, the apt install instructions for browser were removed from the README.md -- in general, where should the install instructions for browser on Linux (and then Windows) go?

Should we add init scripts for all the processes?
 - Alternative is to rely on a cli script to start things up like in PR #572 , though a Windows client might have a better experience with a `serviced`
 - advantage of init script is that `docker start` would get everything running.
