### PR TITLE
Improve search endpoint for fully qualified names

### DIFF
--- a/api/search/basic_index.py
+++ b/api/search/basic_index.py
@@ -56,7 +56,6 @@ def clean_profile_entries(profile):
 def fetch_profile_data_from_file():
     """ takes profile data from file and saves in the profile_data DB
     """
-
     with open(SEARCH_PROFILE_DATA_FILE, 'r') as fin:
         profiles = json.load(fin)
 
@@ -115,6 +114,7 @@ def fetch_namespace_from_file():
             continue
 
         new_entry['username'] = username
+        new_entry['fqu'] = entry
         new_entry['profile'] = check_entry['value']
         namespace.save(new_entry)
         counter += 1
@@ -176,7 +176,6 @@ def create_search_index():
         if validUsername(user['username']):
             pass
         else:
-            # print "ignoring: " + user['username']
             continue
 
         profile = get_json(user['profile'])
@@ -226,6 +225,7 @@ def create_search_index():
         else:
             search_profile['twitter_handle'] = None
 
+        search_profile['fullyQualifiedName'] = user['fqu']
         search_profile['username'] = user['username']
         usernames.append(user['username'])
 

--- a/api/search/utils.py
+++ b/api/search/utils.py
@@ -108,4 +108,7 @@ def validUsername(username):
         if len(parts) == 2:
             if a.match(parts[0]) and a.match(parts[1]):
                 return True
+        if len(parts) == 3:
+            if a.match(parts[0]) and a.match(parts[1]) and a.match(parts[2]):
+                return True
         return False

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -3020,6 +3020,8 @@ Searches for a profile using a search string.
                {
                  "results": [
                    {
+                     "fullyQualifiedName": "albertwenger.id",
+                     "username": "albertwenger",
                      "profile": {
                        "@type": "Person", 
                        "account": [


### PR DESCRIPTION
This does 3 things:

1. Allows valid non-id subdomains to index correctly (this bug relates to the `/api/` directory's _own_ definition of `isValidName`
2. Add `fullyQualifiedName` key to the search result set -- the `username` field is currently rather strange -- it returns only the domainname part if the name is in the `id` namespace, but the fullyQualifiedName otherwise. Fixing that is unfortunately a breaking-change, which we should make at some point, but for now, `fullyQualifiedName` will work.
3. Document those changes in `api-specs.md`