### PR TITLE
Don't show the whole version at api docs

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -4,7 +4,7 @@ set -e
 COMMAND=$1
 
 if [ "$1" = "public_api" ]; then
-    version=$(python2 -c 'exec(open("blockstack_client/version.py").read()) ; print __version__')
+    version=$(python2 -c 'exec(open("blockstack_client/version.py").read()) ; print "{}.{}.{}".format(__version_major__, __version_minor__, __version_patch__)')
     cp docs/api-specs.md /tmp/
     sed -i "s/###version###/$version/g" /tmp/api-specs.md
     aglio -i /tmp/api-specs.md --theme-template docs/aglio_templates/public.jade -o api/templates/index.html


### PR DESCRIPTION
The API call for `ping` shows only the first three (major, minor and patch) version numbers. The API doc for `ping` shows all four. This commit fixes it.