### PR TITLE
Hotfix: Add timeouts to UWSGI proxy

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -61,4 +61,8 @@ BSK_API_TMPLTDIR=/src/blockstack/api/templates
 #  fetching index file dumps from /v1/index_files/blockchain and /v1/index_files/profiles
 BSK_API_BLOCKCHAIN_URL="https://storage.googleapis.com/blockstack-search_indexer_data/blockchain_data.json"
 BSK_API_PROFILE_URL="https://storage.googleapis.com/blockstack-search_indexer_data/profile_data.json"
+
+# Float that sets the timeout for requests getting proxied to blockstack-core
+BSK_SEARCH_API_TIMEOUT = 10
+
 ```

--- a/api/config.py
+++ b/api/config.py
@@ -73,6 +73,9 @@ SEARCH_NODE_URL = os.getenv('SEARCH_NODE_URL', 'https://search.example.org')
 # SEARCH_DEFAULT_LIMIT sets the number of returns per call
 SEARCH_DEFAULT_LIMIT = int(os.getenv('SEARCH_DEFAULT_LIMIT', '50'))
 
+# sets the timeout for requests getting proxied to blockstack-core
+PROXY_TIMEOUT = float(os.getenv('BSK_SEARCH_API_TIMEOUT', '10'))
+
 # Control response to /v1/index_files
 API_BLOCKCHAIN_URL = os.getenv('BSK_API_BLOCKCHAIN_URL', '')
 API_PROFILE_URL = os.getenv('BSK_API_PROFILE_URL', '')

--- a/api/server.py
+++ b/api/server.py
@@ -39,6 +39,7 @@ from .parameters import parameters_required
 from .utils import get_api_calls, cache_control
 from .config import PUBLIC_NODE, PUBLIC_NODE_URL, BASE_API_URL, BASE_INDEXER_API_URL, DEFAULT_CACHE_TIMEOUT
 from .config import SEARCH_NODE_URL, SEARCH_API_ENDPOINT_ENABLED, API_BLOCKCHAIN_URL, API_PROFILE_URL
+from .config import PROXY_TIMEOUT
 
 # hack around absolute paths
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -70,9 +71,9 @@ def default_cache_off(response):
 
 def forwarded_get(url, params = None):
     if params:
-        resp = requests.get(url, params = params, allow_redirects=False)
+        resp = requests.get(url, params = params, allow_redirects=False, timeout=PROXY_TIMEOUT)
     else:
-        resp = requests.get(url, allow_redirects=False)
+        resp = requests.get(url, allow_redirects=False, timeout=PROXY_TIMEOUT)
 
     try:
         log.debug("{} => {}".format(resp.url, resp.status_code))
@@ -104,7 +105,7 @@ def search_people():
     search_url = SEARCH_NODE_URL + '/search'
 
     try:
-        resp = requests.get(url=search_url, params={'query': query})
+        resp = requests.get(url=search_url, params={'query': query}, timeout=PROXY_TIMEOUT)
     except (RequestsConnectionError, RequestsTimeout) as e:
         raise InternalProcessingError()
 
@@ -181,7 +182,7 @@ def catch_all_post(path):
 
     API_URL = BASE_API_URL + '/' + path
 
-    resp = requests.post(API_URL, data=requests.data)
+    resp = requests.post(API_URL, data=requests.data, timeout=PROXY_TIMEOUT)
 
     return jsonify(resp.json()), 200
 

--- a/api/server.py
+++ b/api/server.py
@@ -70,15 +70,19 @@ def default_cache_off(response):
     return response
 
 def forwarded_get(url, params = None):
-    if params:
-        resp = requests.get(url, params = params, allow_redirects=False, timeout=PROXY_TIMEOUT)
-    else:
-        resp = requests.get(url, allow_redirects=False, timeout=PROXY_TIMEOUT)
+    try:
+        if params:
+            resp = requests.get(url, params = params, allow_redirects=False, timeout=PROXY_TIMEOUT)
+        else:
+            resp = requests.get(url, allow_redirects=False, timeout=PROXY_TIMEOUT)
+    except Exception as e:
+        log.error("Exception proxying request to blockstack core: {}".format(e))
+        return jsonify({'error': 'Server error processing request'}), 400
 
     try:
         log.debug("{} => {}".format(resp.url, resp.status_code))
 
-        if resp.headers['content-type'] and 'application/json' in resp.heads['content-type']:
+        if resp.headers['content-type'] and 'application/json' in resp.headers['content-type']:
             respData = jsonify(resp.json())
         else:
             respData = resp.text
@@ -87,7 +91,7 @@ def forwarded_get(url, params = None):
             return respData, resp.status_code, resp.headers['Location']
         else:
             return respData, resp.status_code
-    except:
+    except Exception as e:
         log.error("Bad response from API URL: {} \n {}".format(resp.url, resp.text))
         return jsonify({'error': 'Not found'}), resp.status_code
 


### PR DESCRIPTION
The API service (UWSGI proxy) previously wouldn't timeout requests to blockstack-core.

This resulted in some bad behavior in the event that the blockstack-core was experiencing heavy load --- the UWSGI workers would all be indefinitely tied up while waiting for responses from blockstack-core.

This adds an environment variable option:

```
BSK_SEARCH_API_TIMEOUT
```

Which takes a floating point number representing the number of seconds before timeout (default = 10).

This _also_ fixes what seems to be an existing typo in this file on `master`

You can test this via:

Starting blockstack-core:
```bash
$ blockstack-core start
```

Start a proxy with a really small timeout:
```
$ cd blockstack-core
$ pip install -r api/requirements.txt
$ BLOCKSTACK_DEBUG=1 BSK_SEARCH_API_TIMEOUT=0.0001 FLASK_APP=api.server python -m flask run

 * Serving Flask app "api.server"
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: off
[2019-02-20 13:51:26,119] [DEBUG] [spv:104] (7314.140233015473984) Using mainnet
[2019-02-20 13:51:26,210] [DEBUG] [config:1885] (7314.140233015473984) Load config from '/home/aaron/.blockstack-server/blockstack-server.ini'
[2019-02-20 13:51:26,210] [DEBUG] [config:1635] (7314.140233015473984) Using configuration-given Atlas hostname
[2019-02-20 13:51:26,210] [INFO] [config:1644] (7314.140233015473984) Atlas IP address is (127.0.0.1, 6264)
[2019-02-20 13:51:26,244] [DEBUG] [config:1885] (7314.140233015473984) Load config from '/home/aaron/.blockstack-server/blockstack-server.ini'
[2019-02-20 13:51:26,253] [DEBUG] [config:1885] (7314.140233015473984) Load config from '/home/aaron/.blockstack-server/blockstack-server.ini'
[2019-02-20 13:51:26,257] [DEBUG] [config:1885] (7314.140233015473984) Load config from '/home/aaron/.blockstack-server/blockstack-server.ini'
[20 Feb 2019 13:51:26] [INFO]   [werkzeug]:      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
```

And then:

```
$ curl localhost:5000/v1/info
```

And it should return a 400 error, as well as log the error in the proxy.
