### PR TITLE
Update testing dockerfile

### DIFF
--- a/integration_tests/deployment/docker/Dockerfile.tests
+++ b/integration_tests/deployment/docker/Dockerfile.tests
@@ -1,57 +1,62 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
+WORKDIR /src/blockstack
 
-# Install dependancies from apt
-RUN apt-get -y update
-RUN apt-get install -y python-pip python-dev libssl-dev libffi-dev rng-tools libgmp3-dev lsof
 
-# Install Bitcoin
-RUN apt-get -y update
-RUN apt-get install -y python-software-properties
-RUN apt-get install -y software-properties-common
+# Install dependencies from apt
+RUN apt-get -y update && \
+    apt-get install -y python-pip python-dev libssl-dev libffi-dev \
+    rng-tools libgmp3-dev lsof wget curl apt-utils git gnupg sqlite3 \
+    software-properties-common
 
+# We need bitcoind
 RUN add-apt-repository ppa:bitcoin/bitcoin
 RUN apt-get -y update
-RUN apt-get install -y bitcoind sqlite3 curl
+RUN apt-get install -y bitcoind
 
 # Add standard username and password
 RUN mkdir ~/.bitcoin
 RUN echo "rpcuser=blockstack\nrpcpassword=blockstacksystem\nrpcbind=0.0.0.0\nrpcallowip=0.0.0.0/0\n" > ~/.bitcoin/bitcoin.conf
 
-# Install NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y nodejs
+# Install node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update && apt-get install -y nodejs
 
-# Install requirements for the blockstack.js integration tests
-WORKDIR /src/
-RUN apt-get install -y git
-# RUN npm i -g browserify babel-cli
-ADD https://api.github.com/repos/blockstack/blockstack.js/git/refs/heads/master blockstack-js-version.json
-RUN git clone https://git@github.com/blockstack/blockstack.js.git
-RUN cd blockstack.js && npm i && npm run build && npm ln
+# Install node apps
 
-# Install requirements for running the transaction broadcaster service
+# Blockstack.js
+ADD https://api.github.com/repos/blockstack/blockstack.js/git/refs/heads/master blockstackjs-version.json
+RUN cd /src/ && git clone https://github.com/blockstack/blockstack.js.git
+RUN cd /src/blockstack.js && npm i && npm run build && npm i . -g
+
+# Transaction broadcaster
 ADD https://api.github.com/repos/blockstack/transaction-broadcaster/git/refs/heads/master broadcaster-version.json
-RUN git clone https://git@github.com/blockstack/transaction-broadcaster.git
-RUN cd transaction-broadcaster && npm i && npm ln blockstack && npm run build
+RUN cd /src/ && git clone https://github.com/blockstack/transaction-broadcaster.git
+RUN cd /src/transaction-broadcaster && npm i && npm run build && npm i . -g
 
-# And requirements for running the subdomain registrar service
-ADD https://api.github.com/repos/blockstack/subdomain-registrar/git/refs/heads/master subdomain-version.json
-RUN git clone https://git@github.com/blockstack/subdomain-registrar.git
-RUN cd subdomain-registrar && npm i && npm ln blockstack && npm run build
+# CLI
+ADD https://api.github.com/repos/blockstack/cli-blockstack/git/refs/heads/master cli-version.json
+RUN cd /src/ && git clone https://github.com/blockstack/cli-blockstack.git
+RUN cd /src/cli-blockstack && npm i && npm ln blockstack && npm run build && npm i . -g
 
-# Install pyparsing
-RUN pip install pyparsing
+# Gaia hub
 
-# Build blockstack first
-WORKDIR /src/blockstack
+ADD https://api.github.com/repos/blockstack/gaia/git/refs/heads/master gaia-hub-version.json
+RUN cd /src/ && git clone https://github.com/blockstack/gaia.git
+RUN cd /src/gaia/hub && npm i && npm run build && npm i . -g
+
+# Subdomain registrar
+
+ADD https://api.github.com/repos/blockstack/subdomain-registrar/git/refs/heads/master registrar-version.json
+RUN cd /src/ && git clone https://github.com/blockstack/subdomain-registrar
+RUN cd /src/subdomain-registrar && npm i && npm run build && npm i . -g
+
 
 # Copy all files from the repo into the container
 COPY . .
 
+# Upgrade pip and install pyparsing
+RUN pip install pyparsing
+
 # Install Blockstack from source
-RUN pip install .
-
-# Change into the tests directory
-WORKDIR /src/blockstack/integration_tests
-
-RUN pip install .
+RUN pip install . --upgrade
+RUN pip install ./integration_tests --upgrade


### PR DESCRIPTION
This updates the integration test dockerfile so that it can be used with the current integration tests:

Example:
```bash
docker build . --file integration_tests/deployment/docker/Dockerfile.tests --tag blockstack-core:tests
docker run -it blockstack-core:tests blockstack-test-scenario blockstack_integration_tests.scenarios.name_pre_regup_subdomain
```

