### PR TITLE
Fixes error behavior when communicating with older nodes

### DIFF
--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -1548,7 +1548,7 @@ def get_name_at(name, block_id, include_expired=False, proxy=None):
     try:
         if include_expired:
             resp = proxy.get_historic_name_at(name, block_id)
-        else:
+        if not include_expired or 'KeyError' in resp.get('error', ''):
             resp = proxy.get_name_at(name, block_id)
 
         assert resp, "No such name {} at block {}".format(name, block_id)
@@ -2413,7 +2413,11 @@ def get_zonefiles(hostport, zonefile_hashes, timeout=30, my_hostport=None, proxy
     if proxy is None:
         host, port = url_to_host_port(hostport)
         assert host is not None and port is not None
-        proxy = BlockstackRPCClient(host, port, timeout=timeout, src=my_hostport, protocol = 'http')
+        if int(port) == 6263:
+            protocol = 'https'
+        else:
+            protocol = 'http'
+        proxy = BlockstackRPCClient(host, port, timeout=timeout, src=my_hostport, protocol = protocol)
 
     zonefiles = None
     try:

--- a/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
+++ b/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
@@ -296,9 +296,8 @@ class NamesOwnedTest(APITestCase):
     def build_url(self, addr):
         return '/v1/addresses/bitcoin/{}'.format(addr)
     def test_check_names(self):
-        addrs_to_check = ["1QJQxDas5JhdiXhEbNS14iNjr8auFT96GP",
-                          "16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg"]
-        names_to_check = ["muneeb.id", "judecn.id"]
+        addrs_to_check = ["1J3PUxY5uDShUnHRrMyU6yKtoHEUPhKULs"]
+        names_to_check = ["muneeb.id"]
         for addr, name in zip(addrs_to_check, names_to_check):
             data = self.get_request(self.build_url(addr),
                                     headers = {}, status_code = 200)


### PR DESCRIPTION
This should make `blockstack-core` pass CI tests again.

There were two issues:
1. `get_historic_name_at` doesn't exist on node.blockstack.org, and the previous patch release requires the call.
2. `get_zonefiles` wanted to make http requests when communicating on port `6263`.

In the long run, problem 2 is cause by the fact that we are breaking up host, protocol, and port in the blockstack `client.ini` and there's lots of code that disregards one or two of those config variables. We should just have 1 connection string config variable. 