### PR TITLE
Price endpoint computes with pre+reg only

### DIFF
--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -682,7 +682,7 @@ def cli_price(args, config_path=CONFIG_PATH, proxy=None, password=None, interact
     if operations is not None:
         operations = operations.split(',')
     else:
-        operations = ['preorder', 'register', 'update']
+        operations = ['preorder', 'register']
         if transfer_address:
             operations.append('transfer')
 
@@ -1471,10 +1471,9 @@ def cli_register(args, config_path=CONFIG_PATH, force_data=False, make_profile=F
         else:
             payment_privkey_info = wallet_keys['payment_privkey']
 
-        operations = ['preorder', 'register', 'update']
+        operations = ['preorder', 'register']
         required_checks = ['is_name_available', 'is_payment_address_usable', 'owner_can_receive']
         if transfer_address:
-            operations.append('transfer')
             required_checks.append('recipient_can_receive')
 
         res = check_operations( fqu, operations, owner_privkey_info, payment_privkey_info, min_payment_confs=min_payment_confs,

--- a/blockstack_client/backend/nameops.py
+++ b/blockstack_client/backend/nameops.py
@@ -1326,23 +1326,24 @@ def do_preorder( fqu, payment_privkey_info, owner_privkey_info, cost_satoshis, u
 
     fqu = str(fqu)
 
-    # wrap UTXO client so we remember UTXOs 
+    # wrap UTXO client so we remember UTXOs
     utxo_client = build_utxo_client(utxo_client)
 
     owner_address = virtualchain.get_privkey_address( owner_privkey_info )
     payment_address = virtualchain.get_privkey_address( payment_privkey_info )
-    
+
     min_confirmations = utxo_client.min_confirmations
 
     if burn_address is None:
         burn_address = get_namespace_burn_address(fqu, proxy)
     else:
         burn_address = str(burn_address)
-   
+
     if not dry_run and (safety_checks or (cost_satoshis is None or tx_fee is None)):
         tx_fee = 0
         # find tx fee, and do sanity checks
-        res = check_preorder(fqu, cost_satoshis, owner_privkey_info, payment_privkey_info, config_path=config_path, proxy=proxy, min_payment_confs=min_confirmations, burn_address=burn_address)
+        res = check_preorder(fqu, cost_satoshis, owner_privkey_info, payment_privkey_info, config_path=config_path,
+                             proxy=proxy, min_payment_confs=min_confirmations, burn_address=burn_address)
         if 'error' in res and safety_checks:
             log.error("Failed to check preorder: {}".format(res['error']))
             return res
@@ -1351,7 +1352,7 @@ def do_preorder( fqu, payment_privkey_info, owner_privkey_info, cost_satoshis, u
 
         if cost_satoshis is None:
             cost_satoshis = res['name_price']
-       
+
     assert tx_fee, 'Missing tx fee'
     assert cost_satoshis, "Missing name cost"
 

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -1984,7 +1984,10 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         """
 
         internal = self.server.get_internal_proxy()
-        res = internal.cli_price(name)
+
+        use_single_sig = path_info['qs_values'].get('single_sig', '0')
+
+        res = internal.cli_price(name, None, None, use_single_sig)
         if json_is_error(res):
             # error
             status_code = None

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '17'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.0'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.1'.format(__version_major__, __version_minor__, __version_patch__)

--- a/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
+++ b/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
@@ -349,7 +349,6 @@ class Prices(APITestCase):
         self.assertIn('register_tx_fee', json_keys)
         self.assertIn('total_estimated_cost', json_keys)
         self.assertIn('total_tx_fees', json_keys)
-        self.assertIn('update_tx_fee', json_keys)
 
     def test_ns_price(self):
         data = self.get_request("/v1/prices/namespaces/id",


### PR DESCRIPTION
And adds

`?single_sig=1` query string to the price lookup, which forces the price calculator to use a dummy single signature.

This should bring the price-estimation into line with the actual costs.

Our fee estimation still seems to be a bit on the high side (names should be closer to 0.001 btc than 0.002 btc), but will run that down later.