### PR TITLE
Feature/rest subdomain ops

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -67,7 +67,8 @@ from lib.fast_sync import *
 from lib.rpc import BlockstackAPIEndpoint
 from lib.subdomains import (subdomains_init, SubdomainNotFound, get_subdomain_info, get_subdomain_history,
                             get_DID_subdomain, get_subdomains_owned_by_address, get_subdomain_DID_info,
-                            get_all_subdomains, get_subdomains_count, get_subdomain_resolver, is_subdomain_zonefile_hash)
+                            get_all_subdomains, get_subdomains_count, get_subdomain_resolver, is_subdomain_zonefile_hash,
+                            get_subdomain_ops_at_txid)
 
 import lib.nameset.virtualchain_hooks as virtualchain_hooks
 import lib.config as config
@@ -1431,6 +1432,19 @@ class BlockstackdRPC(BoundedThreadingMixIn, SimpleXMLRPCServer):
         db.close()
 
         return self.success_response( {'names': res} )
+
+
+    def rpc_get_subdomain_ops_at_txid(self, txid, **con_info):
+        """
+        Return the list of subdomain operations accepted within a given txid.
+        Return {'status': True, 'subdomain_ops': [{...}]} on success
+        Return {'error': ...} on error
+        """
+        if not check_string(txid, min_length=64, max_length=64, pattern='^[0-9a-fA-F]{64}$'):
+            return {'error': 'Not a valid txid', 'http_status': 400}
+       
+        subdomain_ops = get_subdomain_ops_at_txid(txid)
+        return self.success_response( {'subdomain_ops': subdomain_ops} )
 
 
     def rpc_get_consensus_at( self, block_id, **con_info ):

--- a/blockstack/lib/schemas.py
+++ b/blockstack/lib/schemas.py
@@ -150,6 +150,11 @@ USER_ZONEFILE_SCHEMA = {
 OP_HISTORY_SCHEMA = {
     'type': 'object',
     'properties': {
+        'accepted': {
+            'type': 'integer',
+            'minimum': 0,
+            'maximum': 1,
+        },
         'address': {
             'type': 'string',
             'pattern': OP_ADDRESS_PATTERN,
@@ -179,6 +184,10 @@ OP_HISTORY_SCHEMA = {
             ],
         },
         'block_number': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        'block_height': {
             'type': 'integer',
             'minimum': 0,
         },
@@ -220,6 +229,10 @@ OP_HISTORY_SCHEMA = {
             'type': 'integer',
             'minimum': 0,
         },
+        'fully_qualified_subdomain': {
+            'type': 'string',
+            'pattern': OP_SUBDOMAIN_NAME_PATTERN,
+        },
         'history_snapshot': {
             'type': 'boolean',
         },
@@ -249,6 +262,16 @@ OP_HISTORY_SCHEMA = {
             'type': 'integer',
             'minimum': 0,
         },
+        'missing': {
+            'anyOf': [
+                {
+                    'type': 'string',
+                },
+                {
+                    'type': 'null',
+                },
+            ],
+        },
         'name': {
             'type': 'string',
             'pattern': OP_NAME_OR_SUBDOMAIN_PATTERN,
@@ -267,6 +290,18 @@ OP_HISTORY_SCHEMA = {
         'opcode': {
             'type': 'string',
             'pattern': OP_CODE_NAME_PATTERN,
+        },
+        'owner': {
+            'type': 'string',
+            'pattern': OP_ADDRESS_PATTERN,
+        },
+        'parent_zonefile_hash': {
+            'type': 'string',
+            'pattern': OP_ZONEFILE_HASH_PATTERN,
+        },
+        'parent_zonefile_index': {
+            'type': 'integer',
+            'minimum': 0,
         },
         'pending': {
             'type': 'boolean'
@@ -292,6 +327,10 @@ OP_HISTORY_SCHEMA = {
         'sequence': {
             'type': 'integer',
             'minimum': 0,
+        },
+        'signature': {
+            'type': 'string',
+            'pattern': OP_BASE64_EMPTY_PATTERN,
         },
         'recipient': {
             'anyOf': [
@@ -358,6 +397,14 @@ OP_HISTORY_SCHEMA = {
         'zonefile': {
             'type': 'string',
             'pattern': OP_BASE64_EMPTY_PATTERN,
+        },
+        'zonefile_hash': {
+            'type': 'string',
+            'pattern': OP_ZONEFILE_HASH_PATTERN,
+        },
+        'zonefile_offset': {
+            'type': 'integer',
+            'minimum': 0,
         },
     },
     'required': [
@@ -538,3 +585,18 @@ SUBDOMAIN_SCHEMA_REQUIRED = [
     'value_hash',
 ]
 
+SUBDOMAIN_HISTORY_REQUIRED = [
+    'fully_qualified_subdomain',
+    'domain',
+    'sequence',
+    'owner',
+    'zonefile_hash',
+    'signature',
+    'block_height',
+    'parent_zonefile_hash',
+    'parent_zonefile_index',
+    'zonefile_offset',
+    'txid',
+    'missing',
+    'resolver',
+]

--- a/integration_tests/blockstack_integration_tests/scenarios/testlib.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/testlib.py
@@ -2064,6 +2064,36 @@ def check_subdomain_db(firstblock=None, **kw):
 
         assert subrec_did == subrec, 'At ({}, {}): Did not resolve to {}, but instead to {}'.format(subd, addr, subrec, subrec_did)
 
+    # make sure we can get all historic states of each subdomain 
+    for subd in all_subdomains:
+        p = subprocess.Popen('sqlite3 "{}" \'select txid,accepted from subdomain_records where fully_qualified_subdomain = "{}" order by parent_zonefile_index, zonefile_offset\''
+                .format(blockstack_opts['subdomaindb_path'], subd), shell=True, stdout=subprocess.PIPE)
+
+        all_txids_and_accepted, _ = p.communicate()
+
+        all_txids_and_accepted = all_txids_and_accepted.strip().split('\n')
+        all_txids_and_accepted = [tuple(ataa.strip().split('|')) for ataa in all_txids_and_accepted]
+
+        for txid_and_accepted in all_txids_and_accepted:
+            txid = txid_and_accepted[0]
+            accepted = txid_and_accepted[1]
+
+            res = requests.get('http://localhost:16268/v1/subdomains/{}'.format(txid))
+            items = res.json()
+            zfh = None
+            
+            for (i, subdomain_op) in enumerate(items):
+                assert subdomain_op['txid'] == txid, subdomain_op
+                assert subdomain_op['zonefile_offset'] >= i, subdomain_op
+                assert subdomain_op['accepted'] == int(accepted), subdomain_op
+                assert subdomain_op['domain'] == subd.split('.', 1)[-1], subdomain_op
+
+                if zfh is None:
+                    zfh = subdomain_op['parent_zonefile_hash']
+
+                assert zfh == subdomain_op['parent_zonefile_hash'], subdomain_op
+
+        
     print '\nend auditing the subdomain db\n'
 
     return True

--- a/integration_tests/blockstack_integration_tests/scenarios/testlib.py
+++ b/integration_tests/blockstack_integration_tests/scenarios/testlib.py
@@ -2074,6 +2074,8 @@ def check_subdomain_db(firstblock=None, **kw):
         all_txids_and_accepted = all_txids_and_accepted.strip().split('\n')
         all_txids_and_accepted = [tuple(ataa.strip().split('|')) for ataa in all_txids_and_accepted]
 
+        assert len(all_txids_and_accepted) > 0, 'no subdomain rows for {}'.format(subd)
+
         for txid_and_accepted in all_txids_and_accepted:
             txid = txid_and_accepted[0]
             accepted = txid_and_accepted[1]


### PR DESCRIPTION
Adds support for the `GET /v1/subdomains/{:txid}` endpoint, so you can see which subdomain operations were processed with this transaction. Example on my local node:

```
$ curl -s http://localhost:6270/v1/subdomains/531d02e4f1cff8a29d3bdee02aaa63c32f5be6dbec2fd7c2b80fbd8e4878c255 | jq
[
  {
    "accepted": 1,
    "block_height": 545901,
    "domain": "id.blockstack",
    "fully_qualified_subdomain": "dinosath.id.blockstack",
    "missing": "",
    "owner": "1Q1EeRrRA9YPEV98doUXFPHC7qVubLHbQm",
    "parent_zonefile_hash": "92d6b2fc656f25503a0cc7d57ddd45738af41358",
    "parent_zonefile_index": 95728,
    "resolver": "https://registrar.blockstack.org",
    "sequence": 0,
    "signature": "None",
    "txid": "531d02e4f1cff8a29d3bdee02aaa63c32f5be6dbec2fd7c2b80fbd8e4878c255",
    "zonefile_hash": "661a8472824ceec21ede4c5fba3b71893177a1bc",
    "zonefile_offset": 0
  },
  {
    "accepted": 1,
    "block_height": 545901,
    "domain": "id.blockstack",
    "fully_qualified_subdomain": "scribendi.id.blockstack",
    "missing": "",
    "owner": "1PWaPygCBCgkgFDvJ8C8Ubn9mHZjZEijFD",
    "parent_zonefile_hash": "92d6b2fc656f25503a0cc7d57ddd45738af41358",
    "parent_zonefile_index": 95728,
    "resolver": "https://registrar.blockstack.org",
    "sequence": 0,
    "signature": "None",
    "txid": "531d02e4f1cff8a29d3bdee02aaa63c32f5be6dbec2fd7c2b80fbd8e4878c255",
    "zonefile_hash": "be41d22958d8fd243eb70c600b53ddf802b04468",
    "zonefile_offset": 1
  },
  {
    "accepted": 1,
    "block_height": 545901,
    "domain": "id.blockstack",
    "fully_qualified_subdomain": "jedschmidt.id.blockstack",
    "missing": "",
    "owner": "13QW6hxWHKKCyj9S5AX6n1UTGjXtVqjuFx",
    "parent_zonefile_hash": "92d6b2fc656f25503a0cc7d57ddd45738af41358",
    "parent_zonefile_index": 95728,
    "resolver": "https://registrar.blockstack.org",
    "sequence": 0,
    "signature": "None",
    "txid": "531d02e4f1cff8a29d3bdee02aaa63c32f5be6dbec2fd7c2b80fbd8e4878c255",
    "zonefile_hash": "988b8750eb38f7b779d00dc8fdfe507c80dbad37",
    "zonefile_offset": 2
  },
  {
    "accepted": 1,
    "block_height": 545901,
    "domain": "id.blockstack",
    "fully_qualified_subdomain": "codysork.id.blockstack",
    "missing": "",
    "owner": "1MW1YptA7aXdBqwYRtG4shYwnr5bZskDV9",
    "parent_zonefile_hash": "92d6b2fc656f25503a0cc7d57ddd45738af41358",
    "parent_zonefile_index": 95728,
    "resolver": "https://registrar.blockstack.org",
    "sequence": 0,
    "signature": "None",
    "txid": "531d02e4f1cff8a29d3bdee02aaa63c32f5be6dbec2fd7c2b80fbd8e4878c255",
    "zonefile_hash": "a988a1d680bedcac8e47e06a6dc2f26f596f60ea",
    "zonefile_offset": 3
  }
]
```

Would love to get this merged in for the new explorer.  CC @hstove @kantai 