### PR TITLE
Add payment_key option to RESTful transactions

### DIFF
--- a/blockstack_client/backend/nameops.py
+++ b/blockstack_client/backend/nameops.py
@@ -161,7 +161,10 @@ def make_cheapest_nameop( opcode, utxo_client, payment_address, payment_utxos, *
     tx_builder = tx_builders[opcode]
 
     # estimate the cheapest transaction by selecting inputs in decreasing value
-    # NOTE: payment_utxos should already be sorted in decreasing value 
+    # NOTE: payment_utxos should already be sorted in decreasing value
+
+    if len(payment_utxos) < 1:
+        raise ValueError("No UTXOs for address {}".format(payment_address))
 
     for i in xrange(1, len(payment_utxos)+1):
         try:

--- a/blockstack_client/backend/queue.py
+++ b/blockstack_client/backend/queue.py
@@ -320,7 +320,7 @@ def queue_append(queue_id, fqu, tx_hash, payment_address=None,
                  config_path=CONFIG_PATH, block_height=None,
                  zonefile_data=None, profile=None, zonefile_hash=None,
                  unsafe_reg = None, confirmations_needed = None,
-                 owner_privkey=None,
+                 owner_privkey=None, payment_privkey = None,
                  min_payment_confs = None, path=DEFAULT_QUEUE_PATH):
 
     """
@@ -334,7 +334,7 @@ def queue_append(queue_id, fqu, tx_hash, payment_address=None,
 
     # required for all queues
     new_entry['payment_address'] = payment_address
-    
+
     if block_height is None:
         block_height = get_block_height(config_path=config_path)
 
@@ -352,6 +352,8 @@ def queue_append(queue_id, fqu, tx_hash, payment_address=None,
         new_entry['min_payment_confs'] = min_payment_confs
     if owner_privkey is not None:
         new_entry['owner_privkey'] = owner_privkey
+    if payment_privkey is not None:
+        new_entry['payment_privkey'] = payment_privkey
 
     if zonefile_data is not None:
         new_entry['zonefile_b64'] = base64.b64encode(zonefile_data)

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -346,7 +346,7 @@ class RegistrarWorker(threading.Thread):
         return accepted
 
 
-    @classmethod 
+    @classmethod
     def register_preorders( cls, queue_path, wallet_data, config_path=CONFIG_PATH, proxy=None ):
         """
         Find all confirmed preorders, and register them.
@@ -363,7 +363,7 @@ class RegistrarWorker(threading.Thread):
         for preorder in preorders:
 
             log.debug("Preorder for '%s' (%s) is confirmed!" % (preorder['fqu'], preorder['tx_hash']))
-            
+
             # did we already register?
             if in_queue("register", preorder['fqu'], path=queue_path):
                 log.warn("Already queued name '%s' for registration" % preorder['fqu'])
@@ -1015,7 +1015,6 @@ def state():
     data = get_queue_state(path=state.queue_path)
     return data
 
-
 # RPC method: backend_set_wallet
 def set_wallet(payment_keypair, owner_keypair, data_keypair, config_path=None, proxy=None):
     """
@@ -1143,7 +1142,9 @@ def get_wallet(config_path=None, proxy=None):
 
 
 # RPC method: backend_preorder
-def preorder(fqu, cost_satoshis, zonefile_data, profile, transfer_address, min_payment_confs, proxy=None, config_path=CONFIG_PATH, unsafe_reg = False):
+def preorder(fqu, cost_satoshis, zonefile_data, profile, transfer_address, min_payment_confs,
+             proxy=None, config_path=CONFIG_PATH, unsafe_reg = False, owner_privkey = None,
+             payment_privkey = None):
     """
     Send preorder transaction and enter it in queue.
     Queue up additional state so we can update and transfer it as well.
@@ -1170,8 +1171,14 @@ def preorder(fqu, cost_satoshis, zonefile_data, profile, transfer_address, min_p
         data['error'] = "Already in queue."
         return data
 
-    payment_privkey_info = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
-    owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
+    if payment_privkey is None:
+        payment_privkey_info = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
+    else:
+        payment_privkey_info = payment_privkey
+    if owner_privkey is None:
+        owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
+    else:
+        owner_privkey_info = owner_privkey
 
     name_data = {
         'transfer_address': transfer_address,
@@ -1188,11 +1195,13 @@ def preorder(fqu, cost_satoshis, zonefile_data, profile, transfer_address, min_p
         name_data['confirmations_needed'] = PREORDER_CONFIRMATIONS
         name_data['unsafe_reg'] = True
 
-    # save the current owner_privkey_info, scrypted with our password
+    # save the current privkey_info, scrypted with our password
     passwd = get_secret('BLOCKSTACK_CLIENT_WALLET_PASSWORD')
     if passwd:
         name_data['owner_privkey'] = aes_encrypt(
             str(owner_privkey_info), hexlify( passwd ))
+        name_data['payment_privkey'] = aes_encrypt(
+            str(payment_privkey_info), hexlify( passwd ))
     else:
         log.warn("Registrar couldn't access wallet password to encrypt privkey," +
                  " sheepishly refusing to store the private key unencrypted.")
@@ -1222,7 +1231,7 @@ def preorder(fqu, cost_satoshis, zonefile_data, profile, transfer_address, min_p
 
 # RPC method: backend_update
 def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_path=CONFIG_PATH, proxy=None,
-            prior_name_data = None, owner_key = None ):
+            prior_name_data = None, owner_key = None, payment_key = None ):
     """
     Send a new zonefile hash.  Queue the zonefile data for subsequent replication.
     zonefile_txt_b64 must be b64-encoded so we can send it over RPC sanely
@@ -1248,11 +1257,10 @@ def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_
 
     resp = None
 
-    payment_privkey_info = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
+    if payment_key is None:
+        payment_key = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
     if owner_key is None:
-        owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
-    else:
-        owner_privkey_info = owner_key
+        owner_key = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
 
     replication_error = None
 
@@ -1267,8 +1275,8 @@ def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_
 
         log.debug("async_update({}, zonefile_data={}, profile={}, transfer_address={})".format(fqu, zonefile_txt, profile, transfer_address)) 
         resp = async_update(fqu, zonefile_txt, profile,
-                            owner_privkey_info,
-                            payment_privkey_info,
+                            owner_key,
+                            payment_key,
                             name_data=name_data,
                             zonefile_hash=zonefile_hash,
                             proxy=proxy,
@@ -1305,7 +1313,7 @@ def update( fqu, zonefile_txt, profile, zonefile_hash, transfer_address, config_
 
 # RPC method: backend_transfer
 def transfer(fqu, transfer_address, prior_name_data = None, config_path=CONFIG_PATH, proxy=None,
-             owner_key = None):
+             owner_key = None, payment_key = None):
     """
     Send transfer transaction.
     Keeps the zonefile data.
@@ -1327,18 +1335,17 @@ def transfer(fqu, transfer_address, prior_name_data = None, config_path=CONFIG_P
         data['error'] = "Already in queue."
         return data
 
-    payment_privkey_info = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
+    if payment_key is None:
+        payment_key = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
     if owner_key is None:
-        owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
-    else:
-        owner_privkey_info = owner_key
+        owner_key = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
 
     kwargs = {}
     if prior_name_data:
         kwargs['name_data'] = prior_name_data
     resp = async_transfer(fqu, transfer_address,
-                          owner_privkey_info,
-                          payment_privkey_info,
+                          owner_key,
+                          payment_key,
                           proxy=proxy,
                           config_path=config_path,
                           queue_path=state.queue_path, **kwargs)

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -1364,7 +1364,8 @@ def transfer(fqu, transfer_address, prior_name_data = None, config_path=CONFIG_P
 
 
 # RPC method: backend_renew
-def renew( fqu, renewal_fee, config_path=CONFIG_PATH, proxy=None ):
+def renew(fqu, renewal_fee, config_path=CONFIG_PATH, proxy=None, owner_key = None,
+          payment_key = None):
     """
     Renew a name
 
@@ -1387,10 +1388,12 @@ def renew( fqu, renewal_fee, config_path=CONFIG_PATH, proxy=None ):
 
     resp = None
 
-    payment_privkey_info = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
-    owner_privkey_info = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
+    if payment_key is None:
+        payment_key = get_wallet_payment_privkey_info(config_path=config_path, proxy=proxy)
+    if owner_key is None:
+        owner_key = get_wallet_owner_privkey_info(config_path=config_path, proxy=proxy)
 
-    resp = async_renew(fqu, owner_privkey_info, payment_privkey_info, renewal_fee,
+    resp = async_renew(fqu, owner_key, payment_key, renewal_fee,
                        proxy=proxy,
                        config_path=config_path,
                        queue_path=state.queue_path)

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -4321,13 +4321,14 @@ class BlockstackAPIEndpointClient(object):
             return self.get_response(req)
 
 
-    def backend_renew(self, fqu, renewal_fee):
+    def backend_renew(self, fqu, renewal_fee, owner_key = None, payment_key = None):
         """
         Queue a renewal
         """
         if is_api_server(self.config_dir):
             # directly invoke the renew
-            return backend.registrar.renew(fqu, renewal_fee, config_path=self.config_path)
+            return backend.registrar.renew(fqu, renewal_fee, config_path=self.config_path,
+                                           owner_key = owner_key, payment_key = payment_key)
 
         else:
             res = self.check_version()
@@ -4338,6 +4339,12 @@ class BlockstackAPIEndpointClient(object):
             data = {
                 'name': fqu,
             }
+
+            if owner_key is not None:
+                data['owner_key'] = owner_key
+            if payment_key is not None:
+                data['payment_key'] = payment_key
+
 
             headers = self.make_request_headers()
             req = requests.post( 'http://{}:{}/v1/names'.format(self.server, self.port), data=json.dumps(data), timeout=self.timeout, headers=headers)

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -696,7 +696,9 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                 },
                 'unsafe': {
                     'type': 'boolean'
-                }
+                },
+                'owner_key': PRIVKEY_INFO_SCHEMA,
+                'payment_key': PRIVKEY_INFO_SCHEMA
             },
             'required': [
                 'name'
@@ -718,6 +720,9 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         cost_satoshis = request.get('cost_satoshis', None)
         unsafe_reg = request.get('unsafe', False)
         make_profile = request.get('make_profile', False)
+
+        owner_key = request.get('owner_key', None)
+        payment_key = request.get('payment_key', None)
 
         if unsafe_reg:
             unsafe_reg = 'true'
@@ -762,7 +767,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             op = 'register'
             log.debug("register {}".format(name))
             res = internal.cli_register(name, zonefile_txt, recipient_address, min_confs,
-                                        unsafe_reg, interactive=False, force_data=True,
+                                        unsafe_reg, owner_key, payment_key, interactive=False, force_data=True,
                                         cost_satoshis=cost_satoshis, make_profile = make_profile)
 
         if 'error' in res:
@@ -944,7 +949,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                     'minimum': 0,
                     'maximum': TX_MAX_FEE
                 },
-                'owner_key': PRIVKEY_INFO_SCHEMA
+                'owner_key': PRIVKEY_INFO_SCHEMA,
+                'payment_key': PRIVKEY_INFO_SCHEMA
             },
             'required': [
                 'owner'
@@ -973,8 +979,10 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             log.debug("Re-encode {} to {}".format(new_addr, recipient_address))
             recipient_address = new_addr
 
-        privkey_info = request.get('owner_key', None)
-        res = internal.cli_transfer(name, recipient_address, privkey_info, interactive=False)
+        owner_key = request.get('owner_key', None)
+        payment_key = request.get('payment_key', None)
+
+        res = internal.cli_transfer(name, recipient_address, owner_key, payment_key, interactive=False)
         if 'error' in res:
             log.error("Failed to transfer {}: {}".format(name, res['error']))
             self._reply_json({"error": 'Transfer failed.\n{}'.format(res['error'])}, status_code=500)
@@ -1020,7 +1028,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                     'minimum': 0,
                     'maximum': TX_MAX_FEE
                 },
-                'owner_key': PRIVKEY_INFO_SCHEMA
+                'owner_key': PRIVKEY_INFO_SCHEMA,
+                'payment_key': PRIVKEY_INFO_SCHEMA
             },
             'additionalProperties': False,
         }
@@ -1063,13 +1072,14 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             return
 
         res = None
-        privkey_info = request.get('owner_key', None)
+        owner_key = request.get('owner_key', None)
+        payment_key = request.get('payment_key', None)
 
         if zonefile_str is not None:
-            res = internal.cli_update(name, str(zonefile_str), "false", privkey_info, interactive=False,
+            res = internal.cli_update(name, str(zonefile_str), "false", owner_key, payment_key, interactive=False,
                                       nonstandard=True, force_data=True)
         else:
-            res = internal.cli_set_zonefile_hash(name, str(zonefile_hash), privkey_info)
+            res = internal.cli_set_zonefile_hash(name, str(zonefile_hash), owner_key, payment_key)
 
         if 'error' in res:
             log.error("Failed to update {}: {}".format(name, res['error']))
@@ -4183,15 +4193,19 @@ class BlockstackAPIEndpointClient(object):
             return self.get_response(req)
 
 
-    def backend_preorder(self, fqu, cost_satoshis, user_zonefile, user_profile, transfer_address, min_payment_confs,
-                         unsafe_reg = False):
+    def backend_preorder(self, fqu, cost_satoshis, user_zonefile, user_profile,
+                         transfer_address, min_payment_confs, unsafe_reg = False,
+                         payment_key = None, owner_key = None):
         """
         Queue up a name for registration.
         """
 
         if is_api_server(self.config_dir):
             # directly invoke the registrar
-            return backend.registrar.preorder(fqu, cost_satoshis, user_zonefile, user_profile, transfer_address, min_payment_confs, config_path=self.config_path, unsafe_reg=unsafe_reg)
+            return backend.registrar.preorder(
+                fqu, cost_satoshis, user_zonefile, user_profile, transfer_address,
+                min_payment_confs, config_path = self.config_path, unsafe_reg = unsafe_reg,
+                owner_key = owner_key, payment_key = payment_key)
 
         else:
             res = self.check_version()
@@ -4215,6 +4229,11 @@ class BlockstackAPIEndpointClient(object):
             if cost_satoshis is not None:
                 data['cost_satoshis'] = cost_satoshis
 
+            if payment_key is not None:
+                data['payment_key'] = payment_key
+            if owner_key is not None:
+                data['owner_key'] = owner_key
+
             if user_profile:
                 # aaron: I'm making explicit a previously-baked-in assumption
                 #   if the user_profile was given to this function, and we make an RPC
@@ -4229,15 +4248,17 @@ class BlockstackAPIEndpointClient(object):
             return self.get_response(req)
 
 
-    def backend_update(self, fqu, zonefile_txt, profile, zonefile_hash, owner_key = None):
+    def backend_update(self, fqu, zonefile_txt, profile, zonefile_hash,
+                       owner_key = None, payment_key = None):
         """
         Queue an update
         """
         if is_api_server(self.config_dir):
             # directly invoke the registrar
             return backend.registrar.update(
-                fqu, zonefile_txt,  profile, zonefile_hash,
-                None, config_path = self.config_path, owner_key = owner_key)
+                fqu, zonefile_txt, profile, zonefile_hash, None,
+                config_path=self.config_path, owner_key=owner_key,
+                payment_key=payment_key)
 
         else:
             res = self.check_version()
@@ -4261,20 +4282,23 @@ class BlockstackAPIEndpointClient(object):
 
             if owner_key is not None:
                 data['owner_key'] = owner_key
+            if payment_key is not None:
+                data['payment_key'] = payment_key
 
             headers = self.make_request_headers()
             req = requests.put( 'http://{}:{}/v1/names/{}/zonefile'.format(self.server, self.port, fqu), data=json.dumps(data), timeout=self.timeout, headers=headers)
             return self.get_response(req)
 
 
-    def backend_transfer(self, fqu, recipient_addr, owner_key = None):
+    def backend_transfer(self, fqu, recipient_addr, owner_key = None, payment_key = None):
         """
         Queue a transfer
         """
         if is_api_server(self.config_dir):
             # directly invoke the transfer
             return backend.registrar.transfer(
-                fqu, recipient_addr, config_path=self.config_path, owner_key = owner_key)
+                fqu, recipient_addr, config_path=self.config_path,
+                owner_key = owner_key, payment_key = payment_key)
 
         else:
             res = self.check_version()
@@ -4288,6 +4312,8 @@ class BlockstackAPIEndpointClient(object):
 
             if owner_key is not None:
                 data['owner_key'] = owner_key
+            if payment_key is not None:
+                data['payment_key'] = payment_key
 
             headers = self.make_request_headers()
             req = requests.put('http://{}:{}/v1/names/{}/owner'.format(self.server, self.port, fqu),

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -934,6 +934,100 @@ after the `UPDATE` has 6 confirmations.
                             },
                             'unsafe': {
                                 'type': 'boolean'
+                            },
+                            'owner_key': {
+                                'anyOf': [
+                                    {
+                                        'anyOf': [
+                                            {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'properties': {
+                                            'address': {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            'private_keys': {
+                                                'items': {
+                                                    'anyOf': [
+                                                        {
+                                                            'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                            'type': 'string'
+                                                        },
+                                                        {
+                                                            'pattern': '^([0-9a-fA-F]+)$',
+                                                            'type': 'string'
+                                                        }
+                                                    ]
+                                                },
+                                                'type': 'array'
+                                            },
+                                            'redeem_script': {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        },
+                                        'required': [
+                                            'owner'
+                                        ],
+                                        'type': 'object'
+                                    }
+                                ]
+                            },
+                            'payment_key': {
+                                'anyOf': [
+                                    {
+                                        'anyOf': [
+                                            {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'properties': {
+                                            'address': {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            'private_keys': {
+                                                'items': {
+                                                    'anyOf': [
+                                                        {
+                                                            'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                            'type': 'string'
+                                                        },
+                                                        {
+                                                            'pattern': '^([0-9a-fA-F]+)$',
+                                                            'type': 'string'
+                                                        }
+                                                    ]
+                                                },
+                                                'type': 'array'
+                                            },
+                                            'redeem_script': {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        },
+                                        'required': [
+                                            'owner'
+                                        ],
+                                        'type': 'object'
+                                    }
+                                ]
                             }
                         },
                         'required': [
@@ -977,7 +1071,7 @@ after the `UPDATE` has 6 confirmations.
                 },
               ],
             }
-                
+
 
 ## Revoke name [DELETE /v1/names/{name}]
 Revokes the name from blockstack.
@@ -1048,6 +1142,53 @@ Transfers a name to a different owner.
                                 'maximum': 500000
                             },
                             'owner_key': {
+                                'anyOf': [
+                                    {
+                                        'anyOf': [
+                                            {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'properties': {
+                                            'address': {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            'private_keys': {
+                                                'items': {
+                                                    'anyOf': [
+                                                        {
+                                                            'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                            'type': 'string'
+                                                        },
+                                                        {
+                                                            'pattern': '^([0-9a-fA-F]+)$',
+                                                            'type': 'string'
+                                                        }
+                                                    ]
+                                                },
+                                                'type': 'array'
+                                            },
+                                            'redeem_script': {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        },
+                                        'required': [
+                                            'owner'
+                                        ],
+                                        'type': 'object'
+                                    }
+                                ]
+                            },
+                            'payment_key': {
                                 'anyOf': [
                                     {
                                         'anyOf': [
@@ -1212,9 +1353,54 @@ The `zonefile` field is preserved for legacy compatibility.
                                             }
                                         },
                                         'required': [
-                                            'address',
-                                            'redeem_script',
-                                            'private_keys'
+                                            'owner'
+                                        ],
+                                        'type': 'object'
+                                    }
+                                ]
+                            },
+                            'payment_key': {
+                                'anyOf': [
+                                    {
+                                        'anyOf': [
+                                            {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'properties': {
+                                            'address': {
+                                                'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                'type': 'string'
+                                            },
+                                            'private_keys': {
+                                                'items': {
+                                                    'anyOf': [
+                                                        {
+                                                            'pattern': '^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$',
+                                                            'type': 'string'
+                                                        },
+                                                        {
+                                                            'pattern': '^([0-9a-fA-F]+)$',
+                                                            'type': 'string'
+                                                        }
+                                                    ]
+                                                },
+                                                'type': 'array'
+                                            },
+                                            'redeem_script': {
+                                                'pattern': '^([0-9a-fA-F]+)$',
+                                                'type': 'string'
+                                            }
+                                        },
+                                        'required': [
+                                            'owner'
                                         ],
                                         'type': 'object'
                                     }

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_opt_key.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_opt_key.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+    Blockstack
+    ~~~~~
+    copyright: (c) 2014-2015 by Halfmoon Labs, Inc.
+    copyright: (c) 2016 by Blockstack.org
+
+    This file is part of Blockstack
+
+    Blockstack is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Blockstack is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+"""
+import os
+import testlib
+import pybitcoin
+import urllib2
+import json
+import blockstack_client
+import blockstack_profiles
+import blockstack_zones
+import sys
+import keylib
+import time
+
+from keylib import ECPrivateKey, ECPublicKey
+
+wallets = [
+    testlib.Wallet( "5JesPiN68qt44Hc2nT8qmyZ1JDwHebfoh9KQ52Lazb1m1LaKNj9", 100000000000 ),
+    testlib.Wallet( "5KHqsiU9qa77frZb6hQy9ocV7Sus9RWJcQGYYBJJBb2Efj1o77e", 100000000000 ),
+    testlib.Wallet( "5Kg5kJbQHvk1B64rJniEmgbD83FpZpbw2RjdAZEzTefs9ihN3Bz", 100000000000 ),
+    testlib.Wallet( "5JuVsoS9NauksSkqEjbUZxWwgGDQbMwPsEfoRBSpLpgDX1RtLX7", 100000000000 ),
+    testlib.Wallet( "5KEpiSRr1BrT8vRD7LKGCEmudokTh1iMHbiThMQpLdwBwhDJB1T", 100000000000 ),
+    testlib.Wallet( "5K5hDuynZ6EQrZ4efrchCwy6DLhdsEzuJtTDAf3hqdsCKbxfoeD", 100000000000 ),
+    testlib.Wallet( "5J39aXEeHh9LwfQ4Gy5Vieo7sbqiUMBXkPH7SaMHixJhSSBpAqz", 100000000000 ),
+    testlib.Wallet( "5K9LmMQskQ9jP1p7dyieLDAeB6vsAj4GK8dmGNJAXS1qHDqnWhP", 100000000000 ),
+    testlib.Wallet( "5KcNen67ERBuvz2f649t9F2o1ddTjC5pVUEqcMtbxNgHqgxG2gZ", 100000000000 ),
+    testlib.Wallet( "5KMbNjgZt29V6VNbcAmebaUT2CZMxqSridtM46jv4NkKTP8DHdV", 100000000000 ),
+]
+
+consensus = "17ac43c1d8549c3181b200f1bf97eb7d"
+wallet_keys = None
+wallet_keys_2 = None
+error = False
+
+index_file_data = "<html><head></head><body>foo.test hello world</body></html>"
+resource_data = "hello world"
+
+new_key = "cPo24qGYz76xSbUCug6e8LzmzLGJPZoowQC7fCVPLN2tzCUJgfcW"
+new_addr = "mqnupoveYRrSHmrxFT9nQQEZt3RLsetbBQ"
+
+insanity_key = "cSCyE5Q1AFVyDAL8LkHo1sFMVqmwdvFcCbGJ71xEvto2Nrtzjm67"
+
+def scenario( wallets, **kw ):
+
+    global wallet_keys, wallet_keys_2, error, index_file_data, resource_data
+
+    wallet_keys = testlib.blockstack_client_initialize_wallet( "0123456789abcdef", wallets[5].privkey, wallets[3].privkey, wallets[4].privkey )
+    test_proxy = testlib.TestAPIProxy()
+    blockstack_client.set_default_proxy( test_proxy )
+
+    testlib.blockstack_namespace_preorder( "test", wallets[1].addr, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_reveal( "test", wallets[1].addr, 52595, 250, 4, [6,5,4,3,2,1,0,0,0,0,0,0,0,0,0,0], 10, 10, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_ready( "test", wallets[1].privkey )
+    testlib.next_block( **kw )
+
+    # tell serialization-checker that value_hash can be ignored here
+    print "BLOCKSTACK_SERIALIZATION_CHECK_IGNORE value_hash"
+    sys.stdout.flush()
+
+    testlib.next_block( **kw )
+
+    config_path = os.environ.get("BLOCKSTACK_CLIENT_CONFIG", None)
+
+    # make a session
+    datastore_pk = keylib.ECPrivateKey(wallets[-1].privkey).to_hex()
+    res = testlib.blockstack_cli_app_signin("foo.test", datastore_pk, 'register.app', ['names', 'register', 'prices', 'zonefiles', 'blockchain', 'node_read', 'wallet_write'])
+    if 'error' in res:
+        print json.dumps(res, indent=4, sort_keys=True)
+        error = True
+        return
+
+    ses = res['token']
+
+    # my own KEYS
+
+    owner_key = new_key
+
+    config_dir = os.path.dirname(config_path)
+    conf = blockstack_client.get_config(config_path)
+    assert conf
+
+    api_pass = conf['api_password']
+
+    payment_key = wallets[1].privkey
+    payer = wallets[1].addr
+
+    # make zonefile for recipient
+    driver_urls = blockstack_client.storage.make_mutable_data_urls('bar.test', use_only=['dht', 'disk'])
+    zonefile = blockstack_client.zonefile.make_empty_zonefile('bar.test', wallets[4].pubkey_hex, urls=driver_urls)
+    zonefile_txt = blockstack_zones.make_zone_file( zonefile, origin='bar.test', ttl=3600 )
+
+
+    postage = {'name': 'bar.test', 'zonefile': zonefile_txt, 'owner_address': new_addr,
+               'payment_key' : payment_key, 'owner_key' : owner_key}
+
+    # leaving the call format of this one the same to make sure that our registrar correctly
+    #   detects that the requested TRANSFER is superfluous
+    # register the name bar.test
+    res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data=postage)
+    if 'error' in res:
+        res['test'] = 'Failed to register user'
+        print json.dumps(res)
+        error = True
+        return False
+
+    print res
+    tx_hash = res['response']['transaction_hash']
+
+    # wait for preorder to get confirmed...
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'preorder', tx_hash )
+    if not res:
+        return False
+
+    # wait for the preorder to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    # wait for register to go through
+    print 'Wait for register to be submitted'
+    time.sleep(10)
+
+    # wait for the register to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'register', None )
+    if not res:
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for update to be submitted'
+    time.sleep(10)
+
+    # wait for update to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'update', None )
+    if not res:
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for transfer to be submitted'
+    time.sleep(10)
+
+    # wait for transfer to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.verify_in_queue(ses, 'bar.test', 'transfer', None )
+    if res:
+        print "Wrongly issued a TRANSFER"
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for transfer to be confirmed'
+    time.sleep(10)
+
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test", ses)
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = 'Failed to get name bar.test'
+        print json.dumps(res)
+        return False
+
+    zonefile_hash = res['response']['zonefile_hash']
+
+    # should still be registered
+    if res['response']['status'] != 'registered':
+        print "register not complete"
+        print json.dumps(res)
+        return False
+
+    # do we have the history for the name?
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/history", ses )
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = "Failed to get name history for foo.test"
+        print json.dumps(res)
+        return False
+
+    # valid history?
+    hist = res['response']
+    if len(hist.keys()) != 3:
+        res['test'] = 'Failed to get update history'
+        res['history'] = hist
+        print json.dumps(res, indent=4, sort_keys=True)
+        return False
+
+    # get the zonefile
+    res = testlib.blockstack_REST_call("GET", "/v1/names/bar.test/zonefile/{}".format(zonefile_hash), ses )
+    if 'error' in res or res['http_status'] != 200:
+        res['test'] = 'Failed to get name zonefile'
+        print json.dumps(res)
+        return False
+
+    # same zonefile we put?
+    if res['response']['zonefile'] != zonefile_txt:
+        res['test'] = 'mismatched zonefile, expected\n{}\n'.format(zonefile_txt)
+        print json.dumps(res)
+        return False
+
+
+    ### Now, we'll do it again, but this time, we're going to CHANGE THE KEY in the middle of registrations.
+    ### to test the different paths, I'll start 3 registrations:
+    # 1 has submitted preorder
+    # 1 has submitted register
+    # 1 has submitted update
+    ### And then I'll issue a change-key
+
+
+    # make zonefile for recipients
+    zonefiles = []
+    for i in [1,2,3]:
+        name = "tricky{}.test".format(i)
+        driver_urls = blockstack_client.storage.make_mutable_data_urls(name, use_only=['dht', 'disk'])
+        zonefile = blockstack_client.zonefile.make_empty_zonefile(name, wallets[4].pubkey_hex, urls=driver_urls)
+        zf_txt = blockstack_zones.make_zone_file( zonefile, origin=name, ttl=3600 )
+        zonefiles.append(zf_txt)
+        postages.append(
+            {'name': name, 'zonefile' : zf_txt, 'owner_address': new_addr,
+             'payment_key' : payment_key, 'owner_key' : owner_key})
+
+    res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data=postages[0])
+    if 'error' in res:
+        res['test'] = 'Failed to register tricky1.test'
+        print json.dumps(res)
+        error = True
+        return False
+
+    tx_hash = res['response']['transaction_hash']
+    # wait for preorder to get confirmed...
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data=postages[1])
+    if 'error' in res:
+        res['test'] = 'Failed to register tricky2.test'
+        print json.dumps(res)
+        error = True
+        return False
+
+    # wait for the preorder to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    # wait for register to go through
+    print 'Wait for register to be submitted'
+    time.sleep(10)
+
+    # wait for the register to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    res = testlib.blockstack_REST_call('POST', '/v1/names', ses, data=postages[2])
+    if 'error' in res:
+        res['test'] = 'Failed to register tricky3.test'
+        print json.dumps(res)
+        error = True
+        return False
+
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+
+    print 'Wait for update to be submitted'
+    time.sleep(10)
+
+    for i in xrange(0, 1):
+        testlib.next_block( **kw )
+
+
+
+    res = testlib.verify_in_queue(ses, 'tricky1.test', 'update', None)
+    res = testlib.verify_in_queue(ses, 'tricky2.test', 'register', None)
+    res = testlib.verify_in_queue(ses, 'tricky3.test', 'preorder', None)
+
+    # let's go crazy.
+    res = testlib.blockstack_REST_call('PUT', '/v1/wallet/keys/owner', None, api_pass=api_pass,
+                                       data=insanity_key)
+    res = testlib.blockstack_REST_call('PUT', '/v1/wallet/keys/payment', None, api_pass=api_pass,
+                                       data=insanity_key)
+    if res['http_status'] != 200 or 'error' in res:
+        print 'failed to set owner key'
+        print res
+        return False
+
+
+    # wait for preorder to get confirmed
+    for i in xrange(0, 6):
+        testlib.next_block( **kw )
+    # wake up registrar, submit register
+    time.sleep(10)
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+    # wake up registrar, submit update
+    time.sleep(10)
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+    # wake up registrar, propogate zonefile
+    time.sleep(10)
+
+def check( state_engine ):
+
+    global wallet_keys, error, index_file_data, resource_data
+
+    config_path = os.environ.get("BLOCKSTACK_CLIENT_CONFIG")
+    assert config_path
+
+    if error:
+        print "Key operation failed."
+        return False
+
+    # not revealed, but ready
+    ns = state_engine.get_namespace_reveal( "test" )
+    if ns is not None:
+        print "namespace not ready"
+        return False
+
+    ns = state_engine.get_namespace( "test" )
+    if ns is None:
+        print "no namespace"
+        return False
+
+    if ns['namespace_id'] != 'test':
+        print "wrong namespace"
+        return False
+
+    names = ['foo.test', 'bar.test', 'tricky1.test', 'tricky2.test', 'tricky3.test']
+    owners = [ wallets[3].addr , new_addr, new_addr, new_addr, new_addr ]
+    test_proxy = testlib.TestAPIProxy()
+
+    for i in xrange(0, len(names)):
+        name = names[i]
+        wallet_payer = 5
+        wallet_owner = 3 + i
+        wallet_data_pubkey = 4
+
+        # not preordered
+        preorder = state_engine.get_name_preorder( name, pybitcoin.make_pay_to_address_script(wallets[wallet_payer].addr), wallets[wallet_owner].addr )
+        if preorder is not None:
+            print "still have preorder"
+            return False
+
+        # registered
+        name_rec = state_engine.get_name( name )
+        if name_rec is None:
+            print "name does not exist"
+            return False
+
+        # owned
+        if name_rec['address'] != owners[i]:
+            print "name {} has wrong owner".format(name)
+            return False
+
+    return True

--- a/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_opt_key.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/rest_register_recipient_opt_key.py
@@ -242,6 +242,7 @@ def scenario( wallets, **kw ):
 
     # make zonefile for recipients
     zonefiles = []
+    postages = []
     for i in [1,2,3]:
         name = "tricky{}.test".format(i)
         driver_urls = blockstack_client.storage.make_mutable_data_urls(name, use_only=['dht', 'disk'])
@@ -356,18 +357,19 @@ def check( state_engine ):
         print "wrong namespace"
         return False
 
-    names = ['foo.test', 'bar.test', 'tricky1.test', 'tricky2.test', 'tricky3.test']
-    owners = [ wallets[3].addr , new_addr, new_addr, new_addr, new_addr ]
+    names = [ 'bar.test', 'tricky1.test', 'tricky2.test', 'tricky3.test']
+    owners = [ new_addr ] * 4
+    payers = [ wallets[1].addr ] * 4
+
     test_proxy = testlib.TestAPIProxy()
 
     for i in xrange(0, len(names)):
         name = names[i]
-        wallet_payer = 5
-        wallet_owner = 3 + i
-        wallet_data_pubkey = 4
 
         # not preordered
-        preorder = state_engine.get_name_preorder( name, pybitcoin.make_pay_to_address_script(wallets[wallet_payer].addr), wallets[wallet_owner].addr )
+        preorder = state_engine.get_name_preorder(
+            name, pybitcoin.make_pay_to_address_script(payers[i]), owners[i])
+
         if preorder is not None:
             print "still have preorder"
             return False
@@ -382,5 +384,7 @@ def check( state_engine ):
         if name_rec['address'] != owners[i]:
             print "name {} has wrong owner".format(name)
             return False
+
+        print name_rec
 
     return True


### PR DESCRIPTION
Adds `owner_key` and `payment_key` options to RESTful register, update, transfer, and renew endpoints.

For *registers*, because it is a multiple-transaction operation, these private keys must be retained by the core node. As before, the core node stores this `scrypted` using the wallet password in the registrar queue db.