### PR TITLE
Add info about snap install and continuous delivery

### DIFF
--- a/images/community/snap/README.md
+++ b/images/community/snap/README.md
@@ -5,6 +5,16 @@ for applications, with automatic and transactional updates. The blockstack snap
 can be installed in all the
 [supported Linux distros](https://snapcraft.io/docs/core/install).
 
+## Install
+
+To help testing the upcoming stable release, you can install the snap from the beta channel:
+
+    $ sudo snap install blockstack --beta
+    
+Or you can install the latest `blockstack` and help testing the most recent changes with:
+
+    $ sudo snap install blockstack --edge
+
 ## Build
 
 To build this snap from source in an Ubuntu 16.04 machine, or later:
@@ -14,3 +24,9 @@ To build this snap from source in an Ubuntu 16.04 machine, or later:
     $ cd blockstack-core/images/community
     $ snapcraft
     $ sudo snap install *.snap --dangerous
+
+## Continuous delivery
+
+We have a [Travis-CI job](https://github.com/elopio/blockstack-core/blob/develop/.travis.yml) that runs daily to sync the maintainer branch with the latest upstream `develop` branch. If that job finds a new git tag in the repo that has not been released as a snap, it will patch the `snapcraft.yaml` file to build the snap corresponding to that tag. Otherwise, it will just leave it to build from the latest commit in `develop`.
+
+Then, [launchpad](https://code.launchpad.net/~elopio/+snap/blockstack) will build and release the snap to the `edge` channel.


### PR DESCRIPTION
Because only an upstream maintainer would be able to use the simple continuous delivery infrastructure that we provide in https://build.snapcraft.io, I had to build my own pipeline for continuous delivery.

I let my imagination run wild, to play with the boundaries of our integrations, and ended up with a git branch that mutates itself :) Any reviews on that Travis-CI job will also be appreciated.

We now have v0.14.4.1 in the beta channel for all the supported architectures, and a process to update the snap in the edge channel every day without manual intervention. So I will start the call for testing with the Ubuntu community as soon as you approve this branch and process.
If things work nicely, I hope to release the next tag to the candidate channel, and make the following tag our first stable release.

Any suggestions are welcome.