### PR TITLE
Expired Names Should Return 404, Not 500

### DIFF
--- a/blockstack/version.py
+++ b/blockstack/version.py
@@ -2,4 +2,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.2'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.3'.format(__version_major__, __version_minor__, __version_patch__)

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -882,6 +882,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                 return self._reply_json({'status': 'available'}, status_code=404)
             elif 'failed to load subdomain' in name_rec['error'].lower():
                 return self._reply_json({'status': 'available'}, status_code=404)
+            elif 'expired' in name_rec['error'].lower():
+                return self._reply_json({'error': name_rec['error']}, status_code=404)
             else:
                 return self._reply_json({'error': 'Blockstack daemon error: {}'.format(name_rec['error'])}, status_code=500)
 

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.2'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.3'.format(__version_major__, __version_minor__, __version_patch__)


### PR DESCRIPTION
Currently, `v1/names/<foo.id>` returns a 500 status code if the name is expired. This changes that to a 404.