### PR TITLE
specify rpc-port for bitcoind in regtest mode

### DIFF
--- a/integration_tests/bin/blockstack-test-scenario
+++ b/integration_tests/bin/blockstack-test-scenario
@@ -900,7 +900,7 @@ def bitcoin_regtest_reset():
 
     # start up
     log.debug("Starting up bitcoind in regtest mode")
-    rc = os.system("bitcoind -daemon -conf=%s" % (bitcoin_conf))
+    rc = os.system("bitcoind -daemon -rpcport=%s -conf=%s" % (18332, bitcoin_conf))
     if rc != 0:
         log.error("Failed to start `bitcoind`: rc = %s" % rc)
         return False


### PR DESCRIPTION
New versions of bitcoind changed the default rpc-port for regtest mode. This was causing our integration test framework to fail to connect to bitcoind.