### PR TITLE
Remove multiname lookups on /v2/users and support a /v1/users endpoint

### DIFF
--- a/api/resolver.py
+++ b/api/resolver.py
@@ -248,15 +248,13 @@ def get_profile(fqa, refresh=False):
             zonefile = res['zonefile']
         except Exception as e:
             log.exception(e)
-            abort(500, "Connection to blockstack-server %s:%s timed out" % 
+            abort(500, "Connection to blockstack-server %s:%s timed out" %
                   (BLOCKSTACKD_IP, BLOCKSTACKD_PORT))
 
         if profile is None or 'error' in zonefile:
             log.error("{}".format(zonefile))
             abort(404)
-            
         prof_data = {'response' : profile}
-     
         if MEMCACHED_ENABLED or refresh:
             log.debug("Memcache set DHT: %s" % fqa)
             mc.set("dht_" + str(fqa), json.dumps(data),
@@ -273,18 +271,15 @@ def get_all_users():
     """ Return all users in the .id namespace
     """
 
-    # aaron: hardcode a non-response for the time being -- 
+    # aaron: hardcode a non-response for the time being --
     #  the previous code was trying to load a non-existent file
-    #  anyways. 
+    #  anyways.
     return {}
-
-# aaron note: do we need to support multiple users in a query?
-#    this seems like a potential avenue for abuse.
 
 @resolver.route('/v2/users/<usernames>', methods=['GET'], strict_slashes=False)
 @crossdomain(origin='*')
 @cache_control(MEMCACHED_TIMEOUT)
-def get_users(usernames):
+def get_users(username):
     """ Fetch data from username in .id namespace
     """
     reply = {}
@@ -295,34 +290,26 @@ def get_users(usernames):
     except:
         pass
 
-    if usernames is None:
-        reply['error'] = "No usernames given"
+    if username is None:
+        reply['error'] = "No username given"
         return jsonify(reply), 404
 
-    if ',' not in usernames:
-        usernames = [usernames]
+    if ',' in username:
+        reply['error'] = 'Multiple username queries are no longer supported.'
+        return jsonify(reply), 401
+
+
+    if "." not in username:
+        fqa = "{}.{}".format(username, 'id')
     else:
-        try:
-            usernames = usernames.rsplit(',')
-        except:
-            reply['error'] = "Invalid input format"
-            return jsonify(reply), 401
+        fqa = username
+    profile = get_profile(fqa, refresh=refresh)
 
-    for username in usernames:
-        if "." not in username:
-            fqa = "{}.{}".format(username, 'id')
-        else:
-            fqa = username
-        profile = get_profile(fqa, refresh=refresh)
-
-        if 'error' in profile:
-            if len(usernames) == 1:
-                reply[username] = profile
-                return jsonify(reply), 502
-        else:
-            reply[username] = profile
-
-    return jsonify(reply), 200
+    reply[username] = profile
+    if 'error' in profile:
+        return jsonify(reply), 502
+    else:
+        return jsonify(reply), 200
 
 
 @resolver.route('/v2/namespace', strict_slashes=False)

--- a/api/resolver.py
+++ b/api/resolver.py
@@ -276,7 +276,7 @@ def get_all_users():
     #  anyways.
     return {}
 
-@resolver.route('/v1/users/<usernames>', methods=['GET'], strict_slashes=False)
+@resolver.route('/v1/users/<username>', methods=['GET'], strict_slashes=False)
 @crossdomain(origin='*')
 @cache_control(MEMCACHED_TIMEOUT)
 def get_users(username):
@@ -311,7 +311,7 @@ def get_users(username):
     else:
         return jsonify(reply), 200
 
-@resolver.route('/v2/users/<usernames>', methods=['GET'], strict_slashes=False)
+@resolver.route('/v2/users/<username>', methods=['GET'], strict_slashes=False)
 @crossdomain(origin='*')
 @cache_control(MEMCACHED_TIMEOUT)
 def get_users_v2(username):

--- a/api/resolver.py
+++ b/api/resolver.py
@@ -276,7 +276,7 @@ def get_all_users():
     #  anyways.
     return {}
 
-@resolver.route('/v2/users/<usernames>', methods=['GET'], strict_slashes=False)
+@resolver.route('/v1/users/<usernames>', methods=['GET'], strict_slashes=False)
 @crossdomain(origin='*')
 @cache_control(MEMCACHED_TIMEOUT)
 def get_users(username):
@@ -311,6 +311,11 @@ def get_users(username):
     else:
         return jsonify(reply), 200
 
+@resolver.route('/v2/users/<usernames>', methods=['GET'], strict_slashes=False)
+@crossdomain(origin='*')
+@cache_control(MEMCACHED_TIMEOUT)
+def get_users_v2(username):
+    return get_users(username)
 
 @resolver.route('/v2/namespace', strict_slashes=False)
 @crossdomain(origin='*')

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -4,9 +4,10 @@ set -e
 COMMAND=$1
 
 if [ "$1" = "public_api" ]; then
-    aglio -i docs/api-specs.md --theme-template docs/aglio_templates/public.jade -o api/templates/index.html
-    version=$(python2 -c 'from blockstack.version import __version_major__, __version_minor__, __version_patch__; print("%s.%s.%s" % (__version_major__, __version_minor__, __version_patch__))')
-    sed -i "s/###version###/$version/g" docs/api-specs.md
+    version=$(python2 -c 'exec(open("blockstack_client/version.py").read()) ; print __version__')
+    cp docs/api-specs.md /tmp/
+    sed -i "s/###version###/$version/g" /tmp/api-specs.md
+    aglio -i /tmp/api-specs.md --theme-template docs/aglio_templates/public.jade -o api/templates/index.html
 elif [ "$1" = "core_api" ]; then
     aglio -i docs/api-specs.md --theme-template docs/aglio_templates/core.jade -o /tmp/index.html
 elif [ "$1" = "deploy_gh" ]; then

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -2418,7 +2418,7 @@ Not implemented.
 + Parameters
   + tld: id (string) - the namespace to fetch names from
 # Group Resolver Endpoints
-## Lookup User [GET /v2/users/{username}]
+## Lookup User [GET /v1/users/{username}]
 Lookup and resolver a user's profile. Defaults to the `id` namespace.
 + Public Only Endpoint
 + Subdomain Aware


### PR DESCRIPTION
Resolver endpoint drops support for multiple usernames on /v2/users (this was a great vector for griefing a server), and then add support for responding to requests on `/v1/users` -- per issue #628 

Example:

https://core.blockstack.org/v1/users/muneeb.id

Documentation is updated to reflect the endpoint.