### PR TITLE
Peer network code review 2/18/2019

### DIFF
--- a/src/chainstate/burn/db/mod.rs
+++ b/src/chainstate/burn/db/mod.rs
@@ -35,7 +35,7 @@ use burnchains::{Txid, BurnchainHeaderHash, Address};
 use util::vrf::ECVRF_check_public_key;
 use util::hash::{hex_bytes, Hash160};
 
-use chainstate::burn::{ConsensusHash, VRFSeed, BlockHeaderHash, OpsHash};
+use chainstate::burn::{ConsensusHash, VRFSeed, BlockHeaderHash, OpsHash, SortitionHash};
 
 use ed25519_dalek::PublicKey as VRFPublicKey;
 
@@ -144,6 +144,7 @@ impl_byte_array_from_row!(BlockHeaderHash);
 impl_byte_array_from_row!(VRFSeed);
 impl_byte_array_from_row!(OpsHash);
 impl_byte_array_from_row!(BurnchainHeaderHash);
+impl_byte_array_from_row!(SortitionHash);
 
 #[allow(non_snake_case)]
 pub fn VRFPublicKey_from_row<'a>(row: &'a Row, index: usize) -> Result<VRFPublicKey, db_error> {

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -1,0 +1,827 @@
+/*
+ copyright: (c) 2013-2018 by Blockstack PBC, a public benefit corporation.
+
+ This file is part of Blockstack.
+
+ Blockstack is free software. You may redistribute or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License or
+ (at your option) any later version.
+
+ Blockstack is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, including without the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use std::collections::BTreeMap;
+
+use chainstate::burn::operations::BlockstackOperationType;
+use chainstate::burn::operations::leader_key_register::LeaderKeyRegisterOp;
+use chainstate::burn::operations::leader_block_commit::LeaderBlockCommitOp;
+use chainstate::burn::operations::user_burn_support::UserBurnSupportOp;
+
+use burnchains::Address;
+use burnchains::PublicKey;
+use burnchains::Burnchain;
+
+use util::hash::Hash160;
+use util::uint::Uint256;
+use util::uint::Uint512;
+use util::uint::BitArray;
+use util::vrf::ECVRF_public_key_to_hex;
+
+use util::log;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BurnSamplePoint<A, K>
+where
+    A: Address,
+    K: PublicKey
+{
+    pub burns: u128,
+    pub range_start: Uint256,
+    pub range_end: Uint256,
+    pub candidate: LeaderBlockCommitOp<A, K>,
+    pub key: LeaderKeyRegisterOp<A, K>,
+    pub user_burns: Vec<UserBurnSupportOp<A, K>>
+}
+
+impl<A, K> BurnSamplePoint<A, K>
+where
+    A: Address,
+    K: PublicKey
+{
+   
+    /// Make a burn distribution -- a list of (burn total, block candidate) pairs -- from a block's
+    /// block commits, leader keys, and user support burns.
+    ///
+    /// All operations need to be from the same block height, or this method panics.
+    ///
+    /// Returns the distribution, which consumes the given lists of operations.
+    pub fn make_distribution(block_candidates: Vec<LeaderBlockCommitOp<A, K>>, consumed_leader_keys: Vec<LeaderKeyRegisterOp<A,K>>, user_burns: Vec<UserBurnSupportOp<A, K>>) -> Vec<BurnSamplePoint<A, K>> {
+        // trivial case
+        if block_candidates.len() == 0 {
+            return vec![];
+        }
+
+        BurnSamplePoint::ops_sanity_checks(&block_candidates, &consumed_leader_keys, &user_burns);
+
+        // map each leader key's position in the blockchain to its index in consumed_leader_keys.
+        // The DB will ensure that there are no duplicates.
+        let mut key_index : BTreeMap<(u64, u32), usize> = BTreeMap::new();
+        for i in 0..consumed_leader_keys.len() {
+            let key_loc = (consumed_leader_keys[i].block_number, consumed_leader_keys[i].vtxindex);
+            assert!(key_index.get(&key_loc).is_none());
+
+            key_index.insert(key_loc, i);
+        }
+
+        // consume block candidates and leader keys to produce the list of burn sample points
+        let mut burn_sample : Vec<BurnSamplePoint<A, K>> = block_candidates
+            .into_iter()
+            .map(|bc| {
+                let key_idx_opt = key_index.get(&(bc.block_number - (bc.key_block_backptr as u64), bc.key_vtxindex as u32));
+                if key_idx_opt.is_none() {
+                    // should never happen -- the DB only accepts a leader block commitment if it
+                    // matches a corresponding VRF public key 
+                    panic!("No leader key for block commitment {} (at {},{}) -- points to ({},{})", 
+                           &bc.txid.to_hex(), bc.block_number, bc.vtxindex, bc.block_number - (bc.key_block_backptr as u64), bc.key_vtxindex);
+                }
+                let key_idx = key_idx_opt.unwrap();
+
+                BurnSamplePoint {
+                    burns: bc.burn_fee as u128,     // Initial burn weight is the block commitment's burn
+                    range_start: Uint256::zero(),   // To be filled in
+                    range_end: Uint256::zero(),     // To be filled in
+                    candidate: bc,
+                    key: consumed_leader_keys[*key_idx].clone(),
+                    user_burns: vec![]
+                }
+            })
+            .collect();
+
+        // assign user burns to the burn sample points 
+        BurnSamplePoint::apply_user_burns(&mut burn_sample, user_burns);
+
+        // calculate burn ranges 
+        BurnSamplePoint::make_sortition_ranges(&mut burn_sample);
+        burn_sample
+    }
+    
+    // sanity checks for making a burn distribution
+    fn ops_sanity_checks(block_candidates: &Vec<LeaderBlockCommitOp<A, K>>, consumed_leader_keys: &Vec<LeaderKeyRegisterOp<A,K>>, user_burns: &Vec<UserBurnSupportOp<A, K>>) -> () {
+        // sanity checks
+        if block_candidates.len() != consumed_leader_keys.len() {
+            panic!("FATAL ERROR: {} block candidates != {} leader keys", block_candidates.len(), consumed_leader_keys.len());
+        }
+
+        let block_height = block_candidates[0].block_number;
+        for i in 1..block_candidates.len() {
+            if block_candidates[i].block_number != block_height {
+                panic!("FATAL ERROR: block commit {} is at ({},{}) not {}", &block_candidates[i].txid.to_hex(), block_candidates[i].block_number, block_candidates[i].vtxindex, block_height);
+            }
+        }
+
+        for i in 0..user_burns.len() {
+            if user_burns[i].block_number != block_height {
+                panic!("FATAL ERROR: user burn {} is at ({},{}) not {}", &user_burns[i].txid.to_hex(), user_burns[i].block_number, user_burns[i].vtxindex, block_height);
+            }
+        }
+
+        return;
+    }
+
+    /// Move a list of user burns into their burn sample points.
+    fn apply_user_burns(burn_sample: &mut Vec<BurnSamplePoint<A, K>>, user_burns: Vec<UserBurnSupportOp<A, K>>) -> () {
+        // map each burn sample's (VRF public key, block hash 160) pair to its index.
+        // The pair will be unique, since the DB requires each VRF key to be unique.
+        // Hovever, the block hash 160 is not guaranteed to be unique -- two different
+        // leaders can burn for the same block.
+        let mut burn_index : BTreeMap<(String, Hash160), usize> = BTreeMap::new();
+        for i in 0..burn_sample.len() {
+            let block_header_hash_160 = Hash160::from_sha256(&burn_sample[i].candidate.block_header_hash.as_bytes());
+            let vrf_hex = ECVRF_public_key_to_hex(&burn_sample[i].key.public_key);
+            assert!(burn_index.get(&(vrf_hex.clone(), block_header_hash_160)).is_none());
+
+            burn_index.insert((vrf_hex, block_header_hash_160), i);
+        }
+
+        // match user burns to the leaders
+        for user_burn in user_burns {
+            let block_idx_opt = burn_index.get(&(ECVRF_public_key_to_hex(&user_burn.public_key), user_burn.block_header_hash_160));
+            match block_idx_opt {
+                Some(ref_block_idx) => {
+                    // user burn matches a (key, block) pair committed to in this block
+                    let idx = *ref_block_idx;
+                    burn_sample[idx].burns += (user_burn.burn_fee as u128);
+                    burn_sample[idx].user_burns.push(user_burn);
+                },
+                None => {
+                    info!("User burn {} ({},{}) of {} for key={}, block={} has no matching block commit",
+                          &user_burn.txid.to_hex(), user_burn.block_number, user_burn.vtxindex, user_burn.burn_fee,
+                          ECVRF_public_key_to_hex(&user_burn.public_key), &user_burn.block_header_hash_160.to_hex());
+                    continue;
+                }
+            };
+        }
+    }
+
+    /// Calculate the ranges between 0 and 2**256 - 1 over which each point in the burn sample
+    /// applies, so we can later select which block to use.
+    fn make_sortition_ranges(burn_sample: &mut Vec<BurnSamplePoint<A, K>>) -> () {
+        if burn_sample.len() == 0 {
+            // empty sample
+            return;
+        }
+        if burn_sample.len() == 1 {
+            // sample that covers the whole range 
+            burn_sample[0].range_start = Uint256::zero();
+            burn_sample[0].range_end = Uint256::max();
+            return;
+        }
+
+        // total burns for valid blocks?
+        // NOTE: this can't overflow -- there's no way we get that many (u64) burns
+        let total_burns_u128: u128 = burn_sample
+            .iter()
+            .fold(0u128, |mut total_burns, sample| {
+                total_burns = total_burns + (sample.burns as u128);
+                total_burns
+            });
+
+        let total_burns = Uint512::from_u128(total_burns_u128);
+
+        // determine range start/end for each sample.
+        // Use fixed-point math on an unsigned 512-bit number -- 
+        //   * the upper 256 bits are the integer
+        //   * the lower 256 bits are the fraction
+        // These range fields correspond to ranges in the 32-byte hash space
+        let mut burn_acc = Uint512::from_u128(burn_sample[0].burns);
+
+        burn_sample[0].range_start = Uint256::zero();
+        burn_sample[0].range_end = ((Uint512::from_uint256(&Uint256::max()) * burn_acc) / total_burns).to_uint256();
+        for i in 1..burn_sample.len() {
+            burn_sample[i].range_start = burn_sample[i-1].range_end;
+            
+            burn_acc = burn_acc + Uint512::from_u128(burn_sample[i].burns);
+            burn_sample[i].range_end = ((Uint512::from_uint256(&Uint256::max()) * burn_acc) / total_burns).to_uint256();
+        }
+
+        for i in 0..burn_sample.len() {
+            test_debug!("Range for block {}: {} / {}: {} - {}", burn_sample[i].candidate.block_header_hash.to_hex(), burn_sample[i].burns, total_burns_u128, burn_sample[i].range_start, burn_sample[i].range_end);
+        }
+    }
+
+    /// Calculate the total amount of crypto destroyed in this burn distribution.
+    /// Returns None if there was an overflow.
+    pub fn get_total_burns(burn_dist: &Vec<BurnSamplePoint<A, K>>) -> Option<u64> {
+        let block_burn_total_u128 : u128 = burn_dist
+            .iter()
+            .fold(0u128, |mut burns_so_far, sample_point| {
+                burns_so_far += sample_point.burns;
+                burns_so_far
+            });
+
+        // check overflow
+        if block_burn_total_u128 >= 0xffffffffffffffff {
+            error!("Excessive burn size {}", block_burn_total_u128);
+            return None;
+        }
+        let block_burn_total = block_burn_total_u128 as u64;
+        Some(block_burn_total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BurnSamplePoint;
+
+    use std::marker::PhantomData;
+
+    use burnchains::Address;
+    use burnchains::PublicKey;
+    use burnchains::Burnchain;
+    use burnchains::BurnchainTxInput;
+    use burnchains::BurnchainInputType;
+
+    use chainstate::burn::operations::leader_key_register::LeaderKeyRegisterOp;
+    use chainstate::burn::operations::leader_block_commit::LeaderBlockCommitOp;
+    use chainstate::burn::operations::user_burn_support::UserBurnSupportOp;
+    use chainstate::burn::operations::leader_block_commit::OPCODE as LeaderBlockCommitOpcode;
+    use chainstate::burn::operations::leader_key_register::OPCODE as LeaderKeyRegisterOpcode;
+    use chainstate::burn::operations::user_burn_support::OPCODE as UserBurnSupportOpcode;
+
+    use burnchains::bitcoin::address::BitcoinAddress;
+    use burnchains::bitcoin::keys::BitcoinPublicKey;
+    use burnchains::bitcoin::BitcoinNetworkType;
+    
+    use burnchains::{Txid, BurnchainHeaderHash};
+    use chainstate::burn::{ConsensusHash, VRFSeed, BlockHeaderHash};
+    use util::hash::hex_bytes;
+    use ed25519_dalek::PublicKey as VRFPublicKey;
+
+    use util::hash::Hash160;
+    use util::uint::Uint256;
+    use util::uint::Uint512;
+    use util::uint::BitArray;
+    use util::vrf::ECVRF_public_key_to_hex;
+
+    use util::log;
+
+    struct BurnDistFixture {
+        consumed_leader_keys: Vec<LeaderKeyRegisterOp<BitcoinAddress, BitcoinPublicKey>>,
+        block_commits: Vec<LeaderBlockCommitOp<BitcoinAddress, BitcoinPublicKey>>,
+        user_burns: Vec<UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey>>,
+        res: Vec<BurnSamplePoint<BitcoinAddress, BitcoinPublicKey>>
+    }
+
+    #[test]
+    fn make_burn_distribution() {
+
+        let first_burn_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap();
+
+        let leader_key_1 : LeaderKeyRegisterOp<BitcoinAddress, BitcoinPublicKey> = LeaderKeyRegisterOp { 
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("2222222222222222222222222222222222222222").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: BitcoinAddress::from_scriptpubkey(BitcoinNetworkType::Testnet, &hex_bytes("76a9140be3e286a15ea85882761618e366586b5574100d88ac").unwrap()).unwrap(),
+
+            op: LeaderKeyRegisterOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1bfa831b5fc56c858198acb8e77e5863c1e9d8ac26d49ddb914e24d8d4083562").unwrap()).unwrap(),
+            vtxindex: 456,
+            block_number: 123,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap(),
+            
+            _phantom: PhantomData
+        };
+        
+        let leader_key_2 : LeaderKeyRegisterOp<BitcoinAddress, BitcoinPublicKey> = LeaderKeyRegisterOp { 
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("3333333333333333333333333333333333333333").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("bb519494643f79f1dea0350e6fb9a1da88dfdb6137117fc2523824a8aa44fe1c").unwrap()).unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: BitcoinAddress::from_scriptpubkey(BitcoinNetworkType::Testnet, &hex_bytes("76a91432b6c66189da32bd0a9f00ee4927f569957d71aa88ac").unwrap()).unwrap(),
+
+            op: LeaderKeyRegisterOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("9410df84e2b440055c33acb075a0687752df63fe8fe84aeec61abe469f0448c7").unwrap()).unwrap(),
+            vtxindex: 457,
+            block_number: 122,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000002").unwrap(),
+            
+            _phantom: PhantomData
+        };
+
+        let leader_key_3 : LeaderKeyRegisterOp<BitcoinAddress, BitcoinPublicKey> = LeaderKeyRegisterOp { 
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("3333333333333333333333333333333333333333").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("de8af7037e522e65d2fe2d63fb1b764bfea829df78b84444338379df13144a02").unwrap()).unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: BitcoinAddress::from_scriptpubkey(BitcoinNetworkType::Testnet, &hex_bytes("76a91432b6c66189da32bd0a9f00ee4927f569957d71aa88ac").unwrap()).unwrap(),
+
+            op: LeaderKeyRegisterOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("eb54704f71d4a2d1128d60ffccced547054b52250ada6f3e7356165714f44d4c").unwrap()).unwrap(),
+            vtxindex: 10,
+            block_number: 121,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000012").unwrap(),
+            
+            _phantom: PhantomData
+        };
+
+        let user_burn_noblock : UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey> = UserBurnSupportOp {
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("4444444444444444444444444444444444444444").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+            block_header_hash_160: Hash160::from_bytes(&hex_bytes("3333333333333333333333333333333333333333").unwrap()).unwrap(),
+            memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            burn_fee: 12345,
+
+            op: UserBurnSupportOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716c").unwrap()).unwrap(),
+            vtxindex: 12,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+            
+            _phantom_a: PhantomData,
+            _phantom_k: PhantomData
+        };
+
+        let user_burn_1 : UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey> = UserBurnSupportOp {
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("4444444444444444444444444444444444444444").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+            block_header_hash_160: Hash160::from_bytes(&hex_bytes("7150f635054b87df566a970b21e07030d6444bf2").unwrap()).unwrap(),       // 22222....2222
+            memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            burn_fee: 10000,
+
+            op: UserBurnSupportOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716c").unwrap()).unwrap(),
+            vtxindex: 13,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+            
+            _phantom_a: PhantomData,
+            _phantom_k: PhantomData
+        };
+        
+        let user_burn_1_2 : UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey> = UserBurnSupportOp {
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("4444444444444444444444444444444444444444").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+            block_header_hash_160: Hash160::from_bytes(&hex_bytes("7150f635054b87df566a970b21e07030d6444bf2").unwrap()).unwrap(),       // 22222....2222
+            memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            burn_fee: 30000,
+
+            op: UserBurnSupportOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716c").unwrap()).unwrap(),
+            vtxindex: 14,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+            
+            _phantom_a: PhantomData,
+            _phantom_k: PhantomData
+        };
+
+        let user_burn_2 : UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey> = UserBurnSupportOp {
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("4444444444444444444444444444444444444444").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("bb519494643f79f1dea0350e6fb9a1da88dfdb6137117fc2523824a8aa44fe1c").unwrap()).unwrap(),
+            block_header_hash_160: Hash160::from_bytes(&hex_bytes("037a1e860899a4fa823c18b66f6264d20236ec58").unwrap()).unwrap(),       // 22222....2223
+            memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            burn_fee: 20000,
+
+            op: UserBurnSupportOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716d").unwrap()).unwrap(),
+            vtxindex: 14,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+            
+            _phantom_a: PhantomData,
+            _phantom_k: PhantomData
+        };
+        
+        let user_burn_2_2 : UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey> = UserBurnSupportOp {
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("4444444444444444444444444444444444444444").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("bb519494643f79f1dea0350e6fb9a1da88dfdb6137117fc2523824a8aa44fe1c").unwrap()).unwrap(),
+            block_header_hash_160: Hash160::from_bytes(&hex_bytes("037a1e860899a4fa823c18b66f6264d20236ec58").unwrap()).unwrap(),       // 22222....2223
+            memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            burn_fee: 40000,
+
+            op: UserBurnSupportOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716c").unwrap()).unwrap(),
+            vtxindex: 15,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+            
+            _phantom_a: PhantomData,
+            _phantom_k: PhantomData
+        };
+
+        let user_burn_nokey : UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey> = UserBurnSupportOp {
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("4444444444444444444444444444444444444444").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("3f3338db51f2b1f6ac0cf6177179a24ee130c04ef2f9849a64a216969ab60e70").unwrap()).unwrap(),
+            block_header_hash_160: Hash160::from_bytes(&hex_bytes("037a1e860899a4fa823c18b66f6264d20236ec58").unwrap()).unwrap(),
+            memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            burn_fee: 12345,
+
+            op: UserBurnSupportOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716e").unwrap()).unwrap(),
+            vtxindex: 15,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+            
+            _phantom_a: PhantomData,
+            _phantom_k: PhantomData
+        };
+
+        let block_commit_1 : LeaderBlockCommitOp<BitcoinAddress, BitcoinPublicKey> = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(&hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap()).unwrap(),
+            new_seed: VRFSeed::from_bytes(&hex_bytes("3333333333333333333333333333333333333333333333333333333333333333").unwrap()).unwrap(),
+            parent_block_backptr: 123,
+            parent_vtxindex: 456,
+            key_block_backptr: 1,
+            key_vtxindex: 456,
+            epoch_num: 50,
+            memo: vec![0x80],
+
+            burn_fee: 12345,
+            input: BurnchainTxInput {
+                keys: vec![
+                    BitcoinPublicKey::from_hex("02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0").unwrap(),
+                ],
+                num_required: 1, 
+                in_type: BurnchainInputType::BitcoinInput,
+            },
+
+            op: 91,     // '[' in ascii
+            txid: Txid::from_bytes_be(&hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf").unwrap()).unwrap(),
+            vtxindex: 444,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+
+            _phantom: PhantomData
+        };        
+        
+        let block_commit_2 : LeaderBlockCommitOp<BitcoinAddress, BitcoinPublicKey> = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(&hex_bytes("2222222222222222222222222222222222222222222222222222222222222223").unwrap()).unwrap(),
+            new_seed: VRFSeed::from_bytes(&hex_bytes("3333333333333333333333333333333333333333333333333333333333333334").unwrap()).unwrap(),
+            parent_block_backptr: 123,
+            parent_vtxindex: 111,
+            key_block_backptr: 2,
+            key_vtxindex: 457,
+            epoch_num: 50,
+            memo: vec![0x80],
+
+            burn_fee: 12345,
+            input: BurnchainTxInput {
+                keys: vec![
+                    BitcoinPublicKey::from_hex("02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0").unwrap(),
+                ],
+                num_required: 1, 
+                in_type: BurnchainInputType::BitcoinInput,
+            },
+
+            op: 91,     // '[' in ascii
+            txid: Txid::from_bytes_be(&hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d0").unwrap()).unwrap(),
+            vtxindex: 445,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+
+            _phantom: PhantomData
+        };        
+        
+        let block_commit_3 : LeaderBlockCommitOp<BitcoinAddress, BitcoinPublicKey> = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(&hex_bytes("2222222222222222222222222222222222222222222222222222222222222224").unwrap()).unwrap(),
+            new_seed: VRFSeed::from_bytes(&hex_bytes("3333333333333333333333333333333333333333333333333333333333333335").unwrap()).unwrap(),
+            parent_block_backptr: 123,
+            parent_vtxindex: 111,
+            key_block_backptr: 3,
+            key_vtxindex: 10,
+            epoch_num: 50,
+            memo: vec![0x80],
+
+            burn_fee: 23456,
+            input: BurnchainTxInput {
+                keys: vec![
+                    BitcoinPublicKey::from_hex("02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0").unwrap(),
+                ],
+                num_required: 1, 
+                in_type: BurnchainInputType::BitcoinInput,
+            },
+
+            op: 91,     // '[' in ascii
+            txid: Txid::from_bytes_be(&hex_bytes("301dc687a9f06a1ae87a013f27133e9cec0843c2983567be73e185827c7c13de").unwrap()).unwrap(),
+            vtxindex: 445,
+            block_number: 124,
+            burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap(),
+
+            _phantom: PhantomData
+        };
+
+        /*
+         You can generate the burn sample ranges with this Python script:
+         #!/usr/bin/python
+
+         import sys
+
+         a = eval(sys.argv[1])
+         b = eval(sys.argv[2])
+
+         s = '{:0128x}'.format((a * (2**256 - 1)) / b).decode('hex')[::-1];
+         l = ['0x{:016x}'.format(int(s[(8*i):(8*(i+1))][::-1].encode('hex'),16)) for i in range(0,(256/8/8))]
+
+         print float(a) / b
+         print '{:0128x}'.format((a * (2**256 - 1)) / b)
+         print '[' + ', '.join(l) + ']'
+        */
+
+        let fixtures : Vec<BurnDistFixture> = vec![
+            BurnDistFixture {
+                consumed_leader_keys: vec![],
+                block_commits: vec![],
+                user_burns: vec![],
+                res: vec![],
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                ],
+                user_burns: vec![],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: block_commit_1.burn_fee.into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![]
+                    }
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                ],
+                user_burns: vec![],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: block_commit_1.burn_fee.into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![],
+                    },
+                    BurnSamplePoint {
+                        burns: block_commit_2.burn_fee.into(),
+                        range_start: Uint256([0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![],
+                    },
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                ],
+                user_burns: vec![
+                    user_burn_noblock.clone(),
+                ],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: block_commit_1.burn_fee.into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![],
+                    },
+                    BurnSamplePoint {
+                        burns: block_commit_2.burn_fee.into(),
+                        range_start: Uint256([0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![],
+                    },
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                ],
+                user_burns: vec![
+                    user_burn_nokey.clone(),
+                ],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: block_commit_1.burn_fee.into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![],
+                    },
+                    BurnSamplePoint {
+                        burns: block_commit_2.burn_fee.into(),
+                        range_start: Uint256([0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![],
+                    },
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                ],
+                user_burns: vec![
+                    user_burn_nokey.clone(),
+                    user_burn_noblock.clone(),
+                    user_burn_1.clone(),
+                ],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: (block_commit_1.burn_fee + user_burn_1.burn_fee).into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0x441d393138e5a796, 0xbada4a3d4046d839, 0xa24749933957018c, 0xa4e5f328cf38744d]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![
+                            user_burn_1.clone(),
+                        ],
+                    },
+                    BurnSamplePoint {
+                        burns: block_commit_2.burn_fee.into(),
+                        range_start: Uint256([0x441d393138e5a796, 0xbada4a3d4046d839, 0xa24749933957018c, 0xa4e5f328cf38744d]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![],
+                    },
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                ],
+                user_burns: vec![
+                    user_burn_nokey.clone(),
+                    user_burn_noblock.clone(),
+                    user_burn_1.clone(),
+                    user_burn_2.clone(),
+                ],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: (block_commit_1.burn_fee + user_burn_1.burn_fee).into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0x65db6527a5c06ed7, 0xfbf9725ae754dd80, 0xeafb8d991cf9964d, 0x6898693a2f1713b4]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![
+                            user_burn_1.clone(),
+                        ],
+                    },
+                    BurnSamplePoint {
+                        burns: (block_commit_2.burn_fee + user_burn_2.burn_fee).into(),
+                        range_start: Uint256([0x65db6527a5c06ed7, 0xfbf9725ae754dd80, 0xeafb8d991cf9964d, 0x6898693a2f1713b4]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![
+                            user_burn_2.clone()
+                        ],
+                    },
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                ],
+                user_burns: vec![
+                    user_burn_nokey.clone(),
+                    user_burn_noblock.clone(),
+                    user_burn_2_2.clone(),
+                    user_burn_1_2.clone(),
+                    user_burn_1.clone(),
+                    user_burn_2.clone(),
+                ],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: (block_commit_1.burn_fee + user_burn_1.burn_fee + user_burn_1_2.burn_fee).into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0xbc9e168afe8ad47e, 0xbbb6d3eb8d1be6c9, 0x45a410039d0a7dc5, 0x6b7815d84b0f9fc0]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![
+                            user_burn_1_2.clone(),
+                            user_burn_1.clone(),
+                        ],
+                    },
+                    BurnSamplePoint {
+                        burns: (block_commit_2.burn_fee + user_burn_2.burn_fee + user_burn_2_2.burn_fee).into(),
+                        range_start: Uint256([0xbc9e168afe8ad47e, 0xbbb6d3eb8d1be6c9, 0x45a410039d0a7dc5, 0x6b7815d84b0f9fc0]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![
+                            user_burn_2_2.clone(),
+                            user_burn_2.clone()
+                        ],
+                    },
+                ]
+            },
+            BurnDistFixture {
+                consumed_leader_keys: vec![
+                    leader_key_1.clone(),
+                    leader_key_2.clone(),
+                    leader_key_3.clone(),
+                ],
+                block_commits: vec![
+                    block_commit_1.clone(),
+                    block_commit_2.clone(),
+                    block_commit_3.clone(),
+                ],
+                user_burns: vec![
+                    user_burn_nokey.clone(),
+                    user_burn_noblock.clone(),
+                    user_burn_2_2.clone(),
+                    user_burn_1_2.clone(),
+                    user_burn_1.clone(),
+                    user_burn_2.clone(),
+                ],
+                res: vec![
+                    BurnSamplePoint {
+                        burns: (block_commit_1.burn_fee + user_burn_1.burn_fee + user_burn_1_2.burn_fee).into(),
+                        range_start: Uint256::zero(),
+                        range_end: Uint256([0xcb48ed15c5086a5c, 0x6b29682cfbe4089c, 0x4a30e732285c18c9, 0x5a7416b691bddbad]),
+                        candidate: block_commit_1.clone(),
+                        key: leader_key_1.clone(),
+                        user_burns: vec![
+                            user_burn_1_2.clone(),
+                            user_burn_1.clone(),
+                        ],
+                    },
+                    BurnSamplePoint {
+                        burns: (block_commit_2.burn_fee + user_burn_2.burn_fee + user_burn_2_2.burn_fee).into(),
+                        range_start: Uint256([0xcb48ed15c5086a5c, 0x6b29682cfbe4089c, 0x4a30e732285c18c9, 0x5a7416b691bddbad]),
+                        range_end: Uint256([0xa224e0451efa00f5, 0xa57394a7b38d5b1c, 0x6bfdbf24cdb0b617, 0xd777aa6d9e769e59]),
+                        candidate: block_commit_2.clone(),
+                        key: leader_key_2.clone(),
+                        user_burns: vec![
+                            user_burn_2_2.clone(),
+                            user_burn_2.clone()
+                        ],
+                    },
+                    BurnSamplePoint {
+                        burns: (block_commit_3.burn_fee).into(),
+                        range_start: Uint256([0xa224e0451efa00f5, 0xa57394a7b38d5b1c, 0x6bfdbf24cdb0b617, 0xd777aa6d9e769e59]),
+                        range_end: Uint256::max(),
+                        candidate: block_commit_3.clone(),
+                        key: leader_key_3.clone(),
+                        user_burns: vec![]
+                    },
+                ]
+            },
+        ];
+
+        for i in 0..fixtures.len() {
+            let f = &fixtures[i];
+            let dist = BurnSamplePoint::make_distribution(f.block_commits.iter().cloned().collect(), f.consumed_leader_keys.iter().cloned().collect(), f.user_burns.iter().cloned().collect());
+            assert_eq!(dist, f.res);
+        }
+    }
+}

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -20,6 +20,7 @@ use std::marker::PhantomData;
 
 use chainstate::burn::operations::BlockstackOperation;
 use chainstate::burn::operations::Error as op_error;
+use chainstate::burn::operations::CheckResult;
 use chainstate::burn::ConsensusHash;
 
 use chainstate::burn::db::DBConn;
@@ -30,6 +31,7 @@ use burnchains::Txid;
 use burnchains::Address;
 use burnchains::PublicKey;
 use burnchains::BurnchainHeaderHash;
+use burnchains::Burnchain;
 
 use util::hash::Hash160;
 use util::vrf::{ECVRF_check_public_key, ECVRF_public_key_to_hex};
@@ -168,11 +170,23 @@ where
         UserBurnSupportOp::<A, K>::parse_from_tx(block_height, block_hash, tx)
     }
 
-    fn check(&self, conn: &DBConn) -> Result<bool, op_error> {
+    fn check(&self, burnchain: &Burnchain, conn: &DBConn) -> Result<CheckResult, op_error> {
+
+        /////////////////////////////////////////////////////////////////
+        // Consensus hash must be recent and valid
+        /////////////////////////////////////////////////////////////////
+
+        let consensus_hash_recent = BurnDB::<A, K>::is_fresh_consensus_hash(conn, self.block_number, burnchain.consensus_hash_lifetime, &self.consensus_hash)
+            .map_err(op_error::DBError)?;
+
+        if !consensus_hash_recent {
+            warn!("Invalid user burn: invalid consensus hash {}", &self.consensus_hash.to_hex());
+            return Ok(CheckResult::UserBurnSupportBadConsensusHash);
+        }
+
         /////////////////////////////////////////////////////////////////////////////////////
-        // There must exist a previously-accepted LeaderKeyRegisterOp.  It may already be
-        // consumed by a LeaderBlockCommitOp by the time this transaction is processed,
-        // so we only check for the key's existence.
+        // There must exist a previously-accepted LeaderKeyRegisterOp that matches this 
+        // user support burn's VRF public key.
         /////////////////////////////////////////////////////////////////////////////////////
 
         let register_key_opt = BurnDB::<A, K>::get_leader_key_by_VRF_key(conn, &self.public_key)
@@ -180,10 +194,17 @@ where
 
         if register_key_opt.is_none() {
             warn!("Invalid user burn: no such leader VRF key {}", &ECVRF_public_key_to_hex(&self.public_key));
-            return Ok(false);
+            return Ok(CheckResult::UserBurnSupportNoLeaderKey);
         }
+        
+        /////////////////////////////////////////////////////////////////////////////////////
+        // The block hash can't be checked here -- the corresponding LeaderBlockCommitOp may
+        // not have been checked yet, so we don't know yet if it exists.  The sortition
+        // algorithm will carry out this check, and only consider user burns if they match
+        // a block commit and the commit's corresponding leader key.
+        /////////////////////////////////////////////////////////////////////////////////////
 
-        Ok(true)
+        Ok(CheckResult::UserBurnSupportOk)
     }
 }
 
@@ -197,18 +218,30 @@ mod tests {
 
     use burnchains::bitcoin::keys::BitcoinPublicKey;
     use burnchains::bitcoin::address::BitcoinAddress;
+    use burnchains::burnchain::get_burn_quota_config;
 
+    use chainstate::burn::operations::leader_key_register::LeaderKeyRegisterOp;
+    use chainstate::burn::operations::leader_key_register::OPCODE as LeaderKeyRegisterOpcode;
+
+    use chainstate::burn::{ConsensusHash, OpsHash, SortitionHash, BlockSnapshot};
+    use chainstate::burn::operations::CheckResult;
+    
     use bitcoin::network::serialize::deserialize;
     use bitcoin::blockdata::transaction::Transaction;
 
-    use chainstate::burn::ConsensusHash;
-    
     use util::hash::{hex_bytes, Hash160};
     use util::log;
+
+    use super::OPCODE as UserBurnSupportOpcode;
 
     struct OpFixture {
         txstr: String,
         result: Option<UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey>>
+    }
+
+    struct CheckFixture {
+        op: UserBurnSupportOp<BitcoinAddress, BitcoinPublicKey>,
+        res: CheckResult
     }
 
     fn make_tx(hex_str: &str) -> Result<Transaction, &'static str> {
@@ -287,6 +320,138 @@ mod tests {
                     assert!(false);
                 }
             };
+        }
+    }
+
+    #[test]
+    fn test_check() {
+        let first_block_height = 120;
+        let first_burn_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000123").unwrap();
+        
+        let block_122_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000002").unwrap();
+        let block_123_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000003").unwrap();
+        let block_124_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000004").unwrap();
+        let block_125_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000005").unwrap();
+        
+        let burnchain = Burnchain {
+            chain_name: "bitcoin".to_string(),
+            network_name: "testnet".to_string(),
+            working_dir: "/nope".to_string(),
+            burn_quota: get_burn_quota_config(&"bitcoin".to_string()).unwrap(),
+            consensus_hash_lifetime: 24
+        };
+        
+        let mut db : BurnDB<BitcoinAddress, BitcoinPublicKey> = BurnDB::connect_memory(first_block_height, &first_burn_hash).unwrap();
+
+        let leader_key_1 : LeaderKeyRegisterOp<BitcoinAddress, BitcoinPublicKey> = LeaderKeyRegisterOp { 
+            consensus_hash: ConsensusHash::from_bytes(&hex_bytes("0000000000000000000000000000000000000000").unwrap()).unwrap(),
+            public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: BitcoinAddress::from_scriptpubkey(BitcoinNetworkType::Testnet, &hex_bytes("76a9140be3e286a15ea85882761618e366586b5574100d88ac").unwrap()).unwrap(),
+
+            op: LeaderKeyRegisterOpcode,
+            txid: Txid::from_bytes_be(&hex_bytes("1bfa831b5fc56c858198acb8e77e5863c1e9d8ac26d49ddb914e24d8d4083562").unwrap()).unwrap(),
+            vtxindex: 456,
+            block_number: 123,
+            burn_header_hash: block_123_hash.clone(),
+            
+            _phantom: PhantomData
+        };
+        
+        // populate consensus hashes
+        {
+            let mut tx = db.tx_begin().unwrap();
+            for i in 0..10 {
+                let snapshot_row = BlockSnapshot {
+                    block_height: i + first_block_height,
+                    burn_header_hash: BurnchainHeaderHash::from_bytes(&[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,i as u8]).unwrap(),
+                    consensus_hash: ConsensusHash::from_bytes(&[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,i as u8]).unwrap(),
+                    ops_hash: OpsHash::from_bytes(&[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,i as u8]).unwrap(),
+                    total_burn: i,
+                    burn_quota: 0,
+                    sortition: true,
+                    sortition_hash: SortitionHash::initial(),
+                    winning_block_txid: Txid::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+                    winning_block_burn_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+                    canonical: true
+                };
+                BurnDB::<BitcoinAddress, BitcoinPublicKey>::insert_block_snapshot(&mut tx, &snapshot_row).unwrap();
+            }
+            
+            tx.commit();
+        }
+
+        {
+            let mut tx = db.tx_begin().unwrap();
+            BurnDB::<BitcoinAddress, BitcoinPublicKey>::insert_leader_key(&mut tx, &leader_key_1).unwrap();
+            tx.commit().unwrap();
+        }
+
+        let check_fixtures = vec![
+            CheckFixture {
+                // reject -- bad consensus hash
+                op: UserBurnSupportOp {
+                    consensus_hash: ConsensusHash::from_bytes(&hex_bytes("1000000000000000000000000000000000000000").unwrap()).unwrap(),
+                    public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+                    block_header_hash_160: Hash160::from_bytes(&hex_bytes("7150f635054b87df566a970b21e07030d6444bf2").unwrap()).unwrap(),       // 22222....2222
+                    memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+                    burn_fee: 10000,
+
+                    op: UserBurnSupportOpcode,
+                    txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716b").unwrap()).unwrap(),
+                    vtxindex: 13,
+                    block_number: 124,
+                    burn_header_hash: block_124_hash.clone(),
+                    
+                    _phantom_a: PhantomData,
+                    _phantom_k: PhantomData
+                },
+                res: CheckResult::UserBurnSupportBadConsensusHash,
+            },
+            CheckFixture {
+                // reject -- no leader key
+                op: UserBurnSupportOp {
+                    consensus_hash: ConsensusHash::from_bytes(&hex_bytes("0000000000000000000000000000000000000000").unwrap()).unwrap(),
+                    public_key: VRFPublicKey::from_bytes(&hex_bytes("bb519494643f79f1dea0350e6fb9a1da88dfdb6137117fc2523824a8aa44fe1c").unwrap()).unwrap(),
+                    block_header_hash_160: Hash160::from_bytes(&hex_bytes("7150f635054b87df566a970b21e07030d6444bf2").unwrap()).unwrap(),       // 22222....2222
+                    memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+                    burn_fee: 10000,
+
+                    op: UserBurnSupportOpcode,
+                    txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716b").unwrap()).unwrap(),
+                    vtxindex: 13,
+                    block_number: 124,
+                    burn_header_hash: block_124_hash.clone(),
+                    
+                    _phantom_a: PhantomData,
+                    _phantom_k: PhantomData
+                },
+                res: CheckResult::UserBurnSupportNoLeaderKey,
+            },
+            CheckFixture {
+                // accept 
+                op: UserBurnSupportOp {
+                    consensus_hash: ConsensusHash::from_bytes(&hex_bytes("0000000000000000000000000000000000000000").unwrap()).unwrap(),
+                    public_key: VRFPublicKey::from_bytes(&hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a").unwrap()).unwrap(),
+                    block_header_hash_160: Hash160::from_bytes(&hex_bytes("7150f635054b87df566a970b21e07030d6444bf2").unwrap()).unwrap(),       // 22222....2222
+                    memo: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+                    burn_fee: 10000,
+
+                    op: UserBurnSupportOpcode,
+                    txid: Txid::from_bytes_be(&hex_bytes("1d5cbdd276495b07f0e0bf0181fa57c175b217bc35531b078d62fc20986c716b").unwrap()).unwrap(),
+                    vtxindex: 13,
+                    block_number: 124,
+                    burn_header_hash: block_124_hash.clone(),
+                    
+                    _phantom_a: PhantomData,
+                    _phantom_k: PhantomData
+                },
+                res: CheckResult::UserBurnSupportOk,
+            }
+        ];
+
+        for fixture in check_fixtures {
+            assert_eq!(fixture.res, fixture.op.check(&burnchain, db.conn()).unwrap());
         }
     }
 }

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -1,0 +1,289 @@
+/*
+ copyright: (c) 2013-2018 by Blockstack PBC, a public benefit corporation.
+
+ This file is part of Blockstack.
+
+ Blockstack is free software. You may redistribute or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License or
+ (at your option) any later version.
+
+ Blockstack is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, including without the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use std::collections::BTreeMap;
+
+use rusqlite::Transaction;
+use rusqlite::Connection;
+
+use chainstate::burn::{
+    BurnchainBlock,
+    OpsHash,
+    ConsensusHash,
+    SortitionHash,
+    VRFSeed,
+    Txid,
+    BurnchainHeaderHash
+};
+
+use chainstate::burn::db::burndb::BurnDB;
+use chainstate::burn::db::Error as db_error;
+use chainstate::burn::operations::BlockstackOperationType;
+use chainstate::burn::operations::leader_key_register::LeaderKeyRegisterOp;
+use chainstate::burn::operations::leader_block_commit::LeaderBlockCommitOp;
+use chainstate::burn::operations::user_burn_support::UserBurnSupportOp;
+use chainstate::burn::BlockSnapshot;
+use chainstate::burn::distribution::BurnSamplePoint;
+
+use burnchains::Address;
+use burnchains::PublicKey;
+use burnchains::Burnchain;
+
+use util::hash::Hash160;
+use util::uint::Uint256;
+use util::uint::Uint512;
+use util::uint::BitArray;
+use util::vrf::ECVRF_public_key_to_hex;
+
+use util::log;
+
+impl BlockSnapshot {
+    /// Calculate a new burn quota by incrementing.
+    /// Panic on numeric overflow.
+    fn burn_quota_inc_checked(last_burn_quota: u64, burn_quota_inc: u64) -> u64 {
+        if last_burn_quota.checked_add(burn_quota_inc).is_none() {
+            panic!("FATAL ERROR burn quota overflow ({} + {})", last_burn_quota, burn_quota_inc);
+        }
+
+        if last_burn_quota + burn_quota_inc > ((1 as u64) << 63) - 1 {
+            panic!("FATAL ERROR burn quota exceeds i64 ({})", last_burn_quota + burn_quota_inc);
+        }
+
+        last_burn_quota + burn_quota_inc
+    }
+
+    /// Calculate a new burn quota by multiplicatively decreasing
+    /// Panic on numeric overflow
+    fn burn_quota_dec_checked(last_burn_quota: u64, burn_quota_num: u64, burn_quota_den: u64) -> u64 {
+        let mut last_burn_quota_u128 = last_burn_quota as u128;
+        if last_burn_quota_u128.checked_mul(burn_quota_num.into()).is_none() {
+            panic!("FATAL ERROR burn quota overflow ({} * {})", last_burn_quota, burn_quota_num);
+        }
+        last_burn_quota_u128 = last_burn_quota_u128 * (burn_quota_num as u128);
+
+        if last_burn_quota_u128.checked_div(burn_quota_den as u128).is_none() {
+            panic!("FATAL ERROR burn quota unsafe divide ({} * {} / {})", last_burn_quota, burn_quota_num, burn_quota_den);
+        }
+        last_burn_quota_u128 = last_burn_quota_u128 / (burn_quota_den as u128);
+
+        last_burn_quota_u128 as u64
+    }
+
+    /// Calculate the total burn.
+    /// Panic on numeric overflow.
+    fn burn_total_checked(last_burn_total: u64, block_burn_total: u64) -> u64 {
+        if block_burn_total.checked_add(last_burn_total).is_none() {
+            panic!("FATAL ERROR burn total overflow ({} + {})", block_burn_total, last_burn_total);
+        }
+
+        block_burn_total + last_burn_total
+    }
+    
+    /// Given the weighted burns, VRF seed of the last winner, and sortition hash, pick the next
+    /// winner.  Return the index into the distribution *if there is a sample to take*.
+    fn sample_burn_distribution<A, K>(dist: &Vec<BurnSamplePoint<A, K>>, VRF_seed: &VRFSeed, sortition_hash: &SortitionHash) -> Option<usize>
+    where
+        A: Address,
+        K: PublicKey
+    {
+        if dist.len() == 0 {
+            // no winners 
+            return None;
+        }
+        if dist.len() == 1 {
+            // only one winner 
+            return Some(0);
+        }
+
+        let index = sortition_hash.mix_VRF_seed(VRF_seed).to_uint256();
+        for i in 0..dist.len() {
+            if (dist[i].range_start <= index) && (index < dist[i].range_end) {
+                debug!("Sampled {}: {} <= HASH({},{}) < {}", dist[i].candidate.block_header_hash.to_hex(), dist[i].range_start, &sortition_hash.to_hex(), &VRF_seed.to_hex(), dist[i].range_end);
+                return Some(i);
+            }
+        }
+
+        // should never happen 
+        panic!("FATAL ERROR: unable to map {} to a range", index);
+    }
+
+    /// Select the next Stacks block header hash using cryptographic sortition.
+    /// Go through all block commits at this height, find out how any burn tokens
+    /// were spent for them, and select one at random using the relative burn amounts
+    /// to weight the sample.  Use HASH(sortition_hash ++ last_VRF_seed) to pick the 
+    /// winning block commit, and by extension, the next VRF seed.
+    ///
+    /// If there are no block commits outstanding, then no winner is picked.
+    ///
+    /// Note that the VRF seed is not guaranteed to be the hash of a valid VRF
+    /// proof.  Miners would only build off of leader block commits for which they
+    /// (1) have the associated block data and (2) the proof in that block is valid.
+    fn select_winning_block<'a, A, K>(tx: &mut Transaction<'a>, block_height: u64, sortition_hash: &SortitionHash, burn_dist: &Vec<BurnSamplePoint<A, K>>) -> Result<Option<LeaderBlockCommitOp<A, K>>, db_error>
+    where
+        A: Address,
+        K: PublicKey
+    {
+        // get the last winner's VRF seed
+        let last_sortition_snapshot = BurnDB::<A, K>::get_last_snapshot_with_sortition(tx, block_height)?;
+        let VRF_seed;
+
+        if last_sortition_snapshot.sortition_hash == SortitionHash::initial() {
+            // this is the sentinal "first-sortition" block 
+            VRF_seed = VRFSeed::initial();
+        }
+        else {
+            // there was a prior winning block commit.  Use its VRF seed.
+            let last_winning_block_commit_opt = BurnDB::<A, K>::get_block_commit(tx, &last_sortition_snapshot.winning_block_txid, &last_sortition_snapshot.winning_block_burn_hash)?;
+            if last_winning_block_commit_opt.is_none() {
+                // something is seriously wrong -- the canonical block snapshot doesn't point to a
+                // canonical block commit.
+                panic!("FATAL ERROR: no block commit for snapshot {:?}", last_sortition_snapshot);
+            }
+            let last_winning_block_commit = last_winning_block_commit_opt.unwrap();
+            VRF_seed = last_winning_block_commit.new_seed.clone();
+        }
+
+        // pick the next winner
+        let win_idx_opt = BlockSnapshot::sample_burn_distribution(burn_dist, &VRF_seed, sortition_hash);
+        match win_idx_opt {
+            None => {
+                // no winner 
+                Ok(None)
+            },
+            Some(win_idx) => {
+                // winner!
+                Ok(Some(burn_dist[win_idx].candidate.clone()))
+            }
+        }
+    }
+    
+
+    /// Make a block snapshot from is block's data and the previous block.
+    /// This process will:
+    /// * calculate the new consensus hash
+    /// * calculate the total burn so far
+    /// * calculate the new burn quota
+    /// * determine whether or not we can do a sortition, and if so,
+    /// * carry out the sortition to select the next candidate block.
+    ///
+    /// All of this is rolled into the BlockSnapshot struct.
+    /// 
+    /// Call this *after* you store all of the block's transactions to the burn db.
+    pub fn make_snapshot<'a, A, K>(tx: &mut Transaction<'a>, burnchain: &Burnchain, first_block_height: u64, block_height: u64, block_hash: &BurnchainHeaderHash, burn_dist: &Vec<BurnSamplePoint<A, K>>) -> Result<BlockSnapshot, db_error>
+    where
+        A: Address, 
+        K: PublicKey
+    {
+        // txids for operations stored in this block
+        let txids = BurnDB::<A, K>::get_block_txids(tx, block_height, block_hash)?;
+
+        // NOTE: this only counts burns from leader block commits and user burns that match them.
+        // It ignores user burns that don't match any block.
+        let block_burn_total_opt = BurnSamplePoint::get_total_burns(burn_dist);
+        if block_burn_total_opt.is_none() {
+            return Err(db_error::Overflow);
+        }
+        let block_burn_total = block_burn_total_opt.unwrap();
+
+        let last_burn_quota;
+        let last_sortition_hash;
+        let last_burn_total;
+
+        let next_sortition;
+        let next_burn_quota;
+        let winning_block_txid;
+        let winning_block_burn_hash;
+
+        let last_block_snapshot_opt = BurnDB::<A, K>::get_block_snapshot(tx, block_height - 1)?;
+
+        match last_block_snapshot_opt {
+            Some(prev_snapshot) => {
+                last_burn_total = prev_snapshot.total_burn;
+                last_burn_quota = prev_snapshot.burn_quota;
+                last_sortition_hash = prev_snapshot.sortition_hash;
+            },
+            None =>  {
+                last_burn_total = 0;
+                last_burn_quota = 0;
+                last_sortition_hash = SortitionHash::initial();
+            }
+        };
+        
+        let next_sortition_hash = last_sortition_hash.mix_burn_header(block_hash);
+       
+        // did we burn enough?
+        // TODO do we have to be sticklers about the burn quota?  can't we just leave it alone if it's "close enough" to the last burn quota?
+        if block_burn_total >= last_burn_quota {
+            // can do a sortition in this block
+            // Try to pick a next block.
+            let winning_block_opt : Option<LeaderBlockCommitOp<A, K>> = BlockSnapshot::select_winning_block(tx, block_height, &next_sortition_hash, burn_dist)?;
+            match winning_block_opt {
+                None => {
+                    // we burned enough for a sortition, but no winner was picked 
+                    next_sortition = false;
+                    winning_block_txid = Txid::from_bytes(&[0u8; 32]).unwrap();
+                    winning_block_burn_hash = BurnchainHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+
+                    info!("SORTITION: Burn quota met ({}), but NO BLOCK CHOSEN", block_burn_total);
+                },
+                Some(winning_block) => {
+                    // we burned enough for a sortition, and a winner was picked! 
+                    next_sortition = true;
+                    winning_block_txid = winning_block.txid.clone();
+                    winning_block_burn_hash = winning_block.burn_header_hash.clone();
+
+                    info!("SORTITION: Burn quota met ({}). WINNER is {} (at {})", block_burn_total, &winning_block.block_header_hash.to_hex(), &winning_block_txid.to_hex());
+                }
+            };
+
+            // either way, we burned enough.  Increaes the quota for the next block.
+            next_burn_quota = BlockSnapshot::burn_quota_inc_checked(last_burn_quota, burnchain.burn_quota.inc);
+        }
+        else {
+            // cannot do a sortition in this block.  Decrease the quota.
+            next_sortition = false;
+            next_burn_quota = BlockSnapshot::burn_quota_dec_checked(last_burn_quota, burnchain.burn_quota.dec_num, burnchain.burn_quota.dec_den);
+
+            winning_block_txid = Txid::from_bytes(&[0u8; 32]).unwrap();
+            winning_block_burn_hash = BurnchainHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+
+            info!("SORTITION: Burn quota NOT MET ({} < {})", block_burn_total, last_burn_quota);
+        }
+
+        let next_burn_total = BlockSnapshot::burn_total_checked(last_burn_total, block_burn_total);
+        
+        let next_ops_hash = OpsHash::from_txids(&txids);
+        let next_ch = ConsensusHash::from_block_data::<A, K>(tx, &next_ops_hash, block_height, first_block_height, next_burn_total)?;
+
+        Ok(BlockSnapshot {
+            block_height: block_height,
+            burn_header_hash: block_hash.clone(),
+            consensus_hash: next_ch,
+            ops_hash: next_ops_hash,
+            total_burn: next_burn_total,
+            burn_quota: next_burn_quota,
+            sortition: next_sortition,
+            sortition_hash: next_sortition_hash,
+            winning_block_txid: winning_block_txid,
+            winning_block_burn_hash: winning_block_burn_hash,
+            canonical: true
+        })
+    }
+}
+

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -31,7 +31,12 @@ pub fn sync_burnchain_bitcoin(working_dir: &String, network_name: &String) -> Re
     use burnchains::bitcoin::indexer::BitcoinIndexerAddress;
     use burnchains::bitcoin::indexer::BitcoinIndexerPublicKey;
 
-    let mut burnchain = Burnchain::new(working_dir, &"bitcoin".to_string(), network_name);
+    let mut burnchain = Burnchain::new(working_dir, &"bitcoin".to_string(), network_name)
+        .map_err(|e| {
+            error!("Failed to instantiate burn chain driver for {}", network_name);
+            e
+        })?;
+
     let new_height_res = burnchain.sync::<BitcoinIndexer, BitcoinIndexerAddress, BitcoinIndexerPublicKey>();
     let new_height = new_height_res
         .map_err(|e| {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -21,4 +21,5 @@
 #[macro_use] pub mod macros;
 pub mod hash;
 pub mod pair;
+pub mod uint;
 pub mod vrf;

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -1,0 +1,573 @@
+/*
+ copyright: (c) 2013-2018 by Blockstack PBC, a public benefit corporation.
+
+ This file is part of Blockstack.
+
+ Blockstack is free software. You may redistribute or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License or
+ (at your option) any later version.
+
+ Blockstack is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, including without the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//! Big unsigned integer types
+//!
+//! Implementation of a various large-but-fixed sized unsigned integer types.
+//! The functions here are designed to be fast.
+//!
+/// Borrowed with gratitude from Andrew Poelstra's rust-bitcoin library
+
+use std::fmt;
+
+/// A trait which allows numbers to act as fixed-size bit arrays
+pub trait BitArray {
+    /// Is bit set?
+    fn bit(&self, idx: usize) -> bool;
+
+    /// Returns an array which is just the bits from start to end
+    fn bit_slice(&self, start: usize, end: usize) -> Self;
+
+    /// Bitwise and with `n` ones
+    fn mask(&self, n: usize) -> Self;
+
+    /// Trailing zeros
+    fn trailing_zeros(&self) -> usize;
+
+    /// Create all-zeros value
+    fn zero() -> Self;
+
+    /// Create value represeting one
+    fn one() -> Self;
+
+    /// Create value representing max
+    fn max() -> Self;
+}
+
+macro_rules! construct_uint {
+    ($name:ident, $n_words:expr) => (
+        /// Little-endian large integer type
+        #[repr(C)]
+        pub struct $name(pub [u64; $n_words]);
+        impl_array_newtype!($name, u64, $n_words);
+
+        impl $name {
+            /// Conversion to u32
+            #[inline]
+            pub fn low_u32(&self) -> u32 {
+                let &$name(ref arr) = self;
+                arr[0] as u32
+            }
+
+            /// Conversion to u64
+            #[inline]
+            pub fn low_u64(&self) -> u64 {
+                let &$name(ref arr) = self;
+                arr[0] as u64
+            }
+
+
+            /// Return the least number of bits needed to represent the number
+            #[inline]
+            pub fn bits(&self) -> usize {
+                let &$name(ref arr) = self;
+                for i in 1..$n_words {
+                    if arr[$n_words - i] > 0 { return (0x40 * ($n_words - i + 1)) - arr[$n_words - i].leading_zeros() as usize; }
+                }
+                0x40 - arr[0].leading_zeros() as usize
+            }
+
+            /// Multiplication by u32
+            pub fn mul_u32(self, other: u32) -> $name {
+                let $name(ref arr) = self;
+                let mut carry = [0u64; $n_words];
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    let not_last_word = i < $n_words - 1;
+                    let upper = other as u64 * (arr[i] >> 32);
+                    let lower = other as u64 * (arr[i] & 0xFFFFFFFF);
+                    if not_last_word {
+                        carry[i + 1] += upper >> 32;
+                    }
+                    let (sum, overflow) = lower.overflowing_add(upper << 32);
+                    ret[i] = sum;
+                    if overflow && not_last_word {
+                        carry[i + 1] += 1;
+                    }
+                }
+                $name(ret) + $name(carry)
+            }
+
+            /// Create an object from a given unsigned 64-bit integer
+            pub fn from_u64(init: u64) -> $name {
+                let mut ret = [0; $n_words];
+                ret[0] = init;
+                $name(ret)
+            }
+
+            /// Create an object from a given signed 64-bit integer
+            pub fn from_i64(init: i64) -> $name {
+                assert!(init >= 0);
+                $name::from_u64(init as u64)
+            }
+
+            /// Create an object from a given unsigned 128-bit integer 
+            pub fn from_u128(init: u128) -> $name {
+                let mut ret = [0u64; $n_words];
+                ret[0] = (init & 0xffffffffffffffffffffffffffffffff) as u64;
+                ret[1] = (init >> 64) as u64;
+                $name(ret)
+            }
+
+            /// max 
+            pub fn max() -> $name {
+                let ret = [0xffffffffffffffff; $n_words];
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Add<$name> for $name {
+            type Output = $name;
+
+            fn add(self, other: $name) -> $name {
+                let $name(ref me) = self;
+                let $name(ref you) = other;
+                let mut ret = [0u64; $n_words];
+                let mut carry = [0u64; $n_words];
+                let mut b_carry = false;
+                for i in 0..$n_words {
+                    ret[i] = me[i].wrapping_add(you[i]);
+                    if i < $n_words - 1 && ret[i] < me[i] {
+                        carry[i + 1] = 1;
+                        b_carry = true;
+                    }
+                }
+                if b_carry { $name(ret) + $name(carry) } else { $name(ret) }
+            }
+        }
+
+        impl ::std::ops::Sub<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn sub(self, other: $name) -> $name {
+                self + !other + BitArray::one()
+            }
+        }
+
+        impl ::std::ops::Mul<$name> for $name {
+            type Output = $name;
+
+            fn mul(self, other: $name) -> $name {
+                let mut me = $name::zero();
+                // TODO: be more efficient about this
+                for i in 0..(2 * $n_words) {
+                    let to_mul = (other >> (32 * i)).low_u32();
+                    me = me + (self.mul_u32(to_mul) << (32 * i));
+                }
+                me
+            }
+        }
+
+        impl ::std::ops::Div<$name> for $name {
+            type Output = $name;
+
+            fn div(self, other: $name) -> $name {
+                let mut sub_copy = self;
+                let mut shift_copy = other;
+                let mut ret = [0u64; $n_words];
+        
+                let my_bits = self.bits();
+                let your_bits = other.bits();
+
+                // Check for division by 0
+                assert!(your_bits != 0);
+
+                // Early return in case we are dividing by a larger number than us
+                if my_bits < your_bits {
+                    return $name(ret);
+                }
+
+                // Bitwise long division
+                let mut shift = my_bits - your_bits;
+                shift_copy = shift_copy << shift;
+                loop {
+                    if sub_copy >= shift_copy {
+                        ret[shift / 64] |= 1 << (shift % 64);
+                        sub_copy = sub_copy - shift_copy;
+                    }
+                    shift_copy = shift_copy >> 1;
+                    if shift == 0 { break; }
+                    shift -= 1;
+                }
+
+                $name(ret)
+            }
+        }
+
+        impl BitArray for $name {
+            #[inline]
+            fn bit(&self, index: usize) -> bool {
+                let &$name(ref arr) = self;
+                arr[index / 64] & (1 << (index % 64)) != 0
+            }
+
+            #[inline]
+            fn bit_slice(&self, start: usize, end: usize) -> $name {
+                (*self >> start).mask(end - start)
+            }
+
+            #[inline]
+            fn mask(&self, n: usize) -> $name {
+                let &$name(ref arr) = self;
+                let mut ret = [0; $n_words];
+                for i in 0..$n_words {
+                    if n >= 0x40 * (i + 1) {
+                        ret[i] = arr[i];
+                    } else {
+                        ret[i] = arr[i] & ((1 << (n - 0x40 * i)) - 1);
+                        break;
+                    }
+                }
+                $name(ret)
+            }
+
+            #[inline]
+            fn trailing_zeros(&self) -> usize {
+                let &$name(ref arr) = self;
+                for i in 0..($n_words - 1) {
+                    if arr[i] > 0 { return (0x40 * i) + arr[i].trailing_zeros() as usize; }
+                }
+                (0x40 * ($n_words - 1)) + arr[$n_words - 1].trailing_zeros() as usize
+            }
+
+            fn zero() -> $name { $name([0; $n_words]) }
+            fn one() -> $name {
+                $name({ let mut ret = [0; $n_words]; ret[0] = 1; ret })
+            }
+            fn max() -> $name {
+                $name({ let ret = [0xffffffffffffffff; $n_words]; ret})
+            }
+        }
+
+        impl ::std::default::Default for $name {
+            fn default() -> $name {
+                BitArray::zero()
+            }
+        }
+
+        impl ::std::ops::BitAnd<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn bitand(self, other: $name) -> $name {
+                let $name(ref arr1) = self;
+                let $name(ref arr2) = other;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = arr1[i] & arr2[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::BitXor<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn bitxor(self, other: $name) -> $name {
+                let $name(ref arr1) = self;
+                let $name(ref arr2) = other;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = arr1[i] ^ arr2[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::BitOr<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn bitor(self, other: $name) -> $name {
+                let $name(ref arr1) = self;
+                let $name(ref arr2) = other;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = arr1[i] | arr2[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Not for $name {
+            type Output = $name;
+
+            #[inline]
+            fn not(self) -> $name {
+                let $name(ref arr) = self;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = !arr[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Shl<usize> for $name {
+            type Output = $name;
+
+            fn shl(self, shift: usize) -> $name {
+                let $name(ref original) = self;
+                let mut ret = [0u64; $n_words];
+                let word_shift = shift / 64;
+                let bit_shift = shift % 64;
+                for i in 0..$n_words {
+                    // Shift
+                    if bit_shift < 64 && i + word_shift < $n_words {
+                        ret[i + word_shift] += original[i] << bit_shift;
+                    }
+                    // Carry
+                    if bit_shift > 0 && i + word_shift + 1 < $n_words {
+                        ret[i + word_shift + 1] += original[i] >> (64 - bit_shift);
+                    }
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Shr<usize> for $name {
+            type Output = $name;
+
+            fn shr(self, shift: usize) -> $name {
+                let $name(ref original) = self;
+                let mut ret = [0u64; $n_words];
+                let word_shift = shift / 64;
+                let bit_shift = shift % 64;
+                for i in word_shift..$n_words {
+                    // Shift
+                    ret[i - word_shift] += original[i] >> bit_shift;
+                    // Carry
+                    if bit_shift > 0 && i < $n_words - 1 {
+                        ret[i - word_shift] += original[i + 1] << (64 - bit_shift);
+                    }
+                }
+                $name(ret)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                let &$name(ref data) = self;
+                write!(f, "0x")?;
+                for ch in data.iter().rev() {
+                    write!(f, "{:016x}", ch)?;
+                }
+                Ok(())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                <fmt::Debug>::fmt(self, f)
+            }
+        }
+    );
+}
+
+construct_uint!(Uint256, 4);
+construct_uint!(Uint512, 8);
+
+impl Uint256 {
+    /// Increment by 1
+    #[inline]
+    pub fn increment(&mut self) {
+        let &mut Uint256(ref mut arr) = self;
+        arr[0] += 1;
+        if arr[0] == 0 {
+            arr[1] += 1;
+            if arr[1] == 0 {
+                arr[2] += 1;
+                if arr[2] == 0 {
+                    arr[3] += 1;
+                }
+            }
+        }
+    }
+}
+
+impl Uint512 {
+    /// from Uint256 
+    pub fn from_uint256(n: &Uint256) -> Uint512 {
+        let mut tmp = [0u64; 8];
+        for i in 0..4 {
+            tmp[i] = n.0[i];
+        }
+        Uint512(tmp)
+    }
+
+    pub fn to_uint256(&self) -> Uint256 {
+        let mut tmp = [0u64; 4];
+        for i in 0..4 {
+            tmp[i] = self.0[i];
+        }
+        Uint256(tmp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use util::uint::Uint256;
+    use util::uint::BitArray;
+
+    #[test]
+    pub fn uint256_bits_test() {
+        assert_eq!(Uint256::from_u64(255).bits(), 8);
+        assert_eq!(Uint256::from_u64(256).bits(), 9);
+        assert_eq!(Uint256::from_u64(300).bits(), 9);
+        assert_eq!(Uint256::from_u64(60000).bits(), 16);
+        assert_eq!(Uint256::from_u64(70000).bits(), 17);
+
+        // Try to read the following lines out loud quickly
+        let mut shl = Uint256::from_u64(70000);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 117);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 217);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 0);
+
+        // Bit set check
+        assert!(!Uint256::from_u64(10).bit(0));
+        assert!(Uint256::from_u64(10).bit(1));
+        assert!(!Uint256::from_u64(10).bit(2));
+        assert!(Uint256::from_u64(10).bit(3));
+        assert!(!Uint256::from_u64(10).bit(4));
+    }
+
+    #[test]
+    pub fn uint256_display_test() {
+        assert_eq!(format!("{}", Uint256::from_u64(0xDEADBEEF)),
+                   "0x00000000000000000000000000000000000000000000000000000000deadbeef");
+        assert_eq!(format!("{}", Uint256::from_u64(u64::max_value())),
+                   "0x000000000000000000000000000000000000000000000000ffffffffffffffff");
+
+        let max_val = Uint256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
+                               0xFFFFFFFFFFFFFFFF]);
+        assert_eq!(format!("{}", max_val),
+                   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    #[test]
+    pub fn uint256_comp_test() {
+        let small = Uint256([10u64, 0, 0, 0]);
+        let big = Uint256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
+        let bigger = Uint256([0x9C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
+        let biggest = Uint256([0x5C8C3EE70C644118u64, 0x0209E7378231E632, 0, 1]);
+
+        assert!(small < big);
+        assert!(big < bigger);
+        assert!(bigger < biggest);
+        assert!(bigger <= biggest);
+        assert!(biggest <= biggest);
+        assert!(bigger >= big);
+        assert!(bigger >= small);
+        assert!(small <= small);
+    }
+
+    #[test]
+    pub fn uint256_arithmetic_test() {
+        let init = Uint256::from_u64(0xDEADBEEFDEADBEEF);
+        let copy = init;
+
+        let add = init + copy;
+        assert_eq!(add, Uint256([0xBD5B7DDFBD5B7DDEu64, 1, 0, 0]));
+        // Bitshifts
+        let shl = add << 88;
+        assert_eq!(shl, Uint256([0u64, 0xDFBD5B7DDE000000, 0x1BD5B7D, 0]));
+        let shr = shl >> 40;
+        assert_eq!(shr, Uint256([0x7DDE000000000000u64, 0x0001BD5B7DDFBD5B, 0, 0]));
+        // Increment
+        let mut incr = shr;
+        incr.increment();
+        assert_eq!(incr, Uint256([0x7DDE000000000001u64, 0x0001BD5B7DDFBD5B, 0, 0]));
+        // Subtraction
+        let sub = incr - init;
+        assert_eq!(sub, Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0]));
+        // Multiplication
+        let mult = sub.mul_u32(300);
+        assert_eq!(mult, Uint256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]));
+        // Division
+        assert_eq!(Uint256::from_u64(105) /
+                   Uint256::from_u64(5),
+                   Uint256::from_u64(21));
+        let div = mult / Uint256::from_u64(300);
+        assert_eq!(div, Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0]));
+        // TODO: bit inversion
+    }
+
+    #[test]
+    pub fn mul_u32_test() {
+        let u64_val = Uint256::from_u64(0xDEADBEEFDEADBEEF);
+
+        let u96_res = u64_val.mul_u32(0xFFFFFFFF);
+        let u128_res = u96_res.mul_u32(0xFFFFFFFF);
+        let u160_res = u128_res.mul_u32(0xFFFFFFFF);
+        let u192_res = u160_res.mul_u32(0xFFFFFFFF);
+        let u224_res = u192_res.mul_u32(0xFFFFFFFF);
+        let u256_res = u224_res.mul_u32(0xFFFFFFFF);
+
+        assert_eq!(u96_res, Uint256([0xffffffff21524111u64, 0xDEADBEEE, 0, 0]));
+        assert_eq!(u128_res, Uint256([0x21524111DEADBEEFu64, 0xDEADBEEE21524110, 0, 0]));
+        assert_eq!(u160_res, Uint256([0xBD5B7DDD21524111u64, 0x42A4822200000001, 0xDEADBEED, 0]));
+        assert_eq!(u192_res, Uint256([0x63F6C333DEADBEEFu64, 0xBD5B7DDFBD5B7DDB, 0xDEADBEEC63F6C334, 0]));
+        assert_eq!(u224_res, Uint256([0x7AB6FBBB21524111u64, 0xFFFFFFFBA69B4558, 0x854904485964BAAA, 0xDEADBEEB]));
+        assert_eq!(u256_res, Uint256([0xA69B4555DEADBEEFu64, 0xA69B455CD41BB662, 0xD41BB662A69B4550, 0xDEADBEEAA69B455C]));
+    }
+
+    #[test]
+    pub fn multiplication_test() {
+        let u64_val = Uint256::from_u64(0xDEADBEEFDEADBEEF);
+
+        let u128_res = u64_val * u64_val;
+
+        assert_eq!(u128_res, Uint256([0x048D1354216DA321u64, 0xC1B1CD13A4D13D46, 0, 0]));
+
+        let u256_res = u128_res * u128_res;
+
+        assert_eq!(u256_res, Uint256([0xF4E166AAD40D0A41u64, 0xF5CF7F3618C2C886u64,
+                                      0x4AFCFF6F0375C608u64, 0x928D92B4D7F5DF33u64]));
+    }
+
+    #[test]
+    pub fn uint256_bitslice_test() {
+        let init = Uint256::from_u64(0xDEADBEEFDEADBEEF);
+        let add = init + (init << 64);
+        assert_eq!(add.bit_slice(64, 128), init);
+        assert_eq!(add.mask(64), init);
+    }
+
+    #[test]
+    pub fn uint256_extreme_bitshift_test() {
+        // Shifting a u64 by 64 bits gives an undefined value, so make sure that
+        // we're doing the Right Thing here
+        let init = Uint256::from_u64(0xDEADBEEFDEADBEEF);
+
+        assert_eq!(init << 64, Uint256([0, 0xDEADBEEFDEADBEEF, 0, 0]));
+        let add = (init << 64) + init;
+        assert_eq!(add, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
+        assert_eq!(add >> 0, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
+        assert_eq!(add << 0, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
+        assert_eq!(add >> 64, Uint256([0xDEADBEEFDEADBEEF, 0, 0, 0]));
+        assert_eq!(add << 64, Uint256([0, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0]));
+    }
+}
+
+


### PR DESCRIPTION
This PR adds support for cryptographic sortition.  It does so by updating the `BlockSnapshot` struct, so that the call to `next_snapshot()` not only generates a new consensus hash, but also looks through all block commits and user support burns accepted in this block, calculates the burn weight behind each block header, projects the burn weights for each block candidate into partitions of the [0, 2**256 - 1) integer range, and uses a `SortitionHash` as a 256-bit integer to pick a winning block.  The `SortitionHash` is a rolling hash of PoW block header hashes and successful sortitions' VRF seeds, so it cannot be predicted in advance.  Here's an example output:

```
INFO [1550544732.106] [src/burnchains/burnchain.rs:482] Burn quota for 125 is 10752
DEBUG [1550544732.106] [src/burnchains/burnchain.rs:1231] TEST: Chain reorg on 124
INFO [1550544732.106] [src/burnchains/burnchain.rs:296] ACCEPT leader block commit cf275f2e4d1700c4fe107ea3730f77afc8309ed4adba7b0485bc6033a9a0073c
INFO [1550544732.106] [src/burnchains/burnchain.rs:296] ACCEPT leader block commit d0275f2e4d1700c4fe107ea3730f77afc8309ed4adba7b0485bc6033a9a0073c
INFO [1550544732.107] [src/burnchains/burnchain.rs:296] ACCEPT leader block commit de137c7c8285e173be673598c24308ec9c3e13273f017ae81a6af0a987c61d30
DEBUG [1550544732.119] [src/chainstate/burn/distribution.rs:215] Range for block 2222222222222222222222222222222222222222222222222222222222222222: 12345 / 48146: 0x0000000000000000000000000000000000000000000000000000000000000000 - 0x41a3ed94d3cb0a8470989faf596c8b650963dded799a7c1a3ed94d3cb0a84709
DEBUG [1550544732.119] [src/chainstate/burn/distribution.rs:215] Range for block 2222222222222222222222222222222222222222222222222222222222222223: 12345 / 48146: 0x41a3ed94d3cb0a8470989faf596c8b650963dded799a7c1a3ed94d3cb0a84709 - 0x8347db29a7961508e1313f5eb2d916ca12c7bbdaf334f8347db29a7961508e12
DEBUG [1550544732.119] [src/chainstate/burn/distribution.rs:215] Range for block 2222222222222222222222222222222222222222222222222222222222222224: 23456 / 48146: 0x8347db29a7961508e1313f5eb2d916ca12c7bbdaf334f8347db29a7961508e12 - 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
DEBUG [1550544732.119] [src/chainstate/burn/sortition.rs:117] Sampled 2222222222222222222222222222222222222222222222222222222222222222: 0x0000000000000000000000000000000000000000000000000000000000000000 <= HASH(39e895cc631a33571faa2381c554653092cf0995285e7eff96dbd1660ff8a869,0000000000000000000000000000000000000000000000000000000000000000) < 0x41a3ed94d3cb0a8470989faf596c8b650963dded799a7c1a3ed94d3cb0a84709
INFO [1550544732.120] [src/chainstate/burn/sortition.rs:251] SORTITION: Burn quota met (48146). WINNER is 2222222222222222222222222222222222222222222222222222222222222222 (at cf275f2e4d1700c4fe107ea3730f77afc8309ed4adba7b0485bc6033a9a0073c)
DEBUG [1550544732.120] [src/chainstate/burn/mod.rs:236] Consensus at 123: 010be243e4635ffe40e709b4ece71a0f8c3ad550
DEBUG [1550544732.120] [src/chainstate/burn/mod.rs:236] Consensus at 122: a18809be2b03ea464abb897eca4f701004bf38de
DEBUG [1550544732.120] [src/chainstate/burn/mod.rs:236] Consensus at 120: 0000000000000000000000000000000000000000
INFO [1550544732.120] [src/burnchains/burnchain.rs:480] OPS-HASH(124): 9bffe770a8ae479eca156555701498bfe7a41ba5cab92dd3aa5a4cb2fa67246e
INFO [1550544732.120] [src/burnchains/burnchain.rs:481] CONSENSUS(124): 6a0193079bb881a193be4e2433a89d4a8cc96c4e
INFO [1550544732.120] [src/burnchains/burnchain.rs:482] Burn quota for 125 is 34440
```

More than half of this PR is unit tests.