### PR TITLE
Use macro for generating a list of all NativeFunctions - use for docgen

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -459,10 +459,8 @@ fn make_api_reference(function: &NativeFunctions) -> FunctionAPI {
 }
 
 pub fn make_json_api_reference() -> String {
-    use vm::functions::NativeFunctions::*;
-    let natives = [ Add, Subtract, Multiply, Divide, CmpGeq, CmpLeq, CmpLess, CmpGreater, Modulo, Power,
-                    BitwiseXOR, And, Or, Not, Equals ];
-    let json_references: Vec<_> = natives.iter()
+    use vm::functions::NativeFunctions;
+    let json_references: Vec<_> = NativeFunctions::ALL.iter()
         .map(|x| make_api_reference(x))
         .collect();
     format!("{}", serde_json::to_string(&json_references)

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -12,7 +12,21 @@ use vm::representations::{SymbolicExpression, SymbolicExpressionType};
 use vm::representations::SymbolicExpressionType::{List, Atom};
 use vm::{LocalContext, Environment, eval};
 
-pub enum NativeFunctions {
+
+macro_rules! define_enum {
+    ($Name:ident { $($Variant:ident),* $(,)* }) =>
+    {
+        #[derive(Debug)]
+        pub enum $Name {
+            $($Variant),*,
+        }
+        impl $Name {
+            pub const ALL: &'static [$Name] = &[$($Name::$Variant),*];
+        }
+    }
+}
+
+define_enum!(NativeFunctions {
     Add,
     Subtract,
     Multiply,
@@ -48,7 +62,7 @@ pub enum NativeFunctions {
     ContractCall,
     AsContract,
     GetBlockInfo
-}
+});
 
 impl NativeFunctions {
     pub fn lookup_by_name(name: &str) -> Option<NativeFunctions> {


### PR DESCRIPTION
We have docgen matching enforced for all native functions -- as in every func must have a corresponding doc object. 

But no way to ensure that every func variant is enumerated during the actual generation. 

This macro appears to be the least invasive technique to achieving this. 

Is this idiomatic usage of macros? Is there a better way to do this?