### PR TITLE
Fix Circle CI behavior

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,36 +1,30 @@
-machine:
-  pre:
-    - sudo -H pip install --upgrade virtualenv
-    - brew update
-    - brew install openssl
-dependencies:
-  pre:
-    - ../virtualenvs/venv-system/bin/pip install git+https://github.com/kantai/py-scrypt.git:
+version: 2
+jobs:
+  build:
+    working_directory: ~/circleci-demo-python-django
+    docker:
+      - image: circleci/python:2.7
         environment:
-          PYSCRYPT_NO_LINK_FLAGS: "1"
-          LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a
-          CPPFLAGS: -I/usr/local/opt/openssl/include
-    - ../virtualenvs/venv-system/bin/pip install git+https://github.com/blockstack/virtualchain
-    - ../virtualenvs/venv-system/bin/pip install git+https://github.com/blockstack/jsontokens-py
-
-compile:
-  post:
-    - ../virtualenvs/venv-system/bin/pip install ./integration_tests
-test:
-  pre:
-    - blockstack setup -y --password PASSWORD
-    - blockstack api start -y --password PASSWORD
-  override:
-    - mkdir $CIRCLE_TEST_REPORTS/django
-    - ../virtualenvs/venv-system/bin/python -m blockstack_integration_tests.live_tests.api_tests --xunit-path "$CIRCLE_TEST_REPORTS/django/" --all
-  post:
-    - blockstack api stop -y
-deployment:
-  tarball_venv:
-    branch: [master, osx-single-file-build, develop]
-    commands:
-      - cp -r ../virtualenvs/venv-system ./venv-copy
-      - virtualenv --relocatable ../virtualenvs/venv-system
-      - mv ../virtualenvs/venv-system ./blockstack-venv
-      - mv ./venv-copy ../virtualenvs/venv-system
-      - tar -czvf $CIRCLE_ARTIFACTS/blockstack-venv.tar.gz blockstack-venv
+          PIPENV_VENV_IN_PROJECT: true
+    steps:
+      - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python2.7/site-packages
+      - restore_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - run:
+          command: |
+            python2 -m venv venv
+            . venv/bin/activate
+            pip install . --upgrade
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - "venv"
+      - run:
+          command: |
+            . venv/bin/activate
+            blockstack setup -y --password PASSWORD
+            blockstack api start -y --password PASSWORD
+            python -m blockstack_integration_tests.live_tests.api_tests
+            blockstack api stop -y

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ jobs:
           command: |
             python -m virtualenv venv
             source venv/bin/activate
+            pip install ./integration_tests
             pip install . --upgrade
 ##      - save_cache:
 ##          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -8,18 +8,18 @@ jobs:
           PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
-##      - restore_cache:
-##          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - restore_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "integration_tests/setup.py" }}
       - run:
           command: |
             python -m virtualenv venv
             source venv/bin/activate
-            pip install ./integration_tests
-            pip install . --upgrade
-##      - save_cache:
-##          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-##          paths:
-##            - "venv"
+            pip install ./integration_tests --upgrade --upgrade-strategy only-if-needed
+            pip install . --upgrade --upgrade-strategy only-if-needed
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "integration_tests/setup.py" }}
+          paths:
+            - "venv"
       - run:
           command: |
             source venv/bin/activate

--- a/circle.yml
+++ b/circle.yml
@@ -1,29 +1,27 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/circleci-demo-python-django
+    working_directory: ~/blockstack
     docker:
       - image: circleci/python:2.7
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python2.7/site-packages
-      - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+##      - restore_cache:
+##          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
-            python2 -m venv venv
-            . venv/bin/activate
+            python -m virtualenv venv
+            source venv/bin/activate
             pip install . --upgrade
-      - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - "venv"
+##      - save_cache:
+##          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+##          paths:
+##            - "venv"
       - run:
           command: |
-            . venv/bin/activate
+            source venv/bin/activate
             blockstack setup -y --password PASSWORD
             blockstack api start -y --password PASSWORD
             python -m blockstack_integration_tests.live_tests.api_tests

--- a/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
+++ b/integration_tests/blockstack_integration_tests/live_tests/api_tests.py
@@ -28,7 +28,6 @@ import binascii
 import traceback
 import jsontokens
 
-from test import test_support
 from binascii import hexlify
 
 from blockstack_client import schemas
@@ -447,27 +446,7 @@ def test_main(args = []):
     for t in test_classes:
         test_map[t.__name__] = t
 
-
-    with test_support.captured_stdout() as out:
-        try:
-            test_support.run_unittest(PingTest)
-        except Exception as e:
-            traceback.print_exc(file=sys.stdout)
-    out = out.getvalue()
-    if out[-3:-1] != "OK":
-        print(out)
-        print("Failure of the ping test means the rest of the unit tests will " +
-              "fail. Is the blockstack api daemon running? (did you run " +
-              "`blockstack api start`)")
-        sys.exit(1)
-
-    if len(args) == 1 and args[0] == "--list":
-        print("Tests supported: ")
-        for testname in test_map.keys():
-            print(testname)
-        return
-
-    test_runner = test_support.run_unittest
+    test_runner = unittest.TextTestRunner(verbosity=2).run
 
     if "--xunit-path" in args:
         ainx = args.index("--xunit-path")
@@ -475,6 +454,12 @@ def test_main(args = []):
         from xmlrunner import XMLTestRunner
         test_runner = XMLTestRunner(output=args[ainx]).run
         del args[ainx]
+
+    if len(args) == 1 and args[0] == "--list":
+        print("Tests supported: ")
+        for testname in test_map.keys():
+            print(testname)
+        return
 
     if "--api_password" in args:
         ainx = args.index("--api_password")


### PR DESCRIPTION
Sometime in the past few days, CircleCI's images stopped working because `virtualenv` no longer exists as a command.

Rather than try to band-aid the behavior in our circle.yml, file, I figured now would be a good time to upgrade our CircleCI build to CircleCI version 2.0. That broke _other surprising things_ because the `test` module doesn't exist in the Docker standard python builds. Anyways, enough complaining, this updated `circle.yml` file + `api_tests.py` works.