### PR TITLE
Updating to enable cut and paste examples

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -32,15 +32,15 @@ const ADD_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "+ (add)",
     signature: "(+ i1 i2...)",
     description: "Adds a variable number of integer inputs and returns the result. In the event of an _overflow_, throws a runtime error.",
-    example: "(+ 1 2 3) => 6"
+    example: "(+ 1 2 3) ;; Returns 6"
 };
 
 const SUB_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "- (subtract)",
     signature: "(- i1 i2...)",
     description: "Subtracts a variable number of integer inputs and returns the result. In the event of an _underflow_, throws a runtime error.",
-    example: "(- 2 1 1) => 0
-(- 0 3) => -3
+    example: "(- 2 1 1) ;; Returns 0
+(- 0 3) ;; Returns -3
 "
 };
 
@@ -49,8 +49,8 @@ const DIV_API: SimpleFunctionAPI = SimpleFunctionAPI {
     signature: "(/ i1 i2...)",
     description: "Integer divides a variable number of integer inputs and returns the result. In the event of division by zero, throws a runtime error.",
     example: "(/ 2 3) => 0
-(/ 5 2) => 2
-(/ 4 2 2) => 1
+(/ 5 2) ;; Returns 2
+(/ 4 2 2) ;; Returns 1
 "
 };
 
@@ -58,9 +58,9 @@ const MUL_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "* (multiply)",
     signature: "(* i1 i2...)",
     description: "Multiplies a variable number of integer inputs and returns the result. In the event of an _overflow_, throws a runtime error.",
-    example: "(* 2 3) => 6
-(* 5 2) => 10
-(* 2 2 2) => 8
+    example: "(* 2 3) ;; Returns 6
+(* 5 2) ;; Returns 10
+(* 2 2 2) ;; Returns 8
 "
 };
 
@@ -68,9 +68,9 @@ const MOD_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "mod",
     signature: "(mod i1 i2)",
     description: "Returns the integer remainder from integer dividing i1 by i2. In the event of a division by zero, throws a runtime error.",
-    example: "(mod 2 3) => 0
-(mod 5 2) => 1
-(mod 7 1) => 0
+    example: "(mod 2 3) ;; Returns 0
+(mod 5 2) ;; Returns 1
+(mod 7 1) ;; Returns 0
 "
 };
 
@@ -78,9 +78,9 @@ const POW_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "pow",
     signature: "(pow i1 i2)",
     description: "Returns the result of raising i1 to the power of i2. In the event of an _overflow_, throws a runtime error.",
-    example: "(pow 2 3) => 8
-(pow 2 2) => 4
-(pow 7 1) => 7
+    example: "(pow 2 3) ;; Returns 8
+(pow 2 2) ;; Returns 4
+(pow 7 1) ;; Returns 7
 "
 };
 
@@ -88,8 +88,8 @@ const XOR_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "xor",
     signature: "(xor i1 i2)",
     description: "Returns the result of bitwise exclusive or'ing i1 with i2.",
-    example: "(xor 1 2) => 3
-(xor 120 280) => 352
+    example: "(xor 1 2) ;; Returns 3
+(xor 120 280) ;; Returns 352
 "
 };
 
@@ -97,9 +97,9 @@ const AND_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "and",
     signature: "(and b1 b2 ...)",
     description: "Returns true if all boolean inputs are true. Importantly, the supplied arguments are evaluated in-order and lazily, such that if one of the arguments returns false, no subsequent arguments are evaluated.",
-    example: "(and 'true 'false) => false
-(and (eq? (+ 1 2) 1) (eq? 4 4)) => false
-(and (eq? (+ 1 2) 3) (eq? 4 4)) => true
+    example: "(and 'true 'false) ;; Returns false
+(and (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns false
+(and (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns true
 "
 };
 
@@ -107,10 +107,10 @@ const OR_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "or",
     signature: "(or b1 b2 ...)",
     description: "Returns true if any boolean inputs are true. Importantly, the supplied arguments are evaluated in-order and lazily, such that if one of the arguments returns true, no subsequent arguments are evaluated.",
-    example: "(or 'true 'false) => true
-(or (eq? (+ 1 2) 1) (eq? 4 4)) => true
-(or (eq? (+ 1 2) 1) (eq? 3 4)) => false
-(or (eq? (+ 1 2) 3) (eq? 4 4)) => true
+    example: "(or 'true 'false) ;; Returns true
+(or (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns true
+(or (eq? (+ 1 2) 1) (eq? 3 4)) ;; Returns false
+(or (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns true
 "
 };
 
@@ -118,8 +118,8 @@ const NOT_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "not",
     signature: "(not b1)",
     description: "Returns the inverse of the boolean input.",
-    example: "(not 'true) => false
-(not (eq? 1 2)) => true
+    example: "(not 'true) ;; Returns false
+(not (eq? 1 2)) ;; Returns true
 "
 };
 
@@ -127,8 +127,8 @@ const GEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: ">= (greater than or equal)",
     signature: "(>= i1 i2)",
     description: "Compares two integers, returning true if i1 is greater than or equal to i2 and false otherwise.",
-    example: "(>= 1 1) => true
-(>= 5 2) => true
+    example: "(>= 1 1) ;; Returns true
+(>= 5 2) ;; Returns true
 "
 };
 
@@ -136,7 +136,7 @@ const LEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "<= (less than or equal)",
     signature: "(> i1 i2)",
     description: "Compares two integers, returning true if i1 is less than or equal to i2 and false otherwise.",
-    example: "(<= 1 1) => true
+    example: "(<= 1 1) ;; Returns true
 (<= 5 2) => false
 "
 };
@@ -145,9 +145,9 @@ const EQUALS_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "eq?",
     signature: "(eq? v1 v2...)",
     description: "Compares the inputted values, returning true if they are all equal. Note that _unlike_ the `(and ...)` function, `(eq? ...)` will _not_ short-circuit.",
-    example: "(eq? 1 1) => true
-(eq? 1 'null) => false
-(eq? \"abc\" 234 234) => false
+    example: "(eq? 1 1) ;; Returns true
+(eq? 1 'null) ;; Returns false
+(eq? \"abc\" 234 234) ;; Returns false
 "
 };
 
@@ -155,8 +155,8 @@ const GREATER_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "> (greater than)",
     signature: "(> i1 i2)",
     description: "Compares two integers, returning true if i1 is greater than i2 and false otherwise.",
-    example: "(> 1 2) => false
-(> 5 2) => true
+    example: "(> 1 2) ;; Returns false
+(> 5 2) ;; Returns true
 "
 };
 
@@ -164,8 +164,8 @@ const LESS_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "< (less than)",
     signature: "(< i1 i2)",
     description: "Compares two integers, returning true if i1 is less than i2 and false otherwise.",
-    example: "(< 1 2) => true
-(< 5 2) => false
+    example: "(< 1 2) ;; Returns true
+(< 5 2) ;; Returns false
 "
 };
 
@@ -214,8 +214,8 @@ const IF_API: SpecialAPI = SpecialAPI {
 which must return the same type. In the case that the boolean input is `true`, the
 `if` function evaluates and returns `expr1`. If the boolean input is `false`, the
 `if` function evaluates and returns `expr2`.",
-    example: "(if true 1 2) => 1
-(if (> 1 2) 1 2) => 2"
+    example: "(if true 1 2) ;; Returns 1
+(if (> 1 2) 1 2) ;; Returns 2"
 };
 
 const LET_API: SpecialAPI = SpecialAPI { 
@@ -226,7 +226,7 @@ const LET_API: SpecialAPI = SpecialAPI {
     description: "The `let` function accepts a list of `variable name` and `expression` pairs,
 evaluating each expression and _binding_ it to the corresponding variable name. The _context_
 created by this set of bindings is used for evaluating and return the value of `expr-body`.",
-    example: "(let ((a 2) (b (+ 5 6 7))) (+ a b)) => 20"
+    example: "(let ((a 2) (b (+ 5 6 7))) (+ a b)) ;; Returns 20"
 };
 
 const MAP_API: SpecialAPI = SpecialAPI {
@@ -236,7 +236,7 @@ const MAP_API: SpecialAPI = SpecialAPI {
     signature: "(map func list)",
     description: "The `map` function applies the input function `func` to each element of the
 input list, and outputs a list containing the _outputs_ from those function applications.",
-    example: "(map not (list true false true false)) -> false true false true"
+    example: "(map not (list true false true false)) ;; Returns false true false true"
 };
 
 const FOLD_API: SpecialAPI = SpecialAPI {
@@ -248,8 +248,8 @@ const FOLD_API: SpecialAPI = SpecialAPI {
 input list _and_ the output of the previous application of the `fold` function. When invoked on
 the first list element, it uses the `initial-value` as the second input. `fold` returns the last
 value return by the successive applications.",
-    example: "(fold * (list 2 2 2) 1) => 8
-(fold * (list 2 2 2) 0) => 0"
+    example: "(fold * (list 2 2 2) 1) ;; Returns 8
+(fold * (list 2 2 2) 0) ;; Returns 0"
 };
 
 const LIST_API: SpecialAPI = SpecialAPI {
@@ -259,7 +259,7 @@ const LIST_API: SpecialAPI = SpecialAPI {
     signature: "(list expr1 expr2 expr3 ...)",
     description: "The `list` function constructs a list composed of the inputted values. Each
 supplied value must be of the same type.",
-    example: "(list (+ 1 2) 4 5) => [3 4 5]",
+    example: "(list (+ 1 2) 4 5) ;; Returns [3 4 5]",
 };
 
 const BEGIN_API: SpecialAPI = SpecialAPI {
@@ -269,7 +269,7 @@ const BEGIN_API: SpecialAPI = SpecialAPI {
     signature: "(begin expr1 expr2 expr3 ... expr-last)",
     description: "The `begin` function evaluates each of its input expressions, returning the
 return value of the last such expression.",
-    example: "(begin (+ 1 2) 4 5) => 5",
+    example: "(begin (+ 1 2) 4 5) ;; Returns 5",
 };
 
 const PRINT_API: SpecialAPI = SpecialAPI {
@@ -280,7 +280,7 @@ const PRINT_API: SpecialAPI = SpecialAPI {
     description: "The `print` function evaluates and returns its input expression. On blockstack-core
 nodes configured for development (as opposed to production mining nodes), this function will also
 cause blockstack-core to print the resulting value to STDOUT.",
-    example: "(print (+ 1 2 3)) => 6",
+    example: "(print (+ 1 2 3)) ;; Returns 6",
 };
 
 const FETCH_API: SpecialAPI = SpecialAPI {
@@ -291,7 +291,7 @@ const FETCH_API: SpecialAPI = SpecialAPI {
     description: "The `fetch-entry` function looks up and returns an entry from a contract's data map.
 The value is looked up using `key-tuple`. If there is no value associated with that key in the data
 map, the function returns Void.",
-    example: "(fetch-entry names-map (tuple (name \"blockstack\"))) => (tuple (id 1337))",
+    example: "(fetch-entry names-map (tuple (name \"blockstack\"))) ;; Returns (tuple (id 1337))",
 };
 
 const SET_API: SpecialAPI = SpecialAPI {
@@ -302,7 +302,7 @@ const SET_API: SpecialAPI = SpecialAPI {
     description: "The `set-entry!` function sets the value associated with the input key to the 
 inputted value. This function performs a _blind_ update; whether or not a value is already associated
 with the key, the function overwrites that existing association.",
-    example: "(set-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) => Void",
+    example: "(set-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns Void",
 };
 
 const INSERT_API: SpecialAPI = SpecialAPI {
@@ -314,8 +314,8 @@ const INSERT_API: SpecialAPI = SpecialAPI {
 inputted value if and only if there is not already a value associated with the key in the map.
 In the event that an insert occurred, the function returns `true`. If a value already existed for
 this key in the data map, the function returns `false`.",
-    example: "(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) => true
-(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) => false
+    example: "(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns true
+(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns false
 ",
 };
 
@@ -327,8 +327,8 @@ const DELETE_API: SpecialAPI = SpecialAPI {
     description: "The `delete-entry!` function removes the value associated with the input key for
 the given map. In the event that an item existed, and was removed, the function returns `true`.
 If a value did not exist for this key in the data map, the function returns `false`.",
-    example: "(delete-entry! names-map (tuple (name \"blockstack\"))) => true
-(delete-entry! names-map (tuple (name \"blockstack\"))) => false
+    example: "(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns true
+(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns false
 ",
 };
 
@@ -340,7 +340,7 @@ const FETCH_CONTRACT_API: SpecialAPI = SpecialAPI {
     description: "The `fetch-contract-entry` function looks up and returns an entry from a
 contract other than the current contract's data map. The value is looked up using `key-tuple`.
 If there is no value associated with that key in the data map, the function returns Void.",
-    example: "(fetch-contract-entry names-contract names-map (tuple (name \"blockstack\"))) => (tuple (id 1337))",
+    example: "(fetch-contract-entry names-contract names-map (tuple (name \"blockstack\"))) ;; Returns (tuple (id 1337))",
 };
 
 const TUPLE_CONS_API: SpecialAPI = SpecialAPI {
@@ -362,8 +362,8 @@ const TUPLE_GET_API: SpecialAPI = SpecialAPI {
     signature: "(get key-name tuple)",
     description: "The `get` function fetches the value associated with a given key from the supplied typed tuple.
 If a Void value is supplied as the inputted tuple, `get` returns Void.",
-    example: "(get id (tuple (name \"blockstack\") (id 1337))) => 1337
-(get id 'null) => 'null
+    example: "(get id (tuple (name \"blockstack\") (id 1337))) ;; Returns 1337
+(get id 'null) ;; Returns 'null
 "
 };
 
@@ -375,7 +375,7 @@ const HASH160_API: SpecialAPI = SpecialAPI {
     description: "The `hash160` function computes RIPEMD160(SHA256(x)) of the inputted value.
 If an integer (128 bit) is supplied the hash is computed over the little endian representation of the
 integer.",
-    example: "(hash160 0) => 0xe4352f72356db555721651aa612e00379167b30f"
+    example: "(hash160 0) ;; Returns 0xe4352f72356db555721651aa612e00379167b30f"
 };
 
 const SHA256_API: SpecialAPI = SpecialAPI {
@@ -386,7 +386,7 @@ const SHA256_API: SpecialAPI = SpecialAPI {
     description: "The `sha256` function computes SHA256(x) of the inputted value.
 If an integer (128 bit) is supplied the hash is computer over the little endian representation of the
 integer.",
-    example: "(sha256 0) => 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb"
+    example: "(sha256 0) ;; Returns 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb"
 };
 
 const KECCAK256_API: SpecialAPI = SpecialAPI {
@@ -397,7 +397,7 @@ const KECCAK256_API: SpecialAPI = SpecialAPI {
     description: "The `keccak256` function computes KECCAK256(value) of the inputted value.
 Note that this differs from the NIST SHA-3 (i.e. FIPS 202) standard. If an integer (128 bit) 
 is supplied the hash is computer over the little endian representation of the integer.",
-    example: "(keccak256 0) => 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4"
+    example: "(keccak256 0) ;; Returns 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4"
 };
 
 const CONTRACT_CALL_API: SpecialAPI = SpecialAPI {
@@ -409,7 +409,7 @@ const CONTRACT_CALL_API: SpecialAPI = SpecialAPI {
 This function _may not_ be used to call a public function defined in the current contract. If the public
 function returns _false_, any database changes resulting from calling `contract-call!` are aborted.
 If the function returns _true_, database changes have occurred.",
-    example: "(contract-call! tokens transfer 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 19) => 'true"
+    example: "(contract-call! tokens transfer 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 19) ;; Returns 'true"
 };
 
 const AS_CONTRACT_API: SpecialAPI = SpecialAPI {
@@ -419,7 +419,7 @@ const AS_CONTRACT_API: SpecialAPI = SpecialAPI {
     signature: "(as-contract expr)",
     description: "The `as-contract` function switches the current context's `tx-sender` value to the _contract's_ 
 principal, and executes `expr` with that context. It returns the resulting value of `expr`.",
-    example: "(as-contract (print tx-sender)) => 'CTcontract.name"
+    example: "(as-contract (print tx-sender)) ;; Returns 'CTcontract.name"
 };
 
 const GET_BLOCK_INFO_API: SpecialAPI = SpecialAPI {
@@ -438,9 +438,9 @@ and block times are accurate only to within two hours. See BIP113 for more infor
 
 The `header-hash`, `burnchain-header-hash`, and `vrf-seed` properties return a 32-byte buffer. 
 ",
-    example: "(get-block-info time 10) => 1557860301
-(get-block-info header-hash 2) => 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb
-(get-block-info vrf-seed 6) => 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4
+    example: "(get-block-info time 10) ;; Returns 1557860301
+(get-block-info header-hash 2) ;; Returns 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb
+(get-block-info vrf-seed 6) ;; Returns 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4
 "
 };
 


### PR DESCRIPTION
The examples in `mod.rs` aren't formatted to be cut and paste into files or commands because of the `=>` instead of legal comments like `;; Returns blah blah`

this fixes that problem

Signed-off-by: Mary Anthony <mary@blockstack.com>