### PR TITLE
Force pagination in history API endpoint

### DIFF
--- a/blockstack/lib/client.py
+++ b/blockstack/lib/client.py
@@ -810,7 +810,8 @@ def put_zonefiles(hostport, zonefile_data_list, timeout=30, my_hostport=None, pr
     return push_info
 
 
-def get_name_record(name, include_history=False, include_expired=False, include_grace=True, proxy=None, hostport=None):
+def get_name_record(name, include_history=False, include_expired=False, include_grace=True, proxy=None, hostport=None,
+                    history_page=None):
     """
     Get the record for a name or a subdomain.  Optionally include its history, and optionally return an expired name or a name in its grace period.
     Return the blockchain-extracted information on success.
@@ -872,9 +873,10 @@ def get_name_record(name, include_history=False, include_expired=False, include_
     lastblock = None
     try:
         if include_history:
-            resp = get_name_and_history(name, proxy=proxy)
+            resp = get_name_and_history(name, proxy=proxy, history_page=history_page)
             if 'error' in resp:
-                # fall back to legacy path 
+                # fall back to legacy path
+                log.debug(resp)
                 resp = proxy.get_name_blockchain_record(name)
         else:
             resp = proxy.get_name_record(name)
@@ -2206,7 +2208,7 @@ def name_history_merge(h1, h2):
     return ret
     
 
-def get_name_history(name, hostport=None, proxy=None):
+def get_name_history(name, hostport=None, proxy=None, history_page=None):
     """
     Get the full history of a name
     Returns {'status': True, 'history': ...} on success, where history is grouped by block
@@ -2219,6 +2221,16 @@ def get_name_history(name, hostport=None, proxy=None):
     hist = {}
     indexing = None
     lastblock = None
+
+    if history_page != None:
+        resp = get_name_history_page(name, history_page, proxy=proxy)
+        if 'error' in resp:
+            return resp
+
+        indexing = resp['indexing']
+        lastblock = resp['lastblock']
+
+        return {'status': True, 'history': resp['history'], 'indexing': indexing, 'lastblock': lastblock}
 
     for i in range(0, 10000):       # this is obviously too big
         resp = get_name_history_page(name, i, proxy=proxy)
@@ -2237,7 +2249,7 @@ def get_name_history(name, hostport=None, proxy=None):
     return {'status': True, 'history': hist, 'indexing': indexing, 'lastblock': lastblock}
 
 
-def get_name_and_history(name, include_expired=False, include_grace=True, hostport=None, proxy=None):
+def get_name_and_history(name, include_expired=False, include_grace=True, hostport=None, proxy=None, history_page=None):
     """
     Get the current name record and its history
     (this is a replacement for proxy.get_name_blockchain_record())
@@ -2248,7 +2260,7 @@ def get_name_and_history(name, include_expired=False, include_grace=True, hostpo
     if proxy is None:
         proxy = connect_hostport(hostport)
 
-    hist = get_name_history(name, proxy=proxy)
+    hist = get_name_history(name, proxy=proxy, history_page=history_page)
     if 'error' in hist:
         return hist
 

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -1092,6 +1092,7 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         qs_values = path_info['qs_values']
         start_block = qs_values.get('start_block', None)
         end_block = qs_values.get('end_block', None)
+        page = int(qs_values.get('page', 0))
 
         try:
             if start_block is None:
@@ -1111,7 +1112,8 @@ class BlockstackAPIEndpointHandler(SimpleHTTPRequestHandler):
         blockstackd_url = get_blockstackd_url(self.server.config_path)
 
         # res = proxy.get_name_blockchain_history(name, start_block, end_block)
-        res = blockstackd_client.get_name_record(name, include_history=True, hostport=blockstackd_url)
+        res = blockstackd_client.get_name_record(name, include_history=True,
+                                                 hostport=blockstackd_url, history_page=page)
         if json_is_error(res):
             self._reply_json({'error': res['error']}, status_code=500)
             return

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -1872,12 +1872,13 @@ Fetch a list of all names known to the node.
                  }
                }
                 
-## Name history [GET /v1/names/{name}/history]
+## Name history [GET /v1/names/{name}/history?page={page}]
 Get a history of all blockchain records of a registered name.
 + Public Endpoint
 + Subdomain aware
 + Parameters
   + name: muneeb.id (string) - name to query
+  + page: 0 (integer) - the page (in 20-entry pages) of the history to fetch
 + Response 200 (application/json)
   + Body
 


### PR DESCRIPTION
This adds a `page=` query string to the API endpoint for history, and forces it's use (as in defaults to page=0).
