### PR TITLE
Feature: Redirect for pending subdomains

### DIFF
--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -239,7 +239,6 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         json_str = json.dumps(json_payload)
         self.wfile.write(json_str)
 
-
     def _read_payload(self, maxlen=None):
         """
         Read raw uploaded data.
@@ -918,7 +917,34 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
 
         if 'error' in name_rec:
             if 'not found' in name_rec['error'].lower():
-                return self._reply_json({'status': 'available'}, status_code=404)
+                if blockstackd_scripts.is_subdomain(name):
+                    # handle redirection to specified resolver
+                    subdomain_name, domain_name = blockstackd_script.is_address_subdomain(name)
+                    domain_rec = blockstackd_client.get_name_record(domain_name, include_history = False,
+                                                                    hostport = blockstackd_url)
+                    if 'error' in domain_rec or 'zonefile' not in domain_rec:
+                        return self._reply_json(
+                            {'status': 'available', 'more': 'failed to lookup parent domain'}, status_code=404)
+                    domain_zf_txt = base64.b64decode(domain_rec['zonefile'])
+                    domain_zf_json = zonefile.decode_name_zonefile(domain_name, domain_zf_txt, allow_legacy=False)
+                    matching_uris = [ x['target'] for x in domain_zf_json['uri'] if x['name'] == '_resolver' ]
+                    if len(matching_uris) == 0:
+                        return self._reply_json(
+                            {'status': 'available',
+                             'more': 'failed to find parent domain\'s resolver'}, status_code=404)
+                    else:
+                        resolver_target = matching_uris[0]
+                        if resolver_target.endswith('/'):
+                            resolver_target = resolver_target[:-1]
+                        redirect_location = resolver_target + '/v1/names/' + name
+                        self._send_headers(status_code = 301,
+                                           more_headers = { 'Location': redirect_location })
+                        self.wfile.write(json.dumps({
+                            'status': 'redirect',
+                            'more': 'Redirecting to the domain\'s designated resolver for pending subdomains' }))
+                        return
+                else:
+                    return self._reply_json({'status': 'available'}, status_code=404)
             elif 'failed to load subdomain' in name_rec['error'].lower():
                 return self._reply_json({'status': 'available'}, status_code=404)
             elif 'expired' in name_rec['error'].lower():

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -941,8 +941,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
                     self._send_headers(status_code = 301,
                                        more_headers = { 'Location': redirect_location })
                     self.wfile.write(json.dumps({
-                        'status': 'redirect',
-                        'more': 'Redirecting to the domain\'s designated resolver for pending subdomains' }))
+                        'status': 'redirect'}))
                     return
             elif 'expired' in name_rec['error'].lower():
                 return self._reply_json({'error': name_rec['error']}, status_code=404)

--- a/integration_tests/blockstack_integration_tests/scenarios/name_pre_regup_subdomain_lookups.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/name_pre_regup_subdomain_lookups.py
@@ -68,14 +68,15 @@ def scenario( wallets, **kw ):
 
     working_dir = testlib.get_working_dir(**kw)
 
-    zf_template = '$ORIGIN {}\n$TTL 3600\n_http._tcp URI 10 1 "http://www.foo.com"\n{}'
+    sub_zf_template = '$ORIGIN {}\n$TTL 3600\n_http._tcp URI 10 1 "http://www.foo.com"\n{}'
+    zf_template = '$ORIGIN {}\n$TTL 3600\n_http._tcp URI 10 1 "http://www.foo.com"\n_resolver URI 10 1 "http://resolver.foo"\n{}'
     zf_default_url = '_file URI 10 1 "file://' + working_dir + '/{}"'
     zf_default_url_2 = '_file URI 20 1 "file://' + working_dir + '/{}"'
 
     subdomain_zonefiles = {
-        'bar.foo1.test': zf_template.format('bar.foo1.test', zf_default_url.format('bar.foo1.test')),
-        'bar.foo2.test': zf_template.format('bar.foo2.test', zf_default_url.format('bar.foo2.test')),
-        'bar.foo3.test': zf_template.format('bar.foo3.test', zf_default_url.format('bar.foo3.test')),
+        'bar.foo1.test': sub_zf_template.format('bar.foo1.test', zf_default_url.format('bar.foo1.test')),
+        'bar.foo2.test': sub_zf_template.format('bar.foo2.test', zf_default_url.format('bar.foo2.test')),
+        'bar.foo3.test': sub_zf_template.format('bar.foo3.test', zf_default_url.format('bar.foo3.test')),
     }
 
     zonefiles = {
@@ -161,6 +162,18 @@ def scenario( wallets, **kw ):
 
     # query each subdomain
     proxy = testlib.make_proxy()
+
+    # test 301 redirects.
+    res = testlib.blockstack_REST_call('GET', '/v1/names/baz.foo1.test', ses)
+    if 'error' in res:
+        res['test'] = 'Failed to query non-registered name.'
+        print json.dumps(res)
+        return False
+    if res['http_status'] != 301:
+        res['test'] = 'Failed to get a redirect.'
+        print json.dumps(res)
+        return False
+
     for i in xrange(1, 4):
         fqn = 'bar.foo{}.test'.format(i)
 
@@ -176,7 +189,7 @@ def scenario( wallets, **kw ):
             print json.dumps(res)
             return False
 
-        if res['response']['zonefile_txt'] != subdomain_zonefiles[fqn]:
+        if res['response']['zonefile'] != subdomain_zonefiles[fqn]:
             print 'wrong zone file'
             print res
             print 'expected'

--- a/integration_tests/blockstack_integration_tests/scenarios/name_pre_regup_subdomain_lookups.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/name_pre_regup_subdomain_lookups.py
@@ -164,7 +164,7 @@ def scenario( wallets, **kw ):
     proxy = testlib.make_proxy()
 
     # test 301 redirects.
-    res = testlib.blockstack_REST_call('GET', '/v1/names/baz.foo1.test', ses)
+    res = testlib.blockstack_REST_call('GET', '/v1/names/baz.foo1.test', ses, allow_redirects = False)
     if 'error' in res:
         res['test'] = 'Failed to query non-registered name.'
         print json.dumps(res)

--- a/integration_tests/blockstack_integration_tests/scenarios/subdomain_registrar_redirect_test.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/subdomain_registrar_redirect_test.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+    Blockstack
+    ~~~~~
+    copyright: (c) 2014-2015 by Halfmoon Labs, Inc.
+    copyright: (c) 2016 by Blockstack.org
+
+    This file is part of Blockstack
+
+    Blockstack is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Blockstack is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+"""
+# activate F-day 2017 at the right time
+"""
+TEST ENV BLOCKSTACK_EPOCH_1_END_BLOCK 682
+TEST ENV BLOCKSTACK_EPOCH_2_END_BLOCK 683
+TEST ENV BLOCKSTACK_EPOCH_2_NAMESPACE_LIFETIME_MULTIPLIER 1
+TEST ENV BLOCKSTACK_EPOCH_3_NAMESPACE_LIFETIME_MULTIPLIER 1
+"""
+
+import testlib
+import virtualchain
+import time
+import json
+import sys
+import os
+import requests
+import blockstack_client
+from subprocess import Popen
+
+wallets = [
+    testlib.Wallet( "5JesPiN68qt44Hc2nT8qmyZ1JDwHebfoh9KQ52Lazb1m1LaKNj9", 100000000000 ),
+    testlib.Wallet( "5KHqsiU9qa77frZb6hQy9ocV7Sus9RWJcQGYYBJJBb2Efj1o77e", 100000000000 ),
+    testlib.Wallet( "5Kg5kJbQHvk1B64rJniEmgbD83FpZpbw2RjdAZEzTefs9ihN3Bz", 100000000000 ),
+    testlib.Wallet( "5JuVsoS9NauksSkqEjbUZxWwgGDQbMwPsEfoRBSpLpgDX1RtLX7", 5500 ),
+    testlib.Wallet( "5KEpiSRr1BrT8vRD7LKGCEmudokTh1iMHbiThMQpLdwBwhDJB1T", 5500 )
+]
+
+consensus = "17ac43c1d8549c3181b200f1bf97eb7d"
+
+TRANSACTION_BROADCAST_LOCATION = os.environ.get('BSK_TRANSACTION_BROADCAST_LOCATION',
+                                                '/src/transaction-broadcaster')
+
+SUBDOMAIN_REGISTRAR_LOCATION = os.environ.get('BSK_SUBDOMAIN_REGISTRAR_LOCATION',
+                                              '/src/subdomain-registrar')
+
+def start_transaction_broadcaster():
+    try:
+        os.rename('/tmp/transaction_broadcaster.db', '/tmp/transaction_broadcaster.db.last')
+    except OSError:
+        pass
+    env = {'BSK_TRANSACTION_BROADCAST_DEVELOP' : '1'}
+    if os.environ.get('BLOCKSTACK_TEST_CLIENT_RPC_PORT', False):
+        env['BLOCKSTACK_TEST_CLIENT_RPC_PORT'] = os.environ.get('BLOCKSTACK_TEST_CLIENT_RPC_PORT')
+    Popen(['node', TRANSACTION_BROADCAST_LOCATION + '/lib/index.js'],
+          env = env)
+
+def start_subdomain_registrar():
+    try:
+        os.rename('/tmp/subdomain_registrar.db', '/tmp/subdomain_registrar.last')
+    except OSError:
+        pass
+    env = {'BSK_SUBDOMAIN_REGTEST' : '1'}
+    if os.environ.get('BLOCKSTACK_TEST_CLIENT_RPC_PORT', False):
+        env['BLOCKSTACK_TEST_CLIENT_RPC_PORT'] = os.environ.get('BLOCKSTACK_TEST_CLIENT_RPC_PORT')
+    Popen(['node', SUBDOMAIN_REGISTRAR_LOCATION + '/lib/index.js'], env = env)
+
+def scenario( wallets, **kw ):
+
+    start_transaction_broadcaster()
+    start_subdomain_registrar()
+
+    testlib.blockstack_namespace_preorder( "id", wallets[1].addr, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_reveal( "id", wallets[1].addr, 52595, 250, 4, [6,5,4,3,2,1,0,0,0,0,0,0,0,0,0,0], 10, 10, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_ready( "id", wallets[1].privkey )
+    testlib.next_block( **kw )
+
+    wallet = testlib.blockstack_client_initialize_wallet( "0123456789abcdef", wallets[2].privkey, wallets[3].privkey, wallets[4].privkey )
+    resp = testlib.blockstack_cli_register( "foo.id", "0123456789abcdef" )
+    if 'error' in resp:
+        print >> sys.stderr, json.dumps(resp, indent=4, sort_keys=True)
+        return False
+
+    # wait for the preorder to get confirmed
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+
+    # wait for the poller to pick it up
+    print >> sys.stderr, "Waiting 10 seconds for the backend to submit the register"
+    time.sleep(10)
+
+    # wait for the register to get confirmed
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+
+    print >> sys.stderr, "Waiting 10 seconds for the backend to acknowledge registration"
+    time.sleep(10)
+
+    # wait for update to get confirmed
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+
+    print >> sys.stderr, "Waiting 10 seconds for the backend to acknowledge update"
+    time.sleep(10)
+
+
+    # now, queue a registration.
+
+    requests.post('http://localhost:3000/register',
+                  json = { 'zonefile' : 'hello world',
+                           'name' : 'bar',
+                           'owner_address': '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' })
+
+    # force a batch out of the subdomain registrar
+
+    requests.post('http://localhost:3000/issue_batch',
+                  headers = {'Authorization': 'bearer tester129'})
+
+    for i in xrange(0, 12):
+        testlib.next_block( **kw )
+
+    print >> sys.stderr, "Waiting 10 seconds for the backend to pickup first batch"
+    time.sleep(10)
+
+    # now, queue another registration
+
+    requests.post('http://localhost:3000/register',
+                  json = { 'zonefile' : 'hello world',
+                           'name' : 'zap',
+                           'owner_address': '1Ez69SnzzmePmZX3WpEzMKTrcBF2gpNQ55' })
+
+    res = testlib.blockstack_REST_call('GET', '/v1/names/zap.foo.id', None)
+
+    if 'error' in res:
+        res['test'] = 'Failed to query zap.foo.id'
+        print json.dumps(res)
+        return False
+
+    if res['http_status'] != 200:
+        res['test'] = 'HTTP status {}, response = {} on name lookup'.format(res['http_status'], res['response'])
+        print json.dumps(res)
+        return False
+
+    name_info = res['response']
+    try:
+        if (name_info['zonefile'] != 'hello world' or
+            name_info['address'] != '1Ez69SnzzmePmZX3WpEzMKTrcBF2gpNQ55'):
+            res['test'] = 'Unexpected name info lookup for zap.foo.id'
+            print 'zap.foo.id JSON:'
+            print json.dumps(name_info)
+            return False
+    except:
+        res['test'] = 'Unexpected name info lookup for zap.foo.id'
+        print 'zap.foo.id JSON:'
+        print json.dumps(name_info)
+        return False
+
+
+def check( state_engine ):
+
+    # not revealed, but ready
+    ns = state_engine.get_namespace_reveal( "id" )
+    if ns is not None:
+        print "namespace reveal exists"
+        return False
+
+    ns = state_engine.get_namespace( "id" )
+    if ns is None:
+        print "no namespace"
+        return False
+
+    if ns['namespace_id'] != 'id':
+        print "wrong namespace"
+        return False
+
+    # registered
+    name_rec = state_engine.get_name( "foo.id" )
+    if name_rec is None:
+        print "name does not exist"
+        return False
+
+    return True

--- a/integration_tests/blockstack_integration_tests/scenarios/testlib.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/testlib.py
@@ -2408,7 +2408,9 @@ def blockstack_app_session( app_domain, methods, config_path=None ):
     return {'ses': ses}
 
 
-def blockstack_REST_call( method, route, session, api_pass=None, app_fqu=None, appname=None, data=None, raw_data=None, config_path=None, **query_fields ):
+def blockstack_REST_call( method, route, session, api_pass=None, app_fqu=None,
+                          appname=None, data=None, raw_data=None,
+                          allow_redirects = True, config_path=None, **query_fields ):
     """
     Low-level call to an API route
     Returns {'http_status': http status, 'response': json}
@@ -2453,7 +2455,7 @@ def blockstack_REST_call( method, route, session, api_pass=None, app_fqu=None, a
         data = raw_data
         headers['content-type'] = 'application/octet-stream'
 
-    resp = requests.request( method, url, headers=headers, data=data, allow_redirects=False )
+    resp = requests.request( method, url, headers=headers, data=data, allow_redirects=allow_redirects )
 
     response = None
     try:

--- a/integration_tests/blockstack_integration_tests/scenarios/testlib.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/testlib.py
@@ -2453,8 +2453,8 @@ def blockstack_REST_call( method, route, session, api_pass=None, app_fqu=None, a
         data = raw_data
         headers['content-type'] = 'application/octet-stream'
 
-    resp = requests.request( method, url, headers=headers, data=data )
-   
+    resp = requests.request( method, url, headers=headers, data=data, allow_redirects=False )
+
     response = None
     try:
         response = resp.json()

--- a/integration_tests/deployment/docker/Dockerfile.tests
+++ b/integration_tests/deployment/docker/Dockerfile.tests
@@ -24,10 +24,9 @@ RUN apt-get install -y nodejs
 # Install requirements for the blockstack.js integration tests
 WORKDIR /src/
 RUN apt-get install -y git
-RUN npm i -g browserify babel-cli
-ADD https://api.github.com/repos/blockstack/blockstack.js/git/refs/heads/feature/blockstack-operations blockstack-js-version.json
+# RUN npm i -g browserify babel-cli
+ADD https://api.github.com/repos/blockstack/blockstack.js/git/refs/heads/master blockstack-js-version.json
 RUN git clone https://git@github.com/blockstack/blockstack.js.git
-RUN cd blockstack.js && git checkout feature/blockstack-operations
 RUN cd blockstack.js && npm i && npm run build && npm ln
 
 # Install requirements for running the transaction broadcaster service
@@ -41,14 +40,10 @@ RUN git clone https://git@github.com/blockstack/subdomain-registrar.git
 RUN cd subdomain-registrar && npm i && npm ln blockstack && npm run build
 
 # Install pyparsing
-RUN pip install --upgrade pip && pip install pyparsing
+RUN pip install pyparsing
 
 # Build blockstack first
 WORKDIR /src/blockstack
-
-# We need virtualchain 18!
-ADD https://api.github.com/repos/blockstack/virtualchain/git/refs/heads/develop virtualchain-version.json
-RUN pip install git+https://github.com/blockstack/virtualchain@develop
 
 # Copy all files from the repo into the container
 COPY . .


### PR DESCRIPTION
This changes the behavior of the API endpoint to return a 301 HTTP redirect when it gets a `/v1/names` request for a not-yet-registered subdomain.

It looks up the domain's zonefile, reads the `_resolver` URI and redirects to the `/v1/names` endpoint listed there. If no such URI exists, or the api endpoint fails to read the zonefile, it responds with 404 (as it did before), with a `more` field with a little more information about the failure.

This implements the blockstack-core side of #750 

The integration test `name_pre_regup_subdomain_lookups.py` was modified to test for the 301 redirection.