### PR TITLE
Increasing the max name length in rpc.py

### DIFF
--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -3220,7 +3220,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         """
 
         URLENCODING_CLASS = r'[a-zA-Z0-9\-_.~%]+'
-        NAME_CLASS = r'[a-z0-9\-_.+]{{{},{}}}'.format(3, LENGTH_MAX_NAME)
+        NAME_CLASS = r'[a-z0-9\-_.+]{{{},{}}}'.format(3, 2*LENGTH_MAX_NAME + 1)
         NAMESPACE_CLASS = r'[a-z0-9\-_+]{{{},{}}}'.format(1, LENGTH_MAX_NAMESPACE_ID)
         BASE58CHECK_CLASS = r'[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+'
 

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.4'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.5'.format(__version_major__, __version_minor__, __version_patch__)


### PR DESCRIPTION
This doubles the allowable name length in 'name' lookup URLs in `rpc.py` --- this is to accommodate for subdomain name lookups.
