### PR TITLE
Hotfix/bigger rpc max len

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -46,9 +46,6 @@ from jsonschema import ValidationError
 import xmlrpclib
 from SimpleXMLRPCServer import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
 
-# stop common XML attacks
-from defusedxml import xmlrpc
-xmlrpc.monkey_patch()
 
 import virtualchain
 from virtualchain.lib.hashing import *
@@ -71,6 +68,11 @@ from lib.subdomains import (subdomains_init, SubdomainNotFound, get_subdomain_in
 
 import lib.nameset.virtualchain_hooks as virtualchain_hooks
 import lib.config as config
+
+# stop common XML attacks
+from defusedxml import xmlrpc
+xmlrpc.MAX_DATA = MAX_RPC_LEN
+xmlrpc.monkey_patch()
 
 # global variables, for use with the RPC server
 bitcoind = None

--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -141,7 +141,7 @@ RPC_DEFAULT_TIMEOUT = 30  # in secs
 RPC_MAX_ZONEFILE_LEN = 40960     # 40KB
 RPC_MAX_INDEXING_DELAY = 2 * 3600   # 2 hours; maximum amount of time before the absence of new blocks causes the node to stop responding
 
-MAX_RPC_LEN = RPC_MAX_ZONEFILE_LEN * 10    # maximum blockstackd RPC length
+MAX_RPC_LEN = RPC_MAX_ZONEFILE_LEN * 250    # maximum blockstackd RPC length == 100 zone files, base64-encoded (assume 1.33x overhead for encoding, plus extra XML)
 if os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"):
     MAX_RPC_LEN = int(os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"))
     print("Overriding MAX_RPC_LEN to {}".format(MAX_RPC_LEN))

--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -141,7 +141,7 @@ RPC_DEFAULT_TIMEOUT = 30  # in secs
 RPC_MAX_ZONEFILE_LEN = 40960     # 40KB
 RPC_MAX_INDEXING_DELAY = 2 * 3600   # 2 hours; maximum amount of time before the absence of new blocks causes the node to stop responding
 
-MAX_RPC_LEN = RPC_MAX_ZONEFILE_LEN * 250    # maximum blockstackd RPC length == 100 zone files, base64-encoded (assume 1.33x overhead for encoding, plus extra XML)
+MAX_RPC_LEN = RPC_MAX_ZONEFILE_LEN * 150    # maximum blockstackd RPC length == 10 zone files, base64-encoded (assume 1.33x overhead for encoding, plus extra XML)
 if os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"):
     MAX_RPC_LEN = int(os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"))
     print("Overriding MAX_RPC_LEN to {}".format(MAX_RPC_LEN))

--- a/blockstack/version.py
+++ b/blockstack/version.py
@@ -2,4 +2,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.4'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.8'.format(__version_major__, __version_minor__, __version_patch__)

--- a/blockstack_client/constants.py
+++ b/blockstack_client/constants.py
@@ -30,6 +30,7 @@ import json
 import tempfile
 import subprocess
 import fcntl
+import blockstack
 
 import virtualchain
 from .version import __version__, __version_major__, __version_minor__, __version_patch__
@@ -294,10 +295,10 @@ BLOCKSTACK_BURN_ADDRESS = virtualchain.hex_hash160_to_address(BLOCKSTACK_BURN_PU
 # never changes, so safe to duplicate to avoid gratuitous imports
 MAXIMUM_NAMES_PER_ADDRESS = 25
 
-RPC_MAX_ZONEFILE_LEN = 4096     # 4KB
+RPC_MAX_ZONEFILE_LEN = blockstack.lib.config.RPC_MAX_ZONEFILE_LEN
 RPC_MAX_PROFILE_LEN = 1024000   # 1MB
 
-MAX_RPC_LEN = RPC_MAX_ZONEFILE_LEN * 110    # maximum blockstackd RPC length--100 zonefiles with overhead
+MAX_RPC_LEN = blockstack.lib.config.MAX_RPC_LEN
 if os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"):
     MAX_RPC_LEN = int(os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"))
     print("Overriding MAX_RPC_LEN to {}".format(MAX_RPC_LEN))

--- a/blockstack_client/version.py
+++ b/blockstack_client/version.py
@@ -24,4 +24,4 @@
 __version_major__ = '0'
 __version_minor__ = '18'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.7'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.8'.format(__version_major__, __version_minor__, __version_patch__)

--- a/integration_tests/blockstack_integration_tests/scenarios/blockstackd_100_big_zonefiles.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/blockstackd_100_big_zonefiles.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+    Blockstack
+    ~~~~~
+    copyright: (c) 2014-2015 by Halfmoon Labs, Inc.
+    copyright: (c) 2016 by Blockstack.org
+
+    This file is part of Blockstack
+
+    Blockstack is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Blockstack is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+""" 
+
+import testlib 
+import json
+import blockstack
+import blockstack_client
+import virtualchain
+import binascii
+import socket
+import base64
+import xmlrpclib
+import StringIO
+import gzip
+
+wallets = [
+    testlib.Wallet( "5JesPiN68qt44Hc2nT8qmyZ1JDwHebfoh9KQ52Lazb1m1LaKNj9", 100000000000 ),
+    testlib.Wallet( "5KHqsiU9qa77frZb6hQy9ocV7Sus9RWJcQGYYBJJBb2Efj1o77e", 100000000000 ),
+    testlib.Wallet( "5Kg5kJbQHvk1B64rJniEmgbD83FpZpbw2RjdAZEzTefs9ihN3Bz", 100000000000 ),
+    testlib.Wallet( "5JuVsoS9NauksSkqEjbUZxWwgGDQbMwPsEfoRBSpLpgDX1RtLX7", 100000000000 ),
+    testlib.Wallet( "5KEpiSRr1BrT8vRD7LKGCEmudokTh1iMHbiThMQpLdwBwhDJB1T", 100000000000 )
+]
+
+consensus = "17ac43c1d8549c3181b200f1bf97eb7d"
+
+def make_big_zonefile(filler):
+    return '{:02x}'.format(filler) * 20480
+
+def scenario( wallets, **kw ):
+
+    # make some zonefiles
+    testlib.blockstack_namespace_preorder( "test", wallets[1].addr, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_reveal( "test", wallets[1].addr, 52595, 250, 4, [6,5,4,3,2,1,0,0,0,0,0,0,0,0,0,0], 10, 10, wallets[0].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_namespace_ready( "test", wallets[1].privkey )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_name_preorder( "foo.test", wallets[2].privkey, wallets[3].addr )
+    testlib.next_block( **kw )
+
+    testlib.blockstack_name_register( "foo.test", wallets[2].privkey, wallets[3].addr )
+    testlib.next_block( **kw )
+
+    zfhashes = []
+
+    for j in range(0, 5):
+        for i in range(0, 20):
+            big_zonefile = make_big_zonefile(i + 20*j)
+            zonefile_hash = blockstack.lib.storage.get_zonefile_data_hash(big_zonefile)
+            testlib.blockstack_name_update("foo.test", zonefile_hash, wallets[3].privkey)
+
+            zfhashes.append(zonefile_hash)
+
+        testlib.next_block(**kw)
+
+        for i in range(0, 20):
+            big_zonefile = make_big_zonefile(i + 20*j)
+            res = blockstack.lib.client.put_zonefiles('http://localhost:16264', [base64.b64encode(big_zonefile)])
+            assert res['saved'][0] == 1
+
+        print '\n\ntest with {} zone files\n\n'.format(20 * j + i)
+        res = blockstack.lib.client.get_zonefiles('http://localhost:16264', zfhashes)
+        assert 'error' not in res, res
+
+        for zfh in zfhashes:
+            assert zfh in res['zonefiles'], 'missing {}, got {}'.format(zfh, res['zonefiles'].keys())
+
+
+def check( state_engine ):
+    
+    return True
+


### PR DESCRIPTION
This PR sets the MAX_DATA size for XMLRPC requests to be 150 * (maximum zonefile size).  This limit was determined by the fact that by far the largest XMLRPC request we make is fetching zone files in Atlas, and Atlas only allows at most 100 zone files to be fetched at once.  Since the RPCs are serialized as XML, and since the zone files are base64-encoded on transmission, the 150 multiplier was chosen to accommodate for the extra space required.  This PR also adds the test `blockstackd_100_big_zonefiles` to verify that the XMLRPC client can fetch 100 40K zone files.

This fix should address the case where a user runs a blockstack node that is synchronizing with the rest of the peer network, and encounters a lot of big zone files (like those from `onename.id`).