### PR TITLE
Fix Code Coverage Reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [[bin]]
 name = "clarity-cli"
+test = false
 path = "src/clarity_cli.rs"
 
 [features]

--- a/circle.yml
+++ b/circle.yml
@@ -13,23 +13,24 @@ jobs:
           path: /build/dist/
           destination: dist/
   build:
+    machine: true
     working_directory: ~/blockstack
-    docker:
-      - image: circleci/rust
     steps:
       - checkout
       - run:
+          name: Pull Cargo Tarpaulin Image
           command: |
-            cargo build
+            docker pull xd009642/tarpaulin
       - run:
-          environment:
-            RUST_BACKTRACE: 1
-            BLOCKSTACK_DEBUG: 1
-            RUSTFLAGS: -Clink-dead-code
+          name: Run tests in Cargo Tarpaulin Image
           command: |
-            cargo test -- --test-threads 1
-#            cargo kcov && bash <(curl -s https://codecov.io/bash)
-
+            docker run --security-opt seccomp=unconfined -e RUST_BACKTRACE=1 -e BLOCKSTACK_DEBUG=1 \
+            -e RUSTFLAGS=-Clink-dead-code -v "$PWD:/volume" xd009642/tarpaulin cargo tarpaulin -o Xml \
+            -- --bin blockstack-core -- --test-threads 1
+      - run:
+          name: Upload to codecov.io
+          command: |
+            bash <(curl -s https://codecov.io/bash)
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             docker run --security-opt seccomp=unconfined -e RUST_BACKTRACE=1 -e BLOCKSTACK_DEBUG=1 \
             -e RUSTFLAGS=-Clink-dead-code -v "$PWD:/volume" xd009642/tarpaulin cargo tarpaulin -o Xml \
-            -- --bin blockstack-core -- --test-threads 1
+            -- --test-threads 1
       - run:
           name: Upload to codecov.io
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ jobs:
           name: Run tests in Cargo Tarpaulin Image
           command: |
             docker run --security-opt seccomp=unconfined -e RUST_BACKTRACE=1 -e BLOCKSTACK_DEBUG=1 \
-            -e RUSTFLAGS=-Clink-dead-code -v "$PWD:/volume" xd009642/tarpaulin cargo tarpaulin -o Xml \
+            -e RUSTFLAGS=-Clink-dead-code -v "$PWD:/volume" xd009642/tarpaulin cargo tarpaulin -t 300 -o Xml \
             -- --test-threads 1
       - run:
           name: Upload to codecov.io


### PR DESCRIPTION
This adds back in a codecov.io reporting system to our CircleCI definitions.

It also turns off tests for the clarity bin, since they were just duplicates.

Note -- the "deploy" definition of our circle definition is also suddenly breaking for some reason, but I think that's unrelated to these changes.