### PR TITLE
REPL and eval_raw local commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,8 +234,12 @@ where command is one of:
                 loop {
                     let content: String = {
                         let mut buffer = String::new();
-                        stdout.write(b"> ");
-                        stdout.flush();
+                        stdout.write(b"> ").unwrap_or_else(|e| {
+                            panic!("Failed to write stdout prompt string:\n{}", e);
+                        });
+                        stdout.flush().unwrap_or_else(|e| {
+                            panic!("Failed to flush stdout prompt string:\n{}", e);
+                        });
                         match io::stdin().read_line(&mut buffer) {
                             Ok(_) => buffer,
                             Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ where command is one of:
 
                 let mut db = db_conn.begin_save_point();
                 let mut ast = parse(&content).expect("Failed to parse program");
-                type_check(&"transient", &mut ast, &mut db, false)
+                type_check(&":transient:", &mut ast, &mut db, false)
                     .unwrap_or_else(|e| {
                         eprintln!("Type check error.\n{}", e);
                         process::exit(1);
@@ -254,7 +254,7 @@ where command is one of:
                     };
 
                     let mut analysis_db = analysis_db_conn.begin_save_point();
-                    match type_check("transient", &mut ast, &mut analysis_db, true) {
+                    match type_check(":transient:", &mut ast, &mut analysis_db, true) {
                         Ok(_) => (),
                         Err(error) => {
                             println!("Type check error:\n{}", error);
@@ -302,7 +302,7 @@ where command is one of:
 
                 let mut ast = parse(&content).expect("Failed to parse program.");
                 let mut analysis_db = analysis_db_conn.begin_save_point();
-                match type_check("transient", &mut ast, &mut analysis_db, true) {
+                match type_check(":transient:", &mut ast, &mut analysis_db, true) {
                     Ok(_) => {
                         let result = vm_env.get_exec_environment(None).eval_raw(&content);
                         match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,8 @@ where command is one of:
   check              to typecheck a potential contract definition.
   launch             to launch a initialize a new contract in the local state database.
   eval               to evaluate (in read-only mode) a program in a given contract context.
+  eval_raw           to typecheck and evaluate an expression without a contract or database context.
+  repl               to typecheck and evaluate expressions in a stdin/stdout loop.
   execute            to execute a public function of a defined contract.
 
 ", argv[0]);
@@ -139,6 +141,7 @@ where command is one of:
 
         use std::io;
         use std::io::Read;
+        use std::io::Write;
         use vm::parser::parse;
         use vm::contexts::OwnedEnvironment;
         use vm::database::{ContractDatabase, ContractDatabaseConnection, ContractDatabaseTransacter};
@@ -207,6 +210,116 @@ where command is one of:
                         process::exit(1);
                     });
 
+                return
+            },
+            "repl" => {
+                let mut db_conn = match ContractDatabaseConnection::memory() {
+                    Ok(db) => db,
+                    Err(error) => {
+                        eprintln!("Could not open vm-state: \n{}", error);
+                        process::exit(1);
+                    }
+                };
+
+                let mut outer_sp = db_conn.begin_save_point_raw();                    
+                let mut db = ContractDatabase::from_savepoint(outer_sp);
+
+                let mut vm_env = OwnedEnvironment::new(&mut db);
+                let mut exec_env = vm_env.get_exec_environment(None);
+
+                let mut analysis_db_conn = AnalysisDatabaseConnection::memory();
+
+                let mut stdout = io::stdout();
+
+                loop {
+                    let content: String = {
+                        let mut buffer = String::new();
+                        stdout.write(b"> ");
+                        stdout.flush();
+                        match io::stdin().read_line(&mut buffer) {
+                            Ok(_) => buffer,
+                            Err(error) => {
+                                eprintln!("Error reading from stdin:\n{}", error);
+                                process::exit(1);
+                            }
+                        }
+                    };
+
+                    let mut ast = match parse(&content) {
+                        Ok(val) => val,
+                        Err(error) => {
+                            println!("Parse error:\n{}", error);
+                            continue;
+                        }
+                    };
+
+                    let mut analysis_db = analysis_db_conn.begin_save_point();
+                    match type_check("transient", &mut ast, &mut analysis_db, true) {
+                        Ok(_) => (),
+                        Err(error) => {
+                            println!("Type check error:\n{}", error);
+                            continue;
+                        } 
+                    }
+
+                    let eval_result = match exec_env.eval_raw(&content) {
+                        Ok(val) => val,
+                        Err(error) => {
+                            println!("Execution error:\n{}", error);
+                            continue;
+                        }
+                    };
+                    
+                    println!("{}", eval_result);
+                }
+            },
+            "eval_raw" => {
+                if argv.len() < 2 {
+                    eprintln!("Usage: {} local eval_raw", argv[0]);
+                    process::exit(1);
+                }
+
+                let content: String = {
+                    let mut buffer = String::new();
+                    io::stdin().read_to_string(&mut buffer)
+                        .expect("Error reading from stdin.");
+                    buffer
+                };
+
+                let mut db_conn = match ContractDatabaseConnection::memory() {
+                    Ok(db) => db,
+                    Err(error) => {
+                        eprintln!("Could not open vm-state: \n{}", error);
+                        process::exit(1);
+                    }
+                };
+
+                let mut outer_sp = db_conn.begin_save_point_raw();                    
+                let mut db = ContractDatabase::from_savepoint(outer_sp);
+                let mut analysis_db_conn = AnalysisDatabaseConnection::memory();
+
+                let mut vm_env = OwnedEnvironment::new(&mut db);
+
+                let mut ast = parse(&content).expect("Failed to parse program.");
+                let mut analysis_db = analysis_db_conn.begin_save_point();
+                match type_check("transient", &mut ast, &mut analysis_db, true) {
+                    Ok(_) => {
+                        let result = vm_env.get_exec_environment(None).eval_raw(&content);
+                        match result {
+                            Ok(x) => {
+                                println!("Program executed successfully! Output: \n{}", x);
+                            },
+                            Err(error) => {
+                                eprintln!("Program execution error: \n{}", error);
+                                process::exit(1);
+                            }
+                        }
+                    },
+                    Err(error) => {
+                        eprintln!("Type check error.\n{}", error);
+                        process::exit(1);
+                    }
+                }
                 return
             },
             "eval" => {

--- a/src/vm/checker/typecheck/tests/contracts.rs
+++ b/src/vm/checker/typecheck/tests/contracts.rs
@@ -232,7 +232,7 @@ fn test_bad_map_usage() {
 
     for contract in tests.iter() {
         let mut contract = parse(contract).unwrap();
-        let result = type_check(&"transient", &mut contract, &mut db, false);
+        let result = type_check(&":transient:", &mut contract, &mut db, false);
         let err = result.expect_err("Expected a type error");
         assert!(match &err.err {
             &CheckErrors::TypeError(_,_) => true,

--- a/src/vm/checker/typecheck/tests/mod.rs
+++ b/src/vm/checker/typecheck/tests/mod.rs
@@ -136,14 +136,14 @@ fn test_define() {
     let mut analysis_db = analysis_conn.begin_save_point();
 
     for mut good_test in good.iter().map(|x| parse(x).unwrap()) {
-        type_check(&"transient", &mut good_test, &mut analysis_db, false).unwrap();
+        type_check(&":transient:", &mut good_test, &mut analysis_db, false).unwrap();
     }
 
     let mut analysis_conn = AnalysisDatabaseConnection::memory();
     let mut analysis_db = analysis_conn.begin_save_point();
     
     for mut bad_test in bad.iter().map(|x| parse(x).unwrap()) {
-        assert!(type_check(&"transient", &mut bad_test, &mut analysis_db, false).is_err());
+        assert!(type_check(&":transient:", &mut bad_test, &mut analysis_db, false).is_err());
     }
 }
 
@@ -175,7 +175,7 @@ fn test_factorial() {
     let mut analysis_conn = AnalysisDatabaseConnection::memory();
     let mut analysis_db = analysis_conn.begin_save_point();
 
-    type_check(&"transient", &mut contract, &mut analysis_db, false).unwrap();
+    type_check(&":transient:", &mut contract, &mut analysis_db, false).unwrap();
 }
 
 #[test]
@@ -204,5 +204,5 @@ fn test_tuple_map() {
     let mut analysis_conn = AnalysisDatabaseConnection::memory();
     let mut analysis_db = analysis_conn.begin_save_point();
 
-    type_check(&"transient", &mut t, &mut analysis_db, false).unwrap();
+    type_check(&":transient:", &mut t, &mut analysis_db, false).unwrap();
 }

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -124,6 +124,18 @@ impl <'a, 'b> Environment <'a, 'b> {
 
         result
     }
+    
+    pub fn eval_raw(&mut self, program: &str) -> Result<Value> {
+        let parsed = parser::parse(program)?;
+        if parsed.len() < 1 {
+            return Err(Error::new(ErrType::ParseError("Expected a program of at least length 1".to_string())))
+        }
+        let local_context = LocalContext::new();
+        let result = {
+            eval(&parsed[0], self, &local_context)
+        };
+        result
+    }
 
     pub fn execute_contract(&mut self, contract_name: &str, 
                             tx_name: &str, args: &[SymbolicExpression]) -> Result<Value> {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -198,7 +198,7 @@ fn eval_all (expressions: &[SymbolicExpression],
  *  database.
  */
 pub fn execute(program: &str) -> Result<Value> {
-    let mut contract_context = ContractContext::new("transient".to_string());
+    let mut contract_context = ContractContext::new(":transient:".to_string());
     let mut conn = ContractDatabaseConnection::memory()?;
     let mut global_context = GlobalContext::begin_from(&mut conn);
     let result = {
@@ -240,7 +240,7 @@ mod test {
                                                          &"do_work", &"");
 
         let context = LocalContext::new();
-        let mut contract_context = ContractContext::new("transient".to_string());
+        let mut contract_context = ContractContext::new(":transient:".to_string());
 
         let mut conn = ContractDatabaseConnection::memory().unwrap();
         let mut global_context = GlobalContext::begin_from(&mut conn);

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -95,7 +95,7 @@ fn test_simple_if_functions() {
             func_args2, parsed_bodies[1].clone(), &"without_else", &"");
 
         let context = LocalContext::new();
-        let mut contract_context = ContractContext::new("transient".to_string());
+        let mut contract_context = ContractContext::new(":transient:".to_string());
         let mut conn = ContractDatabaseConnection::memory().unwrap();
         let mut global_context = GlobalContext::begin_from(&mut conn);
 


### PR DESCRIPTION
### Initial REPL implementation
Implement a new `local` command `local repl`. 

Uses the rust stdin/stdout so input interactivity is limited -- notably input cursor operation. The SDK project can wrap this stdin/out pipe to provide a more full-featured terminal lib. 

Initial implementation is currently stateless, but still quite useful for local dev & testing purposes since it performs type checking and (stateless) evals on expressions. 

Next iterations for providing state require something like:
* Execute evals within an implicit `transient` contract state and commit the savepoints. 
* Allow top-level (contract level) expressions and have them "appended" to `transient` contract source / ast. 

Providing REPL support for multiple contracts requires something like:
* Define a special function (available only in local dev / repl env) for defining & deploying a new contract, with the given name and source-expression. 
* Define another similar special function for switching context between the currently executing contract. 


A `local eval_raw` command is also implemented which provides the same ability to typecheck and execute a raw expression without having to provide any state or db initialization. 