### PR TITLE
For client.getinfo, use env var if set

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -60,7 +60,7 @@ MONGODB_URI = os.getenv('MONGODB_URI', "mongodb://localhost")
 BASE_API_URL = os.getenv('BASE_API_URL', "http://localhost:6270")
 
 # INDEXER_API_URL sets the blockstack indexer daemon connection string (used only for testing at the moment)
-BASE_INDEXER_API_URL = os.getenv('BASE_INDEXER_API_URL', 'http://localhost:6264')
+BASE_INDEXER_API_URL = os.getenv('BASE_INDEXER_API_URL', None)
 
 # PUBLIC_NODE_URL controls the what hostname is returned to clients
 PUBLIC_NODE_URL = os.getenv('PUBLIC_NODE_URL', 'https://core.example.org')

--- a/api/resolver.py
+++ b/api/resolver.py
@@ -62,6 +62,11 @@ else:
 
 blockstack_indexer_url = BASE_INDEXER_API_URL
 
+if blockstack_indexer_url is None:
+    blockstack_working_dir = blockstack.lib.config.default_working_dir()
+    blockstack_config = blockstack.lib.load_configuration(blockstack_working_dir)
+    blockstack_indexer_url = blockstack_config['blockstack-api']['indexer_url']
+
 # copied and patched from proofs.py
 def site_data_to_fixed_proof_url(account, zonefile):
     service = account['service']

--- a/api/server.py
+++ b/api/server.py
@@ -38,7 +38,7 @@ from flask_crossdomain import crossdomain
 
 from .parameters import parameters_required
 from .utils import get_api_calls, cache_control
-from .config import PUBLIC_NODE, PUBLIC_NODE_URL, BASE_API_URL, DEFAULT_CACHE_TIMEOUT
+from .config import PUBLIC_NODE, PUBLIC_NODE_URL, BASE_API_URL, BASE_INDEXER_API_URL, DEFAULT_CACHE_TIMEOUT
 from .config import SEARCH_NODE_URL, SEARCH_API_ENDPOINT_ENABLED
 
 # hack around absolute paths
@@ -50,9 +50,12 @@ sys.path.insert(0, parent_dir)
 import blockstack
 import virtualchain
 
-blockstack_working_dir = blockstack.lib.config.default_working_dir()
-blockstack_config = blockstack.lib.load_configuration(blockstack_working_dir)
-blockstack_indexer_url = blockstack_config['blockstack-api']['indexer_url']
+blockstack_indexer_url = BASE_INDEXER_API_URL
+
+if blockstack_indexer_url is None:
+    blockstack_working_dir = blockstack.lib.config.default_working_dir()
+    blockstack_config = blockstack.lib.load_configuration(blockstack_working_dir)
+    blockstack_indexer_url = blockstack_config['blockstack-api']['indexer_url']
 
 log = virtualchain.get_logger()
 


### PR DESCRIPTION
For the `getInfo` call used to fill the information on the core.blockstack landing page, use the BASE_INDEXER_API_URL if set. If not, read from blockstack-server config file (existing behavior).