### PR TITLE
force single-threaded tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,5 @@ jobs:
             BLOCKSTACK_DEBUG: 1
             RUSTFLAGS: -Clink-dead-code
           command: |
-            cargo test
+            cargo test -- --test-threads 1
 #            cargo kcov && bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Force all cargo tests to run single-threaded so the network tests don't trip over themselves.