### PR TITLE
Add CircleCI definition for Rust implementation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,5 +10,8 @@ jobs:
           command: |
             cargo build
       - run:
+          environment:
+            RUST_BACKTRACE: 1
+            BLOCKSTACK_DEBUG: 1
           command: |
-            cargo test
+            cargo test -- --nocapture --test-threads=1

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/blockstack
+    docker:
+      - image: circleci/rust
+    steps:
+      - checkout
+      - run:
+          command: |
+            cargo build
+      - run:
+          command: |
+            cargo test


### PR DESCRIPTION
This adds a pretty simple CircleCI definition for the rust -- it just runs `cargo test` unit tests (there currently aren't any).

