### PR TITLE
Opt-in for resolving subdomains on the client

### DIFF
--- a/blockstack_client/config.py
+++ b/blockstack_client/config.py
@@ -657,6 +657,11 @@ def get_subdomains_db_path(config_path=CONFIG_PATH):
     subdomain_opts = opts['subdomain-resolution']
     return subdomain_opts['subdomains_db']
 
+def get_is_resolving_subdomains(config_path=CONFIG_PATH):
+    opts = configure(interactive=False, config_file=config_path)
+    subdomain_opts = opts['subdomain-resolution']
+    return subdomain_opts.get('resolving_subdomains', False)
+
 def get_tx_broadcaster(config_path=CONFIG_PATH):
     """
     Get or instantiate our blockchain UTXO provider's transaction broadcaster.

--- a/blockstack_client/subdomains.py
+++ b/blockstack_client/subdomains.py
@@ -208,6 +208,10 @@ class SubdomainDB(object):
         return self.update(full_refresh=True)
 
     def update(self, full_refresh=False):
+        if not is_resolving_subdomains():
+            log.warn('Configured not to resolve subdomains, but tried to update subdomain cache anyways...')
+            return
+
         if full_refresh:
             self._drop_tables()
             self._create_tables()
@@ -362,6 +366,8 @@ class SubdomainDB(object):
         cursor.execute(create_cmd)
         cursor.execute(create_status_cmd)
 
+def is_resolving_subdomains():
+    return config.get_is_resolving_subdomains()
 
 def parse_zonefile_subdomains(domain, zonefile_json):
     registrar_urls = []
@@ -482,6 +488,10 @@ def add_subdomains(subdomains, domain_fqa):
     return issue_zonefile(domain_fqa, zf_txt)
 
 def get_subdomain_info(subdomain, domain_fqa, use_cache = True):
+    if not is_resolving_subdomains():
+        log.error('Tried to resolve subdomain, but subdomain resolution is turned off in this client.')
+        raise SubdomainNotFound(subdomain)
+
     if not use_cache:
         from blockstack_client import data
         zonefiles = data.list_zonefile_history(domain_fqa)
@@ -499,6 +509,9 @@ def get_subdomain_info(subdomain, domain_fqa, use_cache = True):
     return subdomain_obj
 
 def resolve_subdomain(subdomain, domain_fqa, use_cache = True):
+    if not is_resolving_subdomains():
+        log.error('Tried to resolve subdomain, but subdomain resolution is turned off in this client.')
+        raise SubdomainNotFound(subdomain)
     subdomain_obj = get_subdomain_info(subdomain, domain_fqa, use_cache = use_cache)
     return subdomain_record_to_profile(subdomain_obj)
 
@@ -543,6 +556,9 @@ def subdomain_record_to_profile(my_rec):
     return data
 
 def get_subdomains_owned_by_address(address):
+    if not is_resolving_subdomains():
+        return []
+
     db = SubdomainDB()
     db.update()
     return db.get_subdomains_owned_by_address(address)


### PR DESCRIPTION
Resolving subdomains can make certain queries lag right now (the subdomain processing happens client-side -- @jcnelson is looking into moving that into the indexers / or the resolver)

This hotfix no-ops the subdomain lookups on the client unless you turn on support in the client.ini with the field:

```
[subdomain-resolution]
resolving_subdomains = True
```