### PR TITLE
Add note about zone file hash to wire format

### DIFF
--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -179,6 +179,8 @@ See the [Method Glossary](#method-glossary) below.
 
 Example: `hash128("jude.id" + "8d8762c37d82360b84cf4d87f32f7754") == "d1062edb9ec9c85ad1aca6d37f2f5793"`.
 
+The 20 byte zone file hash is computed from zone file data by using `ripemd160(sha56(zone file data))`
+
 Inputs:
 * owner `scriptSig`
 * payment `scriptSig`'s


### PR DESCRIPTION
Adds a small description of how the zone file hash is computed in our wire format.