### PR TITLE
Add deprecated notice to /v1/names/zonefile

### DIFF
--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -1511,6 +1511,7 @@ as a base64 encoded blob with the 'zonefile_b64' property.
 We recommend base64-encoding your zone files in order to guarantee that they
 will be JSON-encodable. 
 
++ DEPRECATED.
 + Request (application/json)
   + Schema
 


### PR DESCRIPTION
This PR adds a deprecated notice to the /v1/names/zonefile endpoint for consistency.

The [category description](https://blockstack.github.io/blockstack-core/#managing-names) states that it should be and @jcnelson did confirm this in Slack.

---
Follow up for https://github.com/blockstack/blockstack-core/pull/796