### PR TITLE
Run Docker tests on Kubernetes

### DIFF
--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -1114,6 +1114,29 @@ def parse_args( argv ):
     args, _ = parser.parse_known_args()
     return args
 
+def influx_write( influx_client, test_start, test_name, status ):
+    test_time = datetime.utcnow() - test_start
+    git_commit = os.environ["GIT_COMMIT"]
+    git_branch = os.environ["GIT_BRANCH"]
+    num_tests = os.environ["NUM_TESTS"]
+    point = [
+        {
+            "measurement": "integration_tests",
+            "tags": {
+                "git_branch": git_branch,
+                "git_commit": git_commit,
+                "status": status,
+                "test_scenario": test_name
+            },
+            "time": datetime.utcnow().isoformat(),
+            "fields": {
+                "runtime": test_time.seconds,
+                "num_tests": num_tests
+            }
+        }
+    ]
+    influx_client.write_points(point)
+
 
 if __name__ == "__main__":
 
@@ -1195,7 +1218,12 @@ if __name__ == "__main__":
     # load up the scenario (so it can set its own extra envars)
     scenario = load_scenario( scenario_module )
     if scenario is None:
+
         print "Failed to load '%s'" % scenario_module
+
+        if args.influx
+            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-load")
+
         sys.exit(1)
 
     # *now* we can import blockstack
@@ -1252,6 +1280,10 @@ if __name__ == "__main__":
                             {"ZONEFILES": os.path.join(working_dir, "zonefiles")} )
     if rc != 0:
         log.error("failed to write config file: exit %s" % rc)
+
+        if args.influx
+            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-config")
+
         sys.exit(1)
 
     # generate config file for the client
@@ -1269,6 +1301,9 @@ if __name__ == "__main__":
 
 
     if rc != 0:
+        if args.influx
+            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-config")
+
         log.error("failed to write config file: exit %s" % rc)
         sys.exit(1)
 
@@ -1284,52 +1319,12 @@ if __name__ == "__main__":
         print "SUCCESS %s" % scenario.__name__
         # shutil.rmtree( working_dir )
         if args.influx:
-            test_time = datetime.utcnow() - test_start
-            git_commit = os.environ["GIT_COMMIT"]
-            git_branch = os.environ["GIT_BRANCH"]
-            num_tests = os.environ["NUM_TESTS"]
-            point = [
-                {
-                    "measurement": "integration_tests",
-                    "tags": {
-                        "git_branch": git_branch,
-                        "git_commit": git_commit,
-                        "success": "true",
-                        "test_scenario": scenario_module.split(".")[2]
-                    },
-                    "time": datetime.utcnow().isoformat(),
-                    "fields": {
-                        "runtime": test_time.microseconds,
-                        "num_tests": num_tests
-                    }
-                }
-            ]
-            influx_client.write_points(point)
+            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "success")
 
         sys.exit(0)
     else:
         if args.influx:
-            test_time = datetime.utcnow() - test_start
-            git_commit = os.environ["GIT_COMMIT"]
-            git_branch = os.environ["GIT_BRANCH"]
-            num_tests = os.environ["NUM_TESTS"]
-            point = [
-                {
-                    "measurement": "integration_tests",
-                    "tags": {
-                        "git_branch": git_branch,
-                        "git_commit": git_commit,
-                        "success": "false",
-                        "test_scenario": scenario_module.split(".")[2]
-                    },
-                    "time": datetime.datetime.utcnow().isoformat(),
-                    "fields": {
-                        "runtime": test_time.microseconds,
-                        "num_tests": num_tests
-                    }
-                }
-            ]
-            influx_client.write_points(point)
+            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure")
 
         print >> sys.stderr, "FAILURE %s" % scenario.__name__
         print >> sys.stderr, "Test output in %s" % working_dir

--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -1221,7 +1221,7 @@ if __name__ == "__main__":
 
         print "Failed to load '%s'" % scenario_module
 
-        if args.influx
+        if args.influx:
             influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-load")
 
         sys.exit(1)
@@ -1281,7 +1281,7 @@ if __name__ == "__main__":
     if rc != 0:
         log.error("failed to write config file: exit %s" % rc)
 
-        if args.influx
+        if args.influx:
             influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-config")
 
         sys.exit(1)
@@ -1301,7 +1301,7 @@ if __name__ == "__main__":
 
 
     if rc != 0:
-        if args.influx
+        if args.influx:
             influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-config")
 
         log.error("failed to write config file: exit %s" % rc)

--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -1294,13 +1294,13 @@ if __name__ == "__main__":
                     "tags": {
                         "git_branch": git_branch,
                         "git_commit": git_commit,
-                        "success": True,
+                        "success": "true",
                         "test_scenario": scenario_module.split(".")[2]
                     },
                     "time": datetime.utcnow().isoformat(),
                     "fields": {
                         "runtime": test_time.microseconds,
-                        "num_tests": int(num_tests)
+                        "num_tests": num_tests
                     }
                 }
             ]
@@ -1319,13 +1319,13 @@ if __name__ == "__main__":
                     "tags": {
                         "git_branch": git_branch,
                         "git_commit": git_commit,
-                        "success": True,
+                        "success": "false",
                         "test_scenario": scenario_module.split(".")[2]
                     },
                     "time": datetime.datetime.utcnow().isoformat(),
                     "fields": {
                         "runtime": test_time.microseconds,
-                        "num_tests": int(num_tests)
+                        "num_tests": num_tests
                     }
                 }
             ]

--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -1300,7 +1300,7 @@ if __name__ == "__main__":
                     "time": datetime.utcnow().isoformat(),
                     "fields": {
                         "runtime": test_time.microseconds,
-                        "num_tests": num_tests
+                        "num_tests": int(num_tests)
                     }
                 }
             ]
@@ -1325,7 +1325,7 @@ if __name__ == "__main__":
                     "time": datetime.datetime.utcnow().isoformat(),
                     "fields": {
                         "runtime": test_time.microseconds,
-                        "num_tests": num_tests
+                        "num_tests": int(num_tests)
                     }
                 }
             ]

--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -1222,7 +1222,7 @@ if __name__ == "__main__":
         print "Failed to load '%s'" % scenario_module
 
         if args.influx:
-            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-load")
+            influx_write(influx_client, test_start, scenario_module.split(".")[2], "failure-load")
 
         sys.exit(1)
 
@@ -1282,7 +1282,7 @@ if __name__ == "__main__":
         log.error("failed to write config file: exit %s" % rc)
 
         if args.influx:
-            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-config")
+            influx_write(influx_client, test_start, scenario_module.split(".")[2], "failure-config")
 
         sys.exit(1)
 
@@ -1302,7 +1302,7 @@ if __name__ == "__main__":
 
     if rc != 0:
         if args.influx:
-            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure-config")
+            influx_write(influx_client, test_start, scenario_module.split(".")[2], "failure-config")
 
         log.error("failed to write config file: exit %s" % rc)
         sys.exit(1)
@@ -1319,12 +1319,12 @@ if __name__ == "__main__":
         print "SUCCESS %s" % scenario.__name__
         # shutil.rmtree( working_dir )
         if args.influx:
-            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "success")
+            influx_write(influx_client, test_start, scenario_module.split(".")[2], "success")
 
         sys.exit(0)
     else:
         if args.influx:
-            influx_write(influx_client, test_start, testscenario_module.split(".")[2]_name, "failure")
+            influx_write(influx_client, test_start, scenario_module.split(".")[2], "failure")
 
         print >> sys.stderr, "FAILURE %s" % scenario.__name__
         print >> sys.stderr, "Test output in %s" % working_dir

--- a/integration_tests/blockstack_integration_tests/tests_skip.txt
+++ b/integration_tests/blockstack_integration_tests/tests_skip.txt
@@ -1,6 +1,7 @@
 # extras for test-launcher
 __init__
 attic
+testlib
 # list of tests to ignore
 virtualchain_abort
 name_preorder_register_update_file_benchmark

--- a/integration_tests/test-launcher
+++ b/integration_tests/test-launcher
@@ -119,7 +119,7 @@ spec:
       - name: INFLUX_SSL
         value: "$influxSSL"
       - name: NUM_TESTS
-        value: $2
+        value: "$2"
     resources:
       limits:
         cpu: 1000m
@@ -134,7 +134,6 @@ EOF
 run-all-kube () {
   local tmpDir=$testDir/tmp/$gitCommit
   local scenarios=$(tests)
-  local numTests=${#scenarios[@]}
 
   # Create kubernetes namespace
   kubectl create ns $gitCommit
@@ -252,8 +251,8 @@ get-runtime-docker () {
 results-local () {
   local exited=$(docker ps -a -q  -f status=exited -f name="$gitCommit")
   for test in $exited; do
-    local success=$(docker logs $test --tail 100 2>&1 | grep -c "SUCCESS")
-    local failure=$(docker logs $test --tail 100 2>&1 | grep -c "FAILURE")
+    local success=$(docker logs $test --tail 120 2>&1 | grep -c "SUCCESS")
+    local failure=$(docker logs $test --tail 120 2>&1 | grep -c "FAILURE")
     local name=$(docker inspect -f '{{.Name}}' $test)
     local runtime=$(get-runtime-docker $test)
     if [ $success -eq 1 ]; then
@@ -305,9 +304,13 @@ write-local () {
 }
 
 progress-local () {
+  local scenarios=$(tests)
+  local totaltests=0
+  for sc in $scenarios; do
+    ((totaltests++))
+  done
   local inprogress=$(expr $(docker ps -f status=running -f name="$gitCommit" | wc -l) - 1)
   local completed=$(expr $(docker ps -a -f status=exited -f name="$gitCommit" | wc -l) - 1)
-  local totaltests=$(expr $(ls -1 $(pwd)/blockstack_integration_tests/scenarios/ | sed -e 's/\.py$//' | wc -l) - 2)
   local remaining=$(expr $totaltests - $(expr $inprogress + $completed))
   echo "TotalTests: $totaltests, Completed: $(percent $completed $totaltests)%, InProgress: $(percent $inprogress $totaltests)%, Remaining: $(percent $remaining $totaltests)%"
 }

--- a/integration_tests/test-launcher
+++ b/integration_tests/test-launcher
@@ -136,7 +136,7 @@ run-all-kube () {
   local scenarios=$(tests)
   local numTests=0
   for sc in $scenarios; do
-    ((totaltests++))
+    ((numTests++))
   done
 
   # Create kubernetes namespace

--- a/integration_tests/test-launcher
+++ b/integration_tests/test-launcher
@@ -134,6 +134,10 @@ EOF
 run-all-kube () {
   local tmpDir=$testDir/tmp/$gitCommit
   local scenarios=$(tests)
+  local numTests=0
+  for sc in $scenarios; do
+    ((totaltests++))
+  done
 
   # Create kubernetes namespace
   kubectl create ns $gitCommit

--- a/integration_tests/test-launcher
+++ b/integration_tests/test-launcher
@@ -145,7 +145,7 @@ run-all-kube () {
   # Make the manifests to launch the pods
   for sc in $scenarios; do
     make-manifest $sc $numTests
-    kubectl apply -f $tmpDir/$sc
+    kubectl apply -f $tmpDir/$sc.yaml
   done
 
   # Remove the temporary files
@@ -231,7 +231,6 @@ run-one-local () {
     -v $outputdir:$containerdir \
     $testImage:$testTag $command >> /dev/null 2>&1
 }
-
 
 # get-runtime-docker $containerID -> gets duration of test in seconds
 get-runtime-docker () {

--- a/integration_tests/test-launcher
+++ b/integration_tests/test-launcher
@@ -145,6 +145,7 @@ run-all-kube () {
   # Make tmp directory
   mkdir -p $tmpDir
 
+  echo "Running $numTests tests..."
   # Make the manifests to launch the pods
   for sc in $scenarios; do
     make-manifest $sc $numTests


### PR DESCRIPTION
This is now in a working state. To run the tests have a configured `kubectl` client and `docker` installation. First build and then push the images to an image repository reachable from your cluster. Next configure the reporting to an `influx` server. The tests requires a reachable instance of `influxdb`. Then run the tests:

```bash
# Build and push 
$ ./test-launcher push-images

# Configure Influx
$ export INFLUX_HOST="db-influxdb.monitoring"
$ export INFLUX_USER="myuser"
$ export INFLUX_PASS="mypass"
$ export INFLUX_SSL="False"

# Run tests
$ ./test-launcher run-all-kube
```

I'm building out reporting, but currently you can get the results by logging into the `influxdb` instance and running queries. The tests take about an hour (53 min for longest test, and ~10 min to scale the cluster) to run:

```
> select count(runtime) from integration_tests where status = 'success'
name: integration_tests
time                 count
----                 -----
1970-01-01T00:00:00Z 230
> select count(runtime) from integration_tests where status = 'failure'
name: integration_tests
time                 count
----                 -----
1970-01-01T00:00:00Z 9
> select count(runtime) from integration_tests
name: integration_tests
time                 count
----                 -----
1970-01-01T00:00:00Z 239
> select max(runtime)/60 from integration_tests
name: integration_tests
time                          max
----                          ---
2017-09-07T03:12:31.66152704Z 53.61666666666667
> select min(runtime)/60 from integration_tests
name: integration_tests
time                           min
----                           ---
2017-09-07T02:08:35.374985984Z 0.5166666666666667
> select * from integration_tests where status = 'failure'
name: integration_tests
time                           git_branch        git_commit num_tests runtime status  test_scenario
----                           ----------        ---------- --------- ------- ------  -------------
2017-09-07T02:01:04.309022976Z develop-dockerfix ea8246a    239       80      failure name_pre_reg_up_deletemutable_nodatakey
2017-09-07T02:02:32.047872Z    develop-dockerfix ea8246a    239       93      failure name_pre_reg_up_app_datastore_stale_directory
2017-09-07T02:04:03.621149952Z develop-dockerfix ea8246a    239       156     failure name_pre_reg_up_nonstandard_zonefile
2017-09-07T02:07:35.948285184Z develop-dockerfix ea8246a    239       61      failure name_pre_reg_up_multidevice_storage
2017-09-07T02:07:36.829479936Z develop-dockerfix ea8246a    239       34      failure name_pre_reg_up_app_datastore_rmtree
2017-09-07T02:11:55.841889024Z develop-dockerfix ea8246a    239       61      failure name_pre_reg_up_storage_gateway
2017-09-07T02:13:51.146543104Z develop-dockerfix ea8246a    239       304     failure name_pre_reg_up_datakey_migration
2017-09-07T02:14:11.219492864Z develop-dockerfix ea8246a    239       87      failure name_pre_reg_up_app_datastore_stale_file
2017-09-07T02:18:57.475995904Z develop-dockerfix ea8246a    239       79      failure name_pre_reg_up_deletemutable
```

Fastest test: `namespace_preorder`
Slowest test: `namespace_preorder_reveal_import_expire`