### PR TITLE
Fix PyMongo's Anger at UWSGI

### DIFF
--- a/api/deployment/blockstack_api.ini
+++ b/api/deployment/blockstack_api.ini
@@ -15,3 +15,5 @@ vacuum = true
 
 die-on-term = true
 close-on-exec = true
+
+lazy-apps = true


### PR DESCRIPTION
PyMongo and UWSGI don't get along very well -- see this thread for more information:

https://jira.mongodb.org/browse/PYTHON-1497

So instead we'll only load the application post-fork (this guarantees that the PyMongo instance is initialized post-fork).

This led to some intermittent performance problems in our search endpoint. Tested via pointing our standard monitoring routines at a test-endpoint (thanks @wileyj !)
