### PR TITLE
Withdraw API Behavior

### DIFF
--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -2300,10 +2300,14 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             address = new_addr
 
         internal = self.server.get_internal_proxy()
-        res = internal.cli_withdraw(
-            address, amount, message, min_confs, tx_only, payment_key,
-            config_path=self.server.config_path, interactive=False,
-            wallet_keys=self.server.wallet_keys)
+        try:
+            res = internal.cli_withdraw(
+                address, amount, message, min_confs, tx_only, payment_key,
+                config_path=self.server.config_path, interactive=False,
+                wallet_keys=self.server.wallet_keys)
+        except ValueError as ve:
+            log.error(ve)
+            return self._reply_json( {'error': ve.message}, status_code=400)
         if 'error' in res:
             log.debug("Failed to transfer balance: {}".format(res['error']))
             error_msg = {'error': 'Failed to transfer balance: {}'.format(res['error'])}

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -2293,6 +2293,9 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         if min_confs < 0:
             min_confs = 0
 
+        if amount == 0:
+            return self._reply_json( { 'error' : 'Refusing to send 0 bitcoin' }, 400 )
+
         # make sure we have the right encoding
         new_addr = virtualchain.address_reencode(str(address))
         if new_addr != address:


### PR DESCRIPTION
See issue #636 #637 

Not enough btc to pay fee now returns 400 (previously was a 500 error), and the message: `Not enough inputs for transaction (total: 4999292165, to spend: 4999292165, fee: 955).`

```
[2017-10-07 15:00:36,496] [DEBUG] [registrar:1043] (1.140572132112128) Registrar sleeping for 1
[2017-10-07 15:00:37,131] [DEBUG] [rpc:3924] (1.140572499130112) 
full path: /v1/wallet/balance
method: POST
path: /v1/wallet/balance
qs: {}
headers:
origin: http://localhost:8888
content-length: 165
accept-language: en-US,en;q=0.5
accept-encoding: gzip, deflate
connection: keep-alive
accept: application/json
user-agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:54.0) Gecko/20100101 Firefox/54.0
dnt: 1
host: localhost:6270
referer: http://localhost:8888/wallet/send
content-type: application/json
authorization: bearer blockstack_integration_test_api_password

[2017-10-07 15:00:37,131] [DEBUG] [app:152] (1.140572499130112) Not a valid token
[2017-10-07 15:00:37,131] [DEBUG] [rpc:3971] (1.140572499130112) Authenticated with password
[2017-10-07 15:00:37,135] [DEBUG] [rpc:2299] (1.140572499130112) Re-encode mrQoGgGV8iZVsy7XoaWAztZAfsowbmPf4g to 1BtqydBWKh8F6rdv61XoAyLqotDEfUHJZf
[2017-10-07 15:00:37,283] [DEBUG] [actions:561] (1.140572499130112) Withdraw 4999292165, tx fee 0
[2017-10-07 15:00:38,171] [DEBUG] [ecdsalib:240] (1.140572499130112) High-S to low-S
[2017-10-07 15:00:38,173] [DEBUG] [session:189] (1.140572499130112) Connect to bitcoind at localhost:18332 (/tmp/blockstack-run-scenario.blockstack_integration_tests.scenarios.portal_test_env/client/client.ini)
[2017-10-07 15:00:38,173] [DEBUG] [session:104] (1.140572499130112) [75] Connect to bitcoind at http://blockstack@localhost:18332, timeout=300.0
[2017-10-07 15:00:38,175] [DEBUG] [fees:93] (1.140572499130112) Bitcoin estimatefee(2) is 5.5e-05 (5 satoshi/byte)
[2017-10-07 15:00:38,175] [ERROR] [rpc:2309] (1.140572499130112) Not enough inputs for transaction (total: 4999292165, to spend: 4999292165, fee: 955).
172.17.0.1 - - [07/Oct/2017 15:00:38] "POST /v1/wallet/balance HTTP/1.1" 400 -
```

Passing an "amount" equal to 0 also is now refused:

```
$ curl -X POST http://localhost:6270/v1/wallet/balance -H 'Origin: http://localhost:8888/' -H 'Authorization: bearer blockstack_integration_test_api_password' -H 'Content-Type: application/json' --data '{"address" : "16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg", "amount" : 0 }'
{"error": "Refusing to send 0 bitcoin"}
```