### PR TITLE
fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ immediately transferrable to Blockstack.
 Blockstack applications look and feel like traditional Web applications.
 Under the hood they use Blockstack APIs for user authentication and storage.
 Blockstack handles user authentication using the [Blockstack Naming
-Service](docs/blockstack_naming_service)
+Service](docs/blockstack_naming_service.md)
 (BNS), a decentralized naming and public key infrastructure built on top of the Bitcoin
 blockchain.  It handles storage using [Gaia](https://github.com/blockstack/gaia), a scalable decentralized
 key/value storage system that looks and feels like `localStorage`,


### PR DESCRIPTION
#### Problem
A link in the root `README.md` file pointing to repo docs about Blockstack Naming Service was broken, _(missing `.md` suffix)_

#### Reproduce
Go to [blockstack/blockstack-core](https://github.com/blockstack/blockstack-core) repo page and search the main README.md for the line: 

> "Blockstack handles user authentication using the Blockstack Naming Service (BNS), a decentralized naming and public key infrastructure built on top of the Bitcoin blockchain." 

try to click the link to the Blockstack Naming Service, it should not work

#### Solution
Add the missing `.md` suffix to the uri