### PR TITLE
Hotfix Zonefile Lookup for Resolver URI Entry

### DIFF
--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.6'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.7'.format(__version_major__, __version_minor__, __version_patch__)


### PR DESCRIPTION
This patches the zonefile return when looking up the resolver entry for a subdomain registrar.

The zonefile record is returned as base64 by the initial lookup, and it must be decoded before returning -- this is currently leading to 500s on the deployed server.