### PR TITLE
Fix macos dist build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Cargo.lock
 
 node_modules
 osxcross
+osxcross*.tar.xz

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Cargo.lock
 **/*.rs.bk
 
 node_modules
+osxcross

--- a/build-scripts/build-dist-mac-x64.sh
+++ b/build-scripts/build-dist-mac-x64.sh
@@ -15,8 +15,9 @@ build_sdk () {
   apt-get update
   apt-get install -y clang cmake
   git clone https://github.com/blockstackpbc/osxcross --depth=1
-  wget -nc https://github.com/blockstackpbc/osxcross/releases/download/v1/MacOSX10.14.sdk.tar.bz2 --directory-prefix=osxcross/tarballs/
-  UNATTENDED=yes OSX_VERSION_MIN=10.7 ./osxcross/build.sh
+  wget -N "https://github.com/blockstackpbc/osxcross/releases/download/v1/MacOSX10.14.sdk.tar.bz2" --directory-prefix=osxcross/tarballs/
+  UNATTENDED=yes DISABLE_LTO_SUPPORT=1 OSX_VERSION_MIN=10.7 ./osxcross/build.sh
+  cd ./osxcross
   BINARYPACKAGE=1 ./package.sh
 }
 

--- a/build-scripts/build-dist-mac-x64.sh
+++ b/build-scripts/build-dist-mac-x64.sh
@@ -8,6 +8,9 @@ set -e
 
 cd "$(dirname "$(dirname "$0")")"
 
+apt-get update
+apt-get install -y clang
+
 build_sdk () {
   apt-get update
   apt-get install -y clang cmake

--- a/build-scripts/build-dist-mac-x64.sh
+++ b/build-scripts/build-dist-mac-x64.sh
@@ -29,7 +29,6 @@ fetch_extract_sdk() {
 fetch_extract_sdk
 rustup target add x86_64-apple-darwin
 
-PATH="$(pwd)/osxcross/target/bin:$PATH" \
 PATH="$(pwd)/osxcross/bin:$PATH" \
 CC=o64-clang \
 CXX=o64-clang++ \

--- a/build-scripts/build-dist-mac-x64.sh
+++ b/build-scripts/build-dist-mac-x64.sh
@@ -4,26 +4,34 @@
 
 ### This script uses osxcross [https://github.com/tpoechtrager/osxcross] to cross-compile from linux to MacOS.
 
+set -e
+
 cd "$(dirname "$(dirname "$0")")"
 
-apt-get update
-apt-get install -y clang
+build_sdk () {
+  apt-get update
+  apt-get install -y clang cmake
+  git clone https://github.com/blockstackpbc/osxcross --depth=1
+  wget -nc https://github.com/blockstackpbc/osxcross/releases/download/v1/MacOSX10.14.sdk.tar.bz2 --directory-prefix=osxcross/tarballs/
+  UNATTENDED=yes OSX_VERSION_MIN=10.7 ./osxcross/build.sh
+  BINARYPACKAGE=1 ./package.sh
+}
 
-git clone https://github.com/tpoechtrager/osxcross.git --depth=1
+fetch_extract_sdk() {
+  wget -nc "https://github.com/blockstackpbc/osxcross/releases/download/v1/osxcross-e0a1718_xcode-v10.2.1.tar.xz"
+  echo "Extracting osxcross package..."
+  tar --checkpoint=1000 -xf  "osxcross-e0a1718_xcode-v10.2.1.tar.xz"
+}
 
-### Download a pre-bundled osx-sdk. The official method requires downloading and extracting the 
-### sdk from a 5.2GB Xcode_7.x.dmg file, which requires an Apple ID to download. 
-wget -nc https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.11.sdk.tar.xz --directory-prefix=osxcross/tarballs/
-
-UNATTENDED=yes OSX_VERSION_MIN=10.7 ./osxcross/build.sh
-
+fetch_extract_sdk
 rustup target add x86_64-apple-darwin
 
 PATH="$(pwd)/osxcross/target/bin:$PATH" \
+PATH="$(pwd)/osxcross/bin:$PATH" \
 CC=o64-clang \
 CXX=o64-clang++ \
 LIBZ_SYS_STATIC=1 \
-CC_x86_64_apple_darwin=x86_64-apple-darwin15-clang \
-CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=x86_64-apple-darwin15-clang \
-CARGO_TARGET_X86_64_APPLE_DARWIN_AR=x86_64-apple-darwin15-ar \
+CC_x86_64_apple_darwin=x86_64-apple-darwin18-clang \
+CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=x86_64-apple-darwin18-clang \
+CARGO_TARGET_X86_64_APPLE_DARWIN_AR=x86_64-apple-darwin18-ar \
 cargo build --target x86_64-apple-darwin --release

--- a/build-scripts/build-dist-mac-x64.sh
+++ b/build-scripts/build-dist-mac-x64.sh
@@ -31,6 +31,7 @@ fetch_extract_sdk
 rustup target add x86_64-apple-darwin
 
 PATH="$(pwd)/osxcross/bin:$PATH" \
+LD_LIBRARY_PATH="$(pwd)/osxcross/lib:$LD_LIBRARY_PATH" \
 CC=o64-clang \
 CXX=o64-clang++ \
 LIBZ_SYS_STATIC=1 \

--- a/build-scripts/docker-run.sh
+++ b/build-scripts/docker-run.sh
@@ -4,7 +4,7 @@ script_path="$(dirname "$0")"
 src_dir="$(dirname "$script_path")"
 cd "$src_dir"
 
-rust_image="rust:1.34-stretch"
+rust_image="rust:1.34.0-stretch"
 
 docker run \
   --volume `pwd`:/build \

--- a/build-scripts/start-builds.sh
+++ b/build-scripts/start-builds.sh
@@ -80,9 +80,9 @@ case $DIST_TARGET_FILTER in
     esac
     ;;
   (*)
+    build_mac_x64
     build_linux_x64
     build_linux_musl_x64
     build_win_x64
-    build_mac_x64
     ;;
 esac

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   deploy:
     working_directory: /build
     docker:
-      - image: rust:1.34-stretch
+      - image: rust:1.34.0-stretch
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Fixed for cross-compiling with latest osxcross.
CircleCI builds are faster -- now using a minimal archive of osxcross that is pre-packaged for use in the `buildpack-deps:stretch` docker image (Rust's base image). 

The dependency archives are uploaded as releases on a fork of osxcross here https://github.com/blockstackpbc/osxcross/releases

The fork & release packages also pin the version so the MacOS build doesn't break again in the same way in the future. 