### PR TITLE
Add /v1/index_files endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -56,4 +56,9 @@ SEARCH_DEFAULT_LIMIT=50
 
 # BSK_API_TMPLTDIR sets the path to the generated documentation for serving
 BSK_API_TMPLTDIR=/src/blockstack/api/templates
+
+# BSK_API_BLOCKCHAIN_URL and BSK_API_PROFILE_URL specify URLs for
+#  fetching index file dumps from /v1/index_files/blockchain and /v1/index_files/profiles
+BSK_API_BLOCKCHAIN_URL="https://storage.googleapis.com/blockstack-search_indexer_data/blockchain_data.json"
+BSK_API_PROFILE_URL="https://storage.googleapis.com/blockstack-search_indexer_data/profile_data.json"
 ```

--- a/api/config.py
+++ b/api/config.py
@@ -73,6 +73,10 @@ SEARCH_NODE_URL = os.getenv('SEARCH_NODE_URL', 'https://search.example.org')
 # SEARCH_DEFAULT_LIMIT sets the number of returns per call
 SEARCH_DEFAULT_LIMIT = int(os.getenv('SEARCH_DEFAULT_LIMIT', '50'))
 
+# Control response to /v1/index_files
+API_BLOCKCHAIN_URL = os.getenv('BSK_API_BLOCKCHAIN_URL', '')
+API_PROFILE_URL = os.getenv('BSK_API_PROFILE_URL', '')
+
 # For the resolver endpoint
 NAMES_FILENAME = "names.json"
 NEW_NAMES_FILENAME = 'new_names.json'

--- a/api/server.py
+++ b/api/server.py
@@ -114,14 +114,26 @@ def search_people():
 
     return jsonify(data), 200
 
-@app.route('/v1/index_files', methods=['GET'])
+@app.route('/v1/index_files/blockchain', methods=['GET'])
 @cache_control(10*60)
 @crossdomain(origin='*')
-def fetch_index_files():
+def fetch_index_blockchain_files():
     if API_BLOCKCHAIN_URL and API_PROFILE_URL:
-        response = { 'indexes': { 'profileData': API_PROFILE_URL,
-                                  'blockchainData': API_BLOCKCHAIN_URL } }
-        return jsonify(response), 200
+        response = make_response((jsonify({ 'blockchainData': API_BLOCKCHAIN_URL }), 302))
+        response.headers['Location'] = API_BLOCKCHAIN_URL
+        return response
+    else:
+        err = { 'error': 'Index file serving not configured on this server.' }
+        return jsonify(err), 404
+
+@app.route('/v1/index_files/profiles', methods=['GET'])
+@cache_control(10*60)
+@crossdomain(origin='*')
+def fetch_index_profile_files():
+    if API_BLOCKCHAIN_URL and API_PROFILE_URL:
+        response = make_response((jsonify({ 'profileData': API_PROFILE_URL }), 302))
+        response.headers['Location'] = API_PROFILE_URL
+        return response
     else:
         err = { 'error': 'Index file serving not configured on this server.' }
         return jsonify(err), 404

--- a/api/server.py
+++ b/api/server.py
@@ -38,7 +38,7 @@ from flask_crossdomain import crossdomain
 from .parameters import parameters_required
 from .utils import get_api_calls, cache_control
 from .config import PUBLIC_NODE, PUBLIC_NODE_URL, BASE_API_URL, BASE_INDEXER_API_URL, DEFAULT_CACHE_TIMEOUT
-from .config import SEARCH_NODE_URL, SEARCH_API_ENDPOINT_ENABLED
+from .config import SEARCH_NODE_URL, SEARCH_API_ENDPOINT_ENABLED, API_BLOCKCHAIN_URL, API_PROFILE_URL
 
 # hack around absolute paths
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -113,6 +113,18 @@ def search_people():
         data = {'results': []}
 
     return jsonify(data), 200
+
+@app.route('/v1/index_files', methods=['GET'])
+@cache_control(10*60)
+@crossdomain(origin='*')
+def fetch_index_files():
+    if API_BLOCKCHAIN_URL and API_PROFILE_URL:
+        response = { 'indexes': { 'profileData': API_PROFILE_URL,
+                                  'blockchainData': API_BLOCKCHAIN_URL } }
+        return jsonify(response), 200
+    else:
+        err = { 'error': 'Index file serving not configured on this server.' }
+        return jsonify(err), 404
 
 CACHE_SPECIFIC = [ re.compile(regex) for regex in
                    [r'^/v1/node/ping/?$',

--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -2244,6 +2244,34 @@ Searches for a profile using a search string.
                  }
             }
 
+
+## Get Profile Index Data [GET /v1/index_files/profiles]
+
+Returns a 302 redirect to a data dump of the profiles indexed by the search indexer.
+If not configured by the server, it returns a 404.
+
++ Public Endpoint
++ Response 302 (application/json)
+  + Body
+  
+             {
+                "profileData": "https://storage.googleapis.com/blockstack-search_indexer_data/profile_data.json"
+             }
+
+## Get Profile Index Data [GET /v1/index_files/blockchain]
+
+Returns a 302 redirect to a data dump of the blockchain names indexed by the search indexer.
+If not configured by the server, it returns a 404.
+
++ Public Endpoint
++ Response 302 (application/json)
+  + Body
+  
+             {
+                "blockchainData": "https://storage.googleapis.com/blockstack-search_indexer_data/blockchain_data.json"
+             }
+
+
 ## Resolve DID [GET /v1/dids/{did}]
 Resolve a Blockstack DID to its DID document object (DDO).  In practice, the DDO
 is stored in the same way as a user profile, but a few extra DDO-specific


### PR DESCRIPTION
Implements #901 ---

This adds a new endpoint: `/v1/index_files`, which can be configured to return URLs for getting search index dumps. By default (if left unconfigured), this returns 404.

You can test this behavior locally:

```bash
$ cd blockstack-core
$ pip install .
$ pip install -r ./api/requirements.txt
$ FLASK_APP=api.server flask run
```

Then:

```http
$ curl localhost:5000/v1/index_files -v
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET /v1/index_files HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.58.0
> Accept: */*
> 
* HTTP 1.0, assume close after body
< HTTP/1.0 404 NOT FOUND
< Content-Type: application/json
< Content-Length: 62
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: OPTIONS, HEAD, POST, GET
< Access-Control-Max-Age: 21600
< Cache-Control: public, max-age=600
< Server: Werkzeug/0.14.1 Python/2.7.15rc1
< Date: Fri, 01 Feb 2019 15:05:22 GMT
< 
{"error":"Index file serving not configured on this server."}
```

If you set the environment variables when running:

```bash
$ export BSK_API_BLOCKCHAIN_URL="https://storage.googleapis.com/blockstack-search_indexer_data/blockchain_data.json"
$ export BSK_API_PROFILE_URL="https://storage.googleapis.com/blockstack-search_indexer_data/profile_data.json"
$ FLASK_APP=api.server flask run
```

Then you should see the response:

```json
$ curl localhost:5000/v1/index_files -v
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET /v1/index_files HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.58.0
> Accept: */*
> 
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Content-Type: application/json
< Content-Length: 212
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: OPTIONS, HEAD, POST, GET
< Access-Control-Max-Age: 21600
< Cache-Control: public, max-age=600
< Server: Werkzeug/0.14.1 Python/2.7.15rc1
< Date: Fri, 01 Feb 2019 15:06:27 GMT
< 
{
  "indexes": {
    "blockchainData": "https://storage.googleapis.com/blockstack-search_indexer_data/blockchain_data.json",
    "profileData": "https://storage.googleapis.com/blockstack-search_indexer_data/profile_data.json"
  }
}
```