### PR TITLE
Fixes submodule for blockstack-consensus-data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "blockstack-consensus-data"]
-	path = blockstack-consensus-data
+	path = integration_tests/blockstack-consensus-data
 	url = https://github.com/blockstack/blockstack-consensus-data


### PR DESCRIPTION
According to https://www.git-scm.com/docs/gitmodules
.gitmodules files must live in the top-level directory of the repository. This broke some automated build processes.