### PR TITLE
Add deprecated notice to `/v1/names/zonefile`

### DIFF
--- a/bin/blockstack-snapshots
+++ b/bin/blockstack-snapshots
@@ -386,8 +386,9 @@ def remove_snapshot(snapshots_dir, block_number):
     if not os.path.exists(snapshot_path) or not os.path.isfile(snapshot_path):
         return {'error': 'No such file or directory: {}'.format(snapshot_path)}
 
-    snapshot_link = os.readlink(os.path.join(snapshots_dir, 'snapshot.bsk'))
-    if os.path.basename(snapshot_link) == 'snapshot.bsk.{}'.format(block_number):
+    cur_sb = os.stat(os.path.join(snapshots_dir, 'snapshot.bsk'))
+    sb = os.stat(snapshot_path)
+    if sb.st_ino == cur_sb.st_ino:
         return {'error': 'Snapshot for {} is the current snapshot'.format(block_number)}
 
     log.debug("Remove old snapshot {}".format(snapshot_path))

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -3220,7 +3220,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         """
 
         URLENCODING_CLASS = r'[a-zA-Z0-9\-_.~%]+'
-        NAME_CLASS = r'[a-z0-9\-_.+]{{{},{}}}'.format(3, LENGTH_MAX_NAME)
+        NAME_CLASS = r'[a-z0-9\-_.+]{{{},{}}}'.format(3, 2*LENGTH_MAX_NAME + 1)
         NAMESPACE_CLASS = r'[a-z0-9\-_+]{{{},{}}}'.format(1, LENGTH_MAX_NAMESPACE_ID)
         BASE58CHECK_CLASS = r'[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+'
 

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.4'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.5'.format(__version_major__, __version_minor__, __version_patch__)

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -1511,6 +1511,7 @@ as a base64 encoded blob with the 'zonefile_b64' property.
 We recommend base64-encoding your zone files in order to guarantee that they
 will be JSON-encodable. 
 
++ DEPRECATED.
 + Request (application/json)
   + Schema
 

--- a/docs/subdomains.md
+++ b/docs/subdomains.md
@@ -258,7 +258,7 @@ correct environment variables for it to run).
 Once this environment has started, you can issue a registration request from curl:
 
 ```
-curl -X POST --data '{"zonefile": "$ORIGIN baz\n$TTL 3600\n_file URI 10 1 \"file:///tmp/baz.profile.json\"\n", "name": "baz", "owner_address": "14x2EMRz1gf16UzGbxZh2c6sJg4A8wcHLD"}' http://localhost:3000/register/
+curl -X POST -H 'Content-Type: application/json' --data '{"zonefile": "$ORIGIN baz\n$TTL 3600\n_file URI 10 1 \"file:///tmp/baz.profile.json\"\n", "name": "baz", "owner_address": "14x2EMRz1gf16UzGbxZh2c6sJg4A8wcHLD"}' http://localhost:3000/register/
 ```
 
 This registers `baz.foo.id` -- you can check the registrar's status with

--- a/docs/subdomains.md
+++ b/docs/subdomains.md
@@ -273,7 +273,7 @@ The API endpoints `/v1/users/<foo.bar.tld>`,
 For example:
 
 ```
-curl http://localhost:6270/v1/names/bar.foo.id | python -m json.tool
+curl http://localhost:6270/v1/names/baz.foo.id | python -m json.tool
 ```
 
 Will return:
@@ -288,8 +288,6 @@ Will return:
     "zonefile_txt": "$ORIGIN bar\n$TTL 3600\n_file URI 10 1 \"file:///tmp/baz.profile.json\"\n"
 }
 ```
-
-The integration test registers `bar.foo.id` during the setup (so remember that for your own testing!)
 
 ### Running an interactive testing environment with the Subdomain Registrar service
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -32,7 +32,7 @@ example, the following command runs the test that will create a
 zonefile hash, and create an empty profile for it:
 
 ```bash
-IMAGE=$(docker run -dt -v /tmp:/tmp quay.io/blockstack/integrationtests:develop blockstack-test-scenario blockstack_integration_tests.scenarios.portal_test_env)
+IMAGE=$(docker run -dt -v /tmp:/tmp quay.io/blockstack/integrationtests:develop blockstack-test-scenario blockstack_integration_tests.scenarios.browser_env)
 ```
 
 You can check the status of the test:
@@ -94,15 +94,15 @@ And from the container, set the test environment variables:
      $ export BLOCKSTACK_TEST=1    # tells Blockstack CLI that it's running with the test environment
      $ export BLOCKSTACK_TESTNET=1 # tells Blockstack CLI to use testnet addresses
      $ export BLOCKSTACK_DEBUG=1   # print debug-level output in the CLI; great for troubleshooting
-     $ export BLOCKSTACK_CLIENT_CONFIG=/tmp/blockstack-run-scenario.blockstack_integration_tests.scenarios.portal_test_env/client/client.ini
+     $ export BLOCKSTACK_CLIENT_CONFIG=/tmp/blockstack-run-scenario.blockstack_integration_tests.scenarios.browser_env/client/client.ini
 ```
 
 You can also set these variables with an automated script included in the test
 framework:
 
 ```bash
-    $ . $(which blockstack-test-env) portal_env_test
-    |blockstack-test portal_env_test| $
+    $ . $(which blockstack-test-env) browser_env
+    |blockstack-test browser_env| $
 ```
 
 Your `$PS1` variable will be updated to show the name of the test if you take
@@ -244,7 +244,7 @@ order to "confirm" it.
 This example will set up an interactive regtest node that you can connect to via Blockstack Browser
 
 ```bash
- $ BLOCKSTACK_TEST_CLIENT_RPC_PORT=6270 blockstack-test-scenario --interactive 2 blockstack_integration_tests.scenarios.portal_test_env
+ $ BLOCKSTACK_TEST_CLIENT_RPC_PORT=6270 blockstack-test-scenario --interactive 2 blockstack_integration_tests.scenarios.browser_env
 ```
 
 In this example, a block will be generated once every 2 seconds.
@@ -252,7 +252,7 @@ In this example, a block will be generated once every 2 seconds.
 You can also do this:
 
 ```bash
- $ BLOCKSTACK_TEST_CLIENT_RPC_PORT=6270 blockstack-test-scenario --interactive-web 3001 blockstack_integration_tests.scenarios.portal_test_env
+ $ BLOCKSTACK_TEST_CLIENT_RPC_PORT=6270 blockstack-test-scenario --interactive-web 3001 blockstack_integration_tests.scenarios.browser_env
 ```
 
 In this example, you will need to manually generate blocks in order to confirm


### PR DESCRIPTION
This PR adds a deprecated notice to the `/v1/names/zonefile` endpoint for consistency.

The [category description](https://blockstack.github.io/blockstack-core/#managing-names) states that it should be and @jcnelson did confirm this in Slack.