### PR TITLE
Add `lsof` to developer docker containers

### DIFF
--- a/images/docker/api/Dockerfile
+++ b/images/docker/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker/whalesay:latest
 
-RUN sudo apt-get update && sudo apt-get install -y build-essential python-pip git-core python-dev libssl-dev libffi-dev rng-tools libgmp3-dev
+RUN sudo apt-get update && sudo apt-get install -y build-essential python-pip git-core python-dev libssl-dev libffi-dev rng-tools libgmp3-dev lsof
 RUN sudo pip install pip --upgrade
 RUN sudo pip install blockstack --upgrade
 

--- a/images/docker/core/Dockerfile
+++ b/images/docker/core/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker/whalesay:latest
 
-RUN sudo apt-get update && sudo apt-get install -y build-essential python-pip git-core python-dev libssl-dev libffi-dev rng-tools libgmp3-dev
+RUN sudo apt-get update && sudo apt-get install -y build-essential python-pip git-core python-dev libssl-dev libffi-dev rng-tools libgmp3-dev lsof
 RUN sudo pip install pip --upgrade
 RUN sudo pip install blockstack --upgrade
 

--- a/images/docker/testmode/Dockerfile
+++ b/images/docker/testmode/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker/whalesay:latest
 
 # Install Blockstack Core
-RUN sudo apt-get update && sudo apt-get install -y build-essential python-pip git-core python-dev libssl-dev libffi-dev rng-tools libgmp3-dev
+RUN sudo apt-get update && sudo apt-get install -y build-essential python-pip git-core python-dev libssl-dev libffi-dev rng-tools libgmp3-dev lsof
 RUN sudo pip install pip --upgrade
 RUN sudo pip install blockstack --upgrade
 


### PR DESCRIPTION
`lsof` is required by core to check that application secrets aren't read by another process. This is used when the `--debug` flag is passed to `api start`.