### PR TITLE
Set low cache on empty result

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -41,6 +41,8 @@ MAX_PROFILE_LIMIT = int(os.getenv('MAX_PROFILE_LIMIT','8142'))           # (8 * 
 # DEFAULT_CACHE_TIMEOUT determines the
 DEFAULT_CACHE_TIMEOUT = int(os.getenv('DEFAULT_CACHE_TIMEOUT','43200'))  # 12 hours in seconds
 
+EMPTY_CACHE_TIMEOUT = int(os.getenv('EMPTY_CACHE_TIMEOUT','60'))  # 1 minute
+
 # DEBUG increases logging verbosity
 DEBUG = str2bool(os.getenv('DEBUG','False'))
 

--- a/api/search/server.py
+++ b/api/search/server.py
@@ -165,6 +165,7 @@ def search_by_name():
 
     resp.headers['Cache-Control'] = 'public, max-age={:d}'.format(cache_timeout)
 
+    return resp
 
 def search_proofs_index(query):
 

--- a/api/search/server.py
+++ b/api/search/server.py
@@ -31,7 +31,7 @@ from time import time
 from flask import request, jsonify, make_response, render_template, Blueprint
 from flask_crossdomain import crossdomain
 
-from api.config import DEFAULT_HOST, DEFAULT_PORT, DEBUG, DEFAULT_CACHE_TIMEOUT
+from api.config import DEFAULT_HOST, DEFAULT_PORT, DEBUG, DEFAULT_CACHE_TIMEOUT, EMPTY_CACHE_TIMEOUT
 from api.config import SEARCH_DEFAULT_LIMIT as DEFAULT_LIMIT
 
 from .substring_search import search_people_by_name, search_people_by_twitter
@@ -159,9 +159,9 @@ def search_by_name():
 
     resp = make_response(jsonify(results))
     if len(results['results']) > 0:
-        cache_timeout = DEFAULT_CACHE_TIMEOUT)
+        cache_timeout = DEFAULT_CACHE_TIMEOUT
     else:
-        cache_timeout = 60
+        cache_timeout = EMPTY_CACHE_TIMEOUT
 
     resp.headers['Cache-Control'] = 'public, max-age={:d}'.format(cache_timeout)
 

--- a/api/search/server.py
+++ b/api/search/server.py
@@ -33,7 +33,6 @@ from flask_crossdomain import crossdomain
 
 from api.config import DEFAULT_HOST, DEFAULT_PORT, DEBUG, DEFAULT_CACHE_TIMEOUT
 from api.config import SEARCH_DEFAULT_LIMIT as DEFAULT_LIMIT
-from api.utils import cache_control
 
 from .substring_search import search_people_by_name, search_people_by_twitter
 from .substring_search import search_people_by_username, search_people_by_bio
@@ -101,7 +100,6 @@ def test_alphanumeric(query):
 
 @searcher.route('/search', methods = ["GET", "POST"], strict_slashes = False)
 @crossdomain(origin='*')
-@cache_control(DEFAULT_CACHE_TIMEOUT)
 def search_by_name():
 
     query = request.args.get('query')
@@ -159,7 +157,13 @@ def search_by_name():
     results = {}
     results['results'] = results_people[:new_limit]
 
-    return jsonify(results)
+    resp = make_response(jsonify(results))
+    if len(results['results']) > 0:
+        cache_timeout = DEFAULT_CACHE_TIMEOUT)
+    else:
+        cache_timeout = 60
+
+    resp.headers['Cache-Control'] = 'public, max-age={:d}'.format(cache_timeout)
 
 
 def search_proofs_index(query):


### PR DESCRIPTION
This sets a low (60 second) cache timeout for empty result sets from the search endpoint.

You can test this by running:

```
DEBUG=True FLASK_APP=api.server EMPTY_CACHE_TIMEOUT=30 DEFAULT_CACHE_TIMEOUT=80 python -m flask run
```

With a mongo server running locally (and search data in the mongo instance):

```
curl http://127.0.0.1:5000/v1/search?query=NoResultExpected -I | grep Cache
Cache-Control: public, max-age=30
```

```
curl http://127.0.0.1:5000/v1/search?query=ResultExpected -I | grep Cache
Cache-Control: public, max-age=80
```


This uses the ENV variable `EMPTY_CACHE_TIMEOUT` to control this behavior.