### PR TITLE
Fix blockstackd migration complaint

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -2516,9 +2516,10 @@ def setup( working_dir=None, return_parser=False ):
 
     # config file version check
     config_server_version = blockstack_opts.get('server_version', None)
-    if config_server_version is None or not blockstack_client.config.semver_match( str(config_server_version), str(VERSION) ):
-        print >> sys.stderr, "Obsolete config file (%s): '%s' != '%s'\nPlease move it out of the way, so Blockstack Server can generate a fresh one." % (virtualchain.get_config_filename(), config_server_version, VERSION)
-        return None
+    if (config_server_version is None
+        or config.versions_need_upgrade(config_server_version, VERSION)):
+       print >> sys.stderr, "Obsolete config file (%s): '%s' != '%s'\nPlease move it out of the way, so Blockstack Server can generate a fresh one." % (virtualchain.get_config_filename(), config_server_version, VERSION)
+       return None
 
     log.debug("config:\n%s" % json.dumps(opts, sort_keys=True, indent=4))
 
@@ -2529,7 +2530,7 @@ def setup( working_dir=None, return_parser=False ):
     argparser = None
 
     if return_parser:
-       arg_bitcoin_opts, argparser = virtualchain.parse_bitcoind_args( return_parser=return_parser )
+      arg_bitcoin_opts, argparser = virtualchain.parse_bitcoind_args( return_parser=return_parser )
 
     else:
        arg_bitcoin_opts = virtualchain.parse_bitcoind_args( return_parser=return_parser )

--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -1182,8 +1182,8 @@ def versions_need_upgrade(v_from, v_to):
         (lambda v : v[:2] < (0,14))
     ]
 
-    v1 = ( int(x) for x in str(v_from).split('.') )
-    v2 = ( int(x) for x in str(v_to).split('.') )
+    v1 = tuple( int(x) for x in str(v_from).split('.') )
+    v2 = tuple( int(x) for x in str(v_to).split('.') )
     if len(v1) < 3 or len(v2) < 3:
         return True # one isn't semver
     if v1[:2] == v2[:2]:

--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -1176,3 +1176,21 @@ def configure( config_file=None, force=False, interactive=True ):
    return ret 
 
 
+def versions_need_upgrade(v_from, v_to):
+    version_upgrades = [
+        # all semver mismatches before "0.14" require upgrade
+        (lambda v : v[:2] < (0,14))
+    ]
+
+    v1 = ( int(x) for x in str(v_from).split('.') )
+    v2 = ( int(x) for x in str(v_to).split('.') )
+    if len(v1) < 3 or len(v2) < 3:
+        return True # one isn't semver
+    if v1[:2] == v2[:2]:
+        return False # same semver, no upgrade
+    # mismatch, see if this version requires a migration
+    for version_needs_upgrade_check in version_upgrades:
+        if version_needs_upgrade_check(v1):
+            return True
+    return False
+

--- a/blockstack/version.py
+++ b/blockstack/version.py
@@ -1,5 +1,5 @@
 # this is the only place where version should be updated
 __version_major__ = '0'
-__version_minor__ = '14'
-__version_patch__ = '4'
+__version_minor__ = '16'
+__version_patch__ = '0'
 __version__ = '{}.{}.{}.0'.format(__version_major__, __version_minor__, __version_patch__)

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -22,6 +22,6 @@
 
 # this is the only place where version should be updated
 __version_major__ = '0'
-__version_minor__ = '14'
-__version_patch__ = '5'
-__version__ = '{}.{}.{}.1'.format(__version_major__, __version_minor__, __version_patch__)
+__version_minor__ = '16'
+__version_patch__ = '0'
+__version__ = '{}.{}.{}.0'.format(__version_major__, __version_minor__, __version_patch__)


### PR DESCRIPTION
This fixes the migration complaint code path in blockstackd. You now need to explicitly add a given version to the config.versions_need_upgrade if that version should trigger the "upgrade your client.ini" complaint.

Resolves #591 

This also bumps the develop branch's version number! 0.16 here we come!