### PR TITLE
Remove requirement of app private key

### DIFF
--- a/blockstack_client/app.py
+++ b/blockstack_client/app.py
@@ -36,6 +36,7 @@ import jsontokens
 import storage
 import data
 import urlparse
+import keylib
 import user as user_db
 from .proxy import get_default_proxy
 
@@ -97,7 +98,12 @@ def app_make_session( blockchain_id, app_public_key, app_domain, methods, app_pu
     if session_lifetime is None:
         session_lifetime = conf.get('default_session_lifetime', 1e80)
 
-    app_user_id = data.datastore_get_id(app_public_key)
+    # blockstack-storage.js assumes it needs to use an
+    #  uncompressed address. let's do that if we need to
+
+    app_datastore_public_key = keylib.key_formatting.decompress(app_public_key)
+
+    app_user_id = data.datastore_get_id(app_datastore_public_key)
 
     api_endpoint_host = conf.get('api_endpoint_host', DEFAULT_API_HOST)
     api_endpoint_port = conf.get('api_endpoint_port', DEFAULT_API_PORT)

--- a/blockstack_client/app.py
+++ b/blockstack_client/app.py
@@ -82,7 +82,7 @@ def app_domain_to_app_name(app_domain):
         return '{}.1'.format(urlinfo.netloc)
 
 
-def app_make_session( blockchain_id, app_private_key, app_domain, methods, app_public_keys, requester_device_id, master_data_privkey, session_lifetime=None, config_path=CONFIG_PATH ):
+def app_make_session( blockchain_id, app_public_key, app_domain, methods, app_public_keys, requester_device_id, master_data_privkey, session_lifetime=None, config_path=CONFIG_PATH ):
     """
     Make a session JWT for this application.
     Verify with user private key
@@ -97,7 +97,6 @@ def app_make_session( blockchain_id, app_private_key, app_domain, methods, app_p
     if session_lifetime is None:
         session_lifetime = conf.get('default_session_lifetime', 1e80)
 
-    app_public_key = get_pubkey_hex(app_private_key)
     app_user_id = data.datastore_get_id(app_public_key)
 
     api_endpoint_host = conf.get('api_endpoint_host', DEFAULT_API_HOST)

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -1783,6 +1783,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         """
 
         if datastore_id != ses['app_user_id']:
+            log.debug("Invalid datastore ID : {} != {}".format(
+                ses['app_user_id'], datastore_id))
             return self._reply_json({'error': 'Invalid datastore ID'}, status_code=403)
 
         if inode_type not in ['files', 'directories']:

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -543,25 +543,18 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         else:
             # current
             blockchain_id = decoded_token['payload']['blockchain_id']
-            app_private_key = str(decoded_token['payload']['app_private_key'])
-            app_public_key = get_pubkey_hex(app_private_key)
             app_public_keys = decoded_token['payload']['app_public_keys']
             requester_device_id = decoded_token['payload']['device_id']
 
             # must be listed in app_public_keys
-            requester_public_key = None
+            app_public_key = None
             for apk in app_public_keys:
                 if apk['device_id'] == requester_device_id:
-                    requester_public_key = apk['public_key']
+                    app_public_key = apk['public_key']
                     break
 
-            if requester_public_key is None:
+            if app_public_key is None:
                 return self._reply_json({'error': 'Invalid authRequest token: requesting device does not have a public key listed'}, status_code=401)
-
-            # must match the app private key
-            if keylib.key_formatting.decompress(requester_public_key) != keylib.key_formatting.decompress(app_public_key):
-                log.error("Device public key mismatch: {} != {}".format(requester_public_key, app_public_key))
-                return self._reply_json({'error': 'Invalid authRequest token: app private key does not match the device\'s listed public key'}, status_code=401)
 
         session_lifetime = DEFAULT_SESSION_LIFETIME
         log.debug("app_public_key: {}".format(app_public_key))
@@ -580,8 +573,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
             return self._reply_json({'error': 'Invalid authRequest token: invalid signature'}, status_code=401)
 
         # make the token
-        res = app.app_make_session( blockchain_id, app_private_key, app_domain, methods, app_public_keys, requester_device_id, self.server.master_data_privkey,
-                                    session_lifetime=session_lifetime, config_path=self.server.config_path)
+        res = app.app_make_session( blockchain_id, app_public_key, app_domain, methods, app_public_keys, requester_device_id, self.server.master_data_privkey,
+                                    session_lifetime=session_lifetime, config_path=self.server.config_path )
 
         if 'error' in res:
             return self._reply_json({'error': 'Failed to create session: {}'.format(res['error'])}, status_code=500)

--- a/blockstack_client/schemas.py
+++ b/blockstack_client/schemas.py
@@ -881,7 +881,9 @@ APP_SESSION_SCHEMA = {
 APP_SESSION_REQUEST_SCHEMA = {
     'type': 'object',
     'properties': APP_SESSION_REQUEST_PROPERTIES,
-    'required': APP_SESSION_REQUEST_PROPERTIES.keys(),
+    'required': [
+        [ 'app_public_keys', 'app_domain', 'version', 'methods',
+          'blockchain_id', 'device_id' ],
 }
 
 # old session request schema

--- a/blockstack_client/schemas.py
+++ b/blockstack_client/schemas.py
@@ -882,8 +882,8 @@ APP_SESSION_REQUEST_SCHEMA = {
     'type': 'object',
     'properties': APP_SESSION_REQUEST_PROPERTIES,
     'required': [
-        [ 'app_public_keys', 'app_domain', 'version', 'methods',
-          'blockchain_id', 'device_id' ],
+        'app_public_keys', 'app_domain', 'version', 'methods',
+        'blockchain_id', 'device_id' ],
 }
 
 # old session request schema


### PR DESCRIPTION
The application private key is no longer a required field of the `APP_SESSION_REQUEST` object. It was not needed by core (it was only being used to generate the datastore ID from the address of the uncompressed pubkey).

For `blockstack-browser` to send the session request without an app private key, it will need to use a new version of core.