### PR TITLE
Hotfix to set account history cache to 1 minute

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -110,13 +110,15 @@ def search_people():
 
 CACHE_SPECIFIC = [ re.compile(regex) for regex in
                    [r'^/v1/node/ping/?$',
+                    r'^/v1/accounts/[\w\.]+/history/?$',
                     r'^/v1/blockchains/bitcoin/consensus/?$',
                     r'^/v1/names/[\w\.]+/?$'] ]
 
 SPECIFIED = {
     0 : 'public, max-age=30',
-    1 : 'public, max-age=30',
-    2 : 'public, max-age=300' }
+    1 : 'public, max-age=60',
+    2 : 'public, max-age=30',
+    3 : 'public, max-age=300' }
 
 
 @app.route('/<path:path>', methods=['GET'])


### PR DESCRIPTION
This simply tweaks the account history cache specification to 1 minute.

I kind of dislike the fact that this kind of change requires repo commits.

I could add support for a config file here.