### PR TITLE
Fixing change which broke the documentation generation

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -126,7 +126,7 @@ const NOT_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const GEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: ">= (greater than or equal)",
     signature: "(>= i1 i2)",
-    description: "Compares two integers, returning `true` if `i1` is greater than or equal to `i2` and false otherwise.",
+    description: "Compares two integers, returning `true` if `i1` is greater than or equal to `i2` and `false` otherwise.",
     example: "(>= 1 1) ;; Returns true
 (>= 5 2) ;; Returns true
 "
@@ -135,7 +135,7 @@ const GEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const LEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "<= (less than or equal)",
     signature: "(> i1 i2)",
-    description: "Compares two integers, returning true if `i1` is less than or equal to `i2` and false otherwise.",
+    description: "Compares two integers, returning true if `i1` is less than or equal to `i2` and `false` otherwise.",
     example: "(<= 1 1) ;; Returns true
 (<= 5 2) ;; Returns false
 "

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -67,7 +67,7 @@ const MUL_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const MOD_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "mod",
     signature: "(mod i1 i2)",
-    description: "Returns the integer remainder from integer dividing i1 by i2. In the event of a division by zero, throws a runtime error.",
+    description: "Returns the integer remainder from integer dividing `i1` by `i2`. In the event of a division by zero, throws a runtime error.",
     example: "(mod 2 3) ;; Returns 0
 (mod 5 2) ;; Returns 1
 (mod 7 1) ;; Returns 0
@@ -77,7 +77,7 @@ const MOD_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const POW_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "pow",
     signature: "(pow i1 i2)",
-    description: "Returns the result of raising i1 to the power of i2. In the event of an _overflow_, throws a runtime error.",
+    description: "Returns the result of raising `i1` to the power of `i2`. In the event of an _overflow_, throws a runtime error.",
     example: "(pow 2 3) ;; Returns 8
 (pow 2 2) ;; Returns 4
 (pow 7 1) ;; Returns 7
@@ -87,7 +87,7 @@ const POW_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const XOR_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "xor",
     signature: "(xor i1 i2)",
-    description: "Returns the result of bitwise exclusive or'ing i1 with i2.",
+    description: "Returns the result of bitwise exclusive or'ing `i1` with `i2`.",
     example: "(xor 1 2) ;; Returns 3
 (xor 120 280) ;; Returns 352
 "
@@ -96,7 +96,7 @@ const XOR_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const AND_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "and",
     signature: "(and b1 b2 ...)",
-    description: "Returns true if all boolean inputs are true. Importantly, the supplied arguments are evaluated in-order and lazily, such that if one of the arguments returns false, no subsequent arguments are evaluated.",
+    description: "Returns `true` if all boolean inputs are `true`. Importantly, the supplied arguments are evaluated in-order and lazily. Lazy evaluation means that if one of the arguments returns `false`, the function short-circuits, and no subsequent arguments are evaluated.",
     example: "(and 'true 'false) ;; Returns false
 (and (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns false
 (and (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns true
@@ -106,7 +106,7 @@ const AND_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const OR_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "or",
     signature: "(or b1 b2 ...)",
-    description: "Returns true if any boolean inputs are true. Importantly, the supplied arguments are evaluated in-order and lazily, such that if one of the arguments returns true, no subsequent arguments are evaluated.",
+    description: "Returns `true` if any boolean inputs are `true`. Importantly, the supplied arguments are evaluated in-order and lazily. Lazy evaluation means that if one of the arguments returns `false`, the function short-circuits, and no subsequent arguments are evaluated.",
     example: "(or 'true 'false) ;; Returns true
 (or (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns true
 (or (eq? (+ 1 2) 1) (eq? 3 4)) ;; Returns false
@@ -119,14 +119,14 @@ const NOT_API: SimpleFunctionAPI = SimpleFunctionAPI {
     signature: "(not b1)",
     description: "Returns the inverse of the boolean input.",
     example: "(not 'true) ;; Returns false
-(not (eq? 1 2)) ;; Returns true
+(not (eq? 1 2)) ;; Returns `true`
 "
 };
 
 const GEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: ">= (greater than or equal)",
     signature: "(>= i1 i2)",
-    description: "Compares two integers, returning true if i1 is greater than or equal to i2 and false otherwise.",
+    description: "Compares two integers, returning `true` if `i1` is greater than or equal to `i2` and false otherwise.",
     example: "(>= 1 1) ;; Returns true
 (>= 5 2) ;; Returns true
 "
@@ -135,7 +135,7 @@ const GEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const LEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "<= (less than or equal)",
     signature: "(> i1 i2)",
-    description: "Compares two integers, returning true if i1 is less than or equal to i2 and false otherwise.",
+    description: "Compares two integers, returning true if `i1` is less than or equal to `i2` and false otherwise.",
     example: "(<= 1 1) ;; Returns true
 (<= 5 2) ;; Returns false
 "
@@ -144,7 +144,7 @@ const LEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const EQUALS_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "eq?",
     signature: "(eq? v1 v2...)",
-    description: "Compares the inputted values, returning true if they are all equal. Note that _unlike_ the `(and ...)` function, `(eq? ...)` will _not_ short-circuit.",
+    description: "Compares the inputted values, returning `true` if they are all equal. Note that _unlike_ the `(and ...)` function, `(eq? ...)` will _not_ short-circuit.",
     example: "(eq? 1 1) ;; Returns true
 (eq? 1 'false) ;; Returns false
 (eq? \"abc\" 234 234) ;; Returns false
@@ -154,7 +154,7 @@ const EQUALS_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const GREATER_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "> (greater than)",
     signature: "(> i1 i2)",
-    description: "Compares two integers, returning true if i1 is greater than i2 and false otherwise.",
+    description: "Compares two integers, returning `true` if `i1` is greater than `i2` and false otherwise.",
     example: "(> 1 2) ;; Returns false
 (> 5 2) ;; Returns true
 "
@@ -163,7 +163,7 @@ const GREATER_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const LESS_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "< (less than)",
     signature: "(< i1 i2)",
-    description: "Compares two integers, returning true if i1 is less than i2 and false otherwise.",
+    description: "Compares two integers, returning `true` if `i1` is less than `i2` and `false` otherwise.",
     example: "(< 1 2) ;; Returns true
 (< 5 2) ;; Returns false
 "
@@ -286,7 +286,7 @@ cause blockstack-core to print the resulting value to STDOUT.",
 const FETCH_API: SpecialAPI = SpecialAPI {
     name: "fetch-entry",
     input_type: "MapName, Tuple",
-    output_type: "Optional<Tuple>",
+    output_type: "Optional(Tuple)",
     signature: "(fetch-entry map-name key-tuple)",
     description: "The `fetch-entry` function looks up and returns an entry from a contract's data map.
 The value is looked up using `key-tuple`.
@@ -313,7 +313,7 @@ const INSERT_API: SpecialAPI = SpecialAPI {
     signature: "(insert-entry! map-name key-tuple value-tuple)",
     description: "The `insert-entry!` function sets the value associated with the input key to the 
 inputted value if and only if there is not already a value associated with the key in the map.
-In the event that an insert occurred, the function returns `true`. If a value already existed for
+If an insert occurs, the function returns `true`. If a value already existed for
 this key in the data map, the function returns `false`.",
     example: "(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns true
 (insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns false
@@ -326,7 +326,7 @@ const DELETE_API: SpecialAPI = SpecialAPI {
     output_type: "bool",
     signature: "(delete-entry! map-name key-tuple)",
     description: "The `delete-entry!` function removes the value associated with the input key for
-the given map. In the event that an item existed, and was removed, the function returns `true`.
+the given map. If an item exists, and is removed, the function returns `true`.
 If a value did not exist for this key in the data map, the function returns `false`.",
     example: "(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns true
 (delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns false
@@ -336,7 +336,7 @@ If a value did not exist for this key in the data map, the function returns `fal
 const FETCH_CONTRACT_API: SpecialAPI = SpecialAPI {
     name: "fetch-contract-entry",
     input_type: "ContractName, MapName, Tuple",
-    output_type: "Optional<Tuple>",
+    output_type: "Optional(Tuple)",
     signature: "(fetch-contract-entry contract-name map-name key-tuple)",
     description: "The `fetch-contract-entry` function looks up and returns an entry from a
 contract other than the current contract's data map. The value is looked up using `key-tuple`.
@@ -351,7 +351,7 @@ const TUPLE_CONS_API: SpecialAPI = SpecialAPI {
     output_type: "Tuple",
     signature: "(tuple ((key0 expr0) (key1 expr1) ...))",
     description: "The `tuple` function constructs a typed tuple from the supplied key and expression pairs.
-Typed tuples can be used as inputs to the `get` function, which selects specific values from a given tuple.
+A `get` function can use typed tuples as input to select specific values from a given tuple.
 Key names may not appear multiple times in the same tuple definition. Supplied expressions are evaluated and
 associated with the expressions' paired key name.",
     example: "(tuple (name \"blockstack\") (id 1337))"
@@ -359,12 +359,12 @@ associated with the expressions' paired key name.",
 
 const TUPLE_GET_API: SpecialAPI = SpecialAPI {
     name: "get",
-    input_type: "KeyName, Tuple|Optional<Tuple>",
+    input_type: "KeyName and Tuple | Optional(Tuple)",
     output_type: "AnyType",
     signature: "(get key-name tuple)",
     description: "The `get` function fetches the value associated with a given key from the supplied typed tuple.
-If an Optional value is supplied as the inputted tuple, `get` will return an Optional type of the specified key in
-the tuple. If the supplied option is a `(none)` option, get will return `(none)`.",
+If an `Optional` value is supplied as the inputted tuple, `get` returns an `Optional` type of the specified key in
+the tuple. If the supplied option is a `(none)` option, get returns `(none)`.",
     example: "(get id (tuple (name \"blockstack\") (id 1337))) ;; Returns 1337
 (get id (fetch-entry names-map (tuple (name \"blockstack\")))) ;; Returns (some 1337)
 (get id (fetch-entry names-map (tuple (name \"non-existent\")))) ;; Returns (none)
@@ -376,7 +376,7 @@ const HASH160_API: SpecialAPI = SpecialAPI {
     input_type: "buff|int",
     output_type: "(buff 20)",
     signature: "(hash160 value)",
-    description: "The `hash160` function computes RIPEMD160(SHA256(x)) of the inputted value.
+    description: "The `hash160` function computes `RIPEMD160(SHA256(x))` of the inputted value.
 If an integer (128 bit) is supplied the hash is computed over the little endian representation of the
 integer.",
     example: "(hash160 0) ;; Returns 0xe4352f72356db555721651aa612e00379167b30f"
@@ -388,7 +388,7 @@ const SHA256_API: SpecialAPI = SpecialAPI {
     output_type: "(buff 32)",
     signature: "(sha256 value)",
     description: "The `sha256` function computes SHA256(x) of the inputted value.
-If an integer (128 bit) is supplied the hash is computer over the little endian representation of the
+If an integer (128 bit) is supplied the hash is computed over the little endian representation of the
 integer.",
     example: "(sha256 0) ;; Returns 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb"
 };
@@ -398,8 +398,8 @@ const KECCAK256_API: SpecialAPI = SpecialAPI {
     input_type: "buff|int",
     output_type: "(buff 32)",
     signature: "(keccak256 value)",
-    description: "The `keccak256` function computes KECCAK256(value) of the inputted value.
-Note that this differs from the NIST SHA-3 (i.e. FIPS 202) standard. If an integer (128 bit) 
+    description: "The `keccak256` function computes `KECCAK256(value)` of the inputted value.
+Note that this differs from the `NIST SHA-3` (that is, FIPS 202) standard. If an integer (128 bit) 
 is supplied the hash is computer over the little endian representation of the integer.",
     example: "(keccak256 0) ;; Returns 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4"
 };
@@ -407,12 +407,12 @@ is supplied the hash is computer over the little endian representation of the in
 const CONTRACT_CALL_API: SpecialAPI = SpecialAPI {
     name: "contract-call!",
     input_type: "ContractName, PublicFunctionName, Arg0, ...",
-    output_type: "Response<A>",
+    output_type: "Response(A,B)",
     signature: "(contract-call! contract-name function-name arg0 arg1 ...)",
     description: "The `contract-call!` function executes the given public function of the given contract.
-This function _may not_ be used to call a public function defined in the current contract. If the public
+You _may not_ this function to call a public function defined in the current contract. If the public
 function returns _err_, any database changes resulting from calling `contract-call!` are aborted.
-If the function returns _ok_, database changes have occurred.",
+If the function returns _ok_, database changes occurred.",
     example: "(contract-call! tokens transfer 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 19) ;; Returns (ok 1)"
 };
 
@@ -428,38 +428,38 @@ principal, and executes `expr` with that context. It returns the resulting value
 
 
 const EXPECTS_API: SpecialAPI = SpecialAPI {
-    input_type: "Optional<A>|Response<A,B>, C",
+    input_type: "Optional(A) | Response(A,B), C",
     output_type: "A",
     name: "expects!",
     signature: "(expects! option-input thrown-value)",
     description: "The `expects!` function attempts to 'unpack' the first argument: if the argument is
-an option type, and the argument is a `(some ...)` option, `expects!` will return the inner value of the
-option. If the argument is a response type, and the argument is an `(ok ...)` response, `expects!` will
-return the inner value of the `ok`. If the supplied argument is either an `(err ...)` or a `(none)` value,
-`expects!` will _return_ `thrown-value` from the current function, exiting the current control-flow.",
+an option type, and the argument is a `(some ...)` option, `expects!` returns the inner value of the
+option. If the argument is a response type, and the argument is an `(ok ...)` response, `expects!` returns
+ the inner value of the `ok`. If the supplied argument is either an `(err ...)` or a `(none)` value,
+`expects!` _returns_ `thrown-value` from the current function and exits the current control-flow.",
     example: "(expects! (fetch-entry names-map (tuple (name \"blockstack\"))) (err 1)) ;; Returns (tuple (id 1337))",
 };
 
 const EXPECTS_ERR_API: SpecialAPI = SpecialAPI {
-    input_type: "Response<A,B>, C",
+    input_type: "Response(A,B), C",
     output_type: "B",
     name: "expects-err!",
     signature: "(expects-err! response-input thrown-value)",
     description: "The `expects-err!` function attempts to 'unpack' the first argument: if the argument
-is an `(err ...)` response, `expects-err!` will return the inner value of the `err`.
+is an `(err ...)` response, `expects-err!` returns the inner value of the `err`.
 If the supplied argument is an `(ok ...)` value,
-`expects-err!` will _return_ `thrown-value` from the current function, exiting the current control-flow.",
+`expects-err!` _returns_ `thrown-value` from the current function and exits the current control-flow.",
     example: "(expects-err! (err 1) 'false) ;; Returns 1",
 };
 
 const DEFAULT_TO_API: SpecialAPI = SpecialAPI {
-    input_type: "A, Optional<A>",
+    input_type: "A, Optional(A)",
     output_type: "A",
     name: "default-to",
     signature: "(default-to default-value option-value)",
     description: "The `default-to` function attempts to 'unpack' the second argument: if the argument is
-a `(some ...)` option, it will return the inner value of the option. If the second argument is a `(none)` value,
-`default-to` will return the value of `default-value`.",
+a `(some ...)` option, it returns the inner value of the option. If the second argument is a `(none)` value,
+`default-to` it returns the value of `default-value`.",
     example: "(default-to 0 (get id (fetch-entry names-map (tuple (name \"blockstack\"))))) ;; Returns 1337
 (default-to 0 (get id (fetch-entry names-map (tuple (name \"non-existant\"))))) ;; Returns 0
 ",
@@ -467,10 +467,10 @@ a `(some ...)` option, it will return the inner value of the option. If the seco
 
 const CONS_OK_API: SpecialAPI = SpecialAPI {
     input_type: "A",
-    output_type: "Response<A,B>",
+    output_type: "Response(A,B)",
     name: "ok",
     signature: "(ok value)",
-    description: "The `ok` function constructs a response type from the input value. This is used for
+    description: "The `ok` function constructs a response type from the input value. Use `ok` for
 creating return values in public functions. An _ok_ value indicates that any database changes during
 the processing of the function should materialize.",
     example: "(ok 1) ;; Returns (ok 1)",
@@ -478,33 +478,33 @@ the processing of the function should materialize.",
 
 const CONS_ERR_API: SpecialAPI = SpecialAPI {
     input_type: "A",
-    output_type: "Response<A,B>",
+    output_type: "Response(A,B)",
     name: "err",
     signature: "(err value)",
-    description: "The `err` function constructs a response type from the input value. This is used for
+    description: "The `err` function constructs a response type from the input value. Use `err` for
 creating return values in public functions. An _err_ value indicates that any database changes during
 the processing of the function should be rolled back.",
     example: "(err 'true) ;; Returns (err 'true)",
 };
 
 const IS_OK_API: SpecialAPI = SpecialAPI {
-    input_type: "Response<A,B>",
+    input_type: "Response(A,B)",
     output_type: "bool",
     name: "is-ok?",
     signature: "(is-ok? value)",
-    description: "`is-ok?` tests a supplied response value, returning true if the response was `ok`,
-and false if it was an `err`.",
+    description: "`is-ok?` tests a supplied response value, returning `true` if the response was `ok`,
+and `false` if it was an `err`.",
     example: "(is-ok? (ok 1)) ;; Returns 'true
 (is-ok? (err 1)) ;; Returns 'false",
 };
 
 const IS_NONE_API: SpecialAPI = SpecialAPI {
-    input_type: "Option<A>",
+    input_type: "Option(A)",
     output_type: "bool",
     name: "is-none?",
     signature: "(is-none? value)",
-    description: "`is-none?` tests a supplied option value, returning true if the option value is `(none)`,
-and false if it is a `(some ...)`.",
+    description: "`is-none?` tests a supplied option value, returning `true` if the option value is `(none)`,
+and `false` if it is a `(some ...)`.",
     example: "(is-none? (get id (fetch-entry names-map (tuple (name \"blockstack\"))))) ;; Returns 'false
 (is-none? (get id (fetch-entry names-map (tuple (name \"non-existant\"))))) ;; Returns 'true"
 };
@@ -512,16 +512,16 @@ and false if it is a `(some ...)`.",
 const GET_BLOCK_INFO_API: SpecialAPI = SpecialAPI {
     name: "get-block-info",
     input_type: "BlockInfoPropertyName, BlockHeightInt",
-    output_type: "buff|int",
+    output_type: "buff | int",
     signature: "(get-block-info prop-name block-height-expr)",
     description: "The `get-block-info` function fetches data for a block of the given block height. The 
-value and type returned is determined by the specified property name. If the provided block height integer does
+value and type returned is determined by the specified `BlockInfoPropertyName`. If the provided `BlockHeightInt` does
 not correspond to an existing block, the function is aborted. The currently available property names 
 are `time`, `header-hash`, `burnchain-header-hash`, and `vrf-seed`. 
 
 The `time` property returns an integer value of the block header time field. This is a Unix epoch timestamp in seconds 
-which roughly corresponds to when the block was mined. Warning: this does not increase monotonically with each block
-and block times are accurate only to within two hours. See BIP113 for more information. 
+which roughly corresponds to when the block was mined. **Warning**: this does not increase monotonically with each block
+and block times are accurate only to within two hours. See [BIP113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) for more information. 
 
 The `header-hash`, `burnchain-header-hash`, and `vrf-seed` properties return a 32-byte buffer. 
 ",

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -97,9 +97,9 @@ const AND_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "and",
     signature: "(and b1 b2 ...)",
     description: "Returns `true` if all boolean inputs are `true`. Importantly, the supplied arguments are evaluated in-order and lazily. Lazy evaluation means that if one of the arguments returns `false`, the function short-circuits, and no subsequent arguments are evaluated.",
-    example: "(and 'true 'false) ;; Returns false
-(and (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns false
-(and (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns true
+    example: "(and 'true 'false) ;; Returns 'false
+(and (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns 'false
+(and (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns 'true
 "
 };
 
@@ -107,10 +107,10 @@ const OR_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "or",
     signature: "(or b1 b2 ...)",
     description: "Returns `true` if any boolean inputs are `true`. Importantly, the supplied arguments are evaluated in-order and lazily. Lazy evaluation means that if one of the arguments returns `false`, the function short-circuits, and no subsequent arguments are evaluated.",
-    example: "(or 'true 'false) ;; Returns true
-(or (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns true
-(or (eq? (+ 1 2) 1) (eq? 3 4)) ;; Returns false
-(or (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns true
+    example: "(or 'true 'false) ;; Returns 'true
+(or (eq? (+ 1 2) 1) (eq? 4 4)) ;; Returns 'true
+(or (eq? (+ 1 2) 1) (eq? 3 4)) ;; Returns 'false
+(or (eq? (+ 1 2) 3) (eq? 4 4)) ;; Returns 'true
 "
 };
 
@@ -118,8 +118,8 @@ const NOT_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "not",
     signature: "(not b1)",
     description: "Returns the inverse of the boolean input.",
-    example: "(not 'true) ;; Returns false
-(not (eq? 1 2)) ;; Returns `true`
+    example: "(not 'true) ;; Returns 'false
+(not (eq? 1 2)) ;; Returns 'true
 "
 };
 
@@ -127,8 +127,8 @@ const GEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: ">= (greater than or equal)",
     signature: "(>= i1 i2)",
     description: "Compares two integers, returning `true` if `i1` is greater than or equal to `i2` and `false` otherwise.",
-    example: "(>= 1 1) ;; Returns true
-(>= 5 2) ;; Returns true
+    example: "(>= 1 1) ;; Returns 'true
+(>= 5 2) ;; Returns 'true
 "
 };
 
@@ -136,8 +136,8 @@ const LEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "<= (less than or equal)",
     signature: "(> i1 i2)",
     description: "Compares two integers, returning true if `i1` is less than or equal to `i2` and `false` otherwise.",
-    example: "(<= 1 1) ;; Returns true
-(<= 5 2) ;; Returns false
+    example: "(<= 1 1) ;; Returns 'true
+(<= 5 2) ;; Returns 'false
 "
 };
 
@@ -145,9 +145,9 @@ const EQUALS_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "eq?",
     signature: "(eq? v1 v2...)",
     description: "Compares the inputted values, returning `true` if they are all equal. Note that _unlike_ the `(and ...)` function, `(eq? ...)` will _not_ short-circuit.",
-    example: "(eq? 1 1) ;; Returns true
-(eq? 1 'false) ;; Returns false
-(eq? \"abc\" 234 234) ;; Returns false
+    example: "(eq? 1 1) ;; Returns 'true
+(eq? 1 'false) ;; Returns 'false
+(eq? \"abc\" 234 234) ;; Returns 'false
 "
 };
 
@@ -155,8 +155,8 @@ const GREATER_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "> (greater than)",
     signature: "(> i1 i2)",
     description: "Compares two integers, returning `true` if `i1` is greater than `i2` and false otherwise.",
-    example: "(> 1 2) ;; Returns false
-(> 5 2) ;; Returns true
+    example: "(> 1 2) ;; Returns 'false
+(> 5 2) ;; Returns 'true
 "
 };
 
@@ -164,8 +164,8 @@ const LESS_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "< (less than)",
     signature: "(< i1 i2)",
     description: "Compares two integers, returning `true` if `i1` is less than `i2` and `false` otherwise.",
-    example: "(< 1 2) ;; Returns true
-(< 5 2) ;; Returns false
+    example: "(< 1 2) ;; Returns 'true
+(< 5 2) ;; Returns 'false
 "
 };
 
@@ -236,7 +236,7 @@ const MAP_API: SpecialAPI = SpecialAPI {
     signature: "(map func list)",
     description: "The `map` function applies the input function `func` to each element of the
 input list, and outputs a list containing the _outputs_ from those function applications.",
-    example: "(map not (list true false true false)) ;; Returns false true false true"
+    example: "(map not (list true false true false)) ;; Returns 'false true false true"
 };
 
 const FOLD_API: SpecialAPI = SpecialAPI {
@@ -277,9 +277,8 @@ const PRINT_API: SpecialAPI = SpecialAPI {
     input_type: "A",
     output_type: "A",
     signature: "(print expr)",
-    description: "The `print` function evaluates and returns its input expression. On blockstack-core
-nodes configured for development (as opposed to production mining nodes), this function will also
-cause blockstack-core to print the resulting value to STDOUT.",
+    description: "The `print` function evaluates and returns its input expression. On Blockstack Core
+nodes configured for development (as opposed to production mining nodes), this function prints the resulting value to `STDOUT` (standard output).",
     example: "(print (+ 1 2 3)) ;; Returns 6",
 };
 
@@ -303,7 +302,7 @@ const SET_API: SpecialAPI = SpecialAPI {
     description: "The `set-entry!` function sets the value associated with the input key to the 
 inputted value. This function performs a _blind_ update; whether or not a value is already associated
 with the key, the function overwrites that existing association.",
-    example: "(set-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns true",
+    example: "(set-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns 'true",
 };
 
 const INSERT_API: SpecialAPI = SpecialAPI {
@@ -315,8 +314,8 @@ const INSERT_API: SpecialAPI = SpecialAPI {
 inputted value if and only if there is not already a value associated with the key in the map.
 If an insert occurs, the function returns `true`. If a value already existed for
 this key in the data map, the function returns `false`.",
-    example: "(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns true
-(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns false
+    example: "(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns 'true
+(insert-entry! names-map (tuple (name \"blockstack\")) (tuple (id 1337))) ;; Returns 'false
 ",
 };
 
@@ -328,8 +327,8 @@ const DELETE_API: SpecialAPI = SpecialAPI {
     description: "The `delete-entry!` function removes the value associated with the input key for
 the given map. If an item exists, and is removed, the function returns `true`.
 If a value did not exist for this key in the data map, the function returns `false`.",
-    example: "(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns true
-(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns false
+    example: "(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns 'true
+(delete-entry! names-map (tuple (name \"blockstack\"))) ;; Returns 'false
 ",
 };
 
@@ -387,7 +386,7 @@ const SHA256_API: SpecialAPI = SpecialAPI {
     input_type: "buff|int",
     output_type: "(buff 32)",
     signature: "(sha256 value)",
-    description: "The `sha256` function computes SHA256(x) of the inputted value.
+    description: "The `sha256` function computes `SHA256(x)` of the inputted value.
 If an integer (128 bit) is supplied the hash is computed over the little endian representation of the
 integer.",
     example: "(sha256 0) ;; Returns 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb"

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -499,7 +499,7 @@ and `false` if it was an `err`.",
 };
 
 const IS_NONE_API: SpecialAPI = SpecialAPI {
-    input_type: "Option(A)",
+    input_type: "Optional(A)",
     output_type: "bool",
     name: "is-none?",
     signature: "(is-none? value)",


### PR DESCRIPTION
The inclusion of constructions such as `<A>` in input and output types broke the documentation generation. This change replaces `<A>` with `(A)` constructions and fixes the documentation generation.

@kantai not clear to me if this causes problems -- were they `<>` syntactically necessary? I took them as shorthand for replacement with type/element.

Signed-off-by: Mary Anthony <mary@blockstack.com>