### PR TITLE
404 on missing subdomain instead of 500 status code

### DIFF
--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -880,6 +880,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         if 'error' in name_rec:
             if 'not found' in name_rec['error'].lower():
                 return self._reply_json({'status': 'available'}, status_code=404)
+            elif 'failed to load subdomain' in name_rec['error'].lower():
+                return self._reply_json({'status': 'available'}, status_code=404)
             else:
                 return self._reply_json({'error': 'Blockstack daemon error: {}'.format(name_rec['error'])}, status_code=500)
 

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.0'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.1'.format(__version_major__, __version_minor__, __version_patch__)

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
           PYSCRYPT_NO_LINK_FLAGS: "1"
           LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a
           CPPFLAGS: -I/usr/local/opt/openssl/include
-    - ../virtualenvs/venv-system/bin/pip install git+https://github.com/blockstack/virtualchain@develop
+    - ../virtualenvs/venv-system/bin/pip install git+https://github.com/blockstack/virtualchain
     - ../virtualenvs/venv-system/bin/pip install git+https://github.com/blockstack/jsontokens-py
 
 compile:


### PR DESCRIPTION
Return a 404 error on missing subdomains, instead of 500 for the `/v1/names/` endpoint.