### PR TITLE
Add random address generation

### DIFF
--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -27,6 +27,7 @@ where command is one of:
   eval_raw           to typecheck and evaluate an expression without a contract or database context.
   repl               to typecheck and evaluate expressions in a stdin/stdout loop.
   execute            to execute a public function of a defined contract.
+  generate_address   to generate a random Stacks public address for testing purposes.
 
 ", invoked_by);
     process::exit(1);
@@ -51,6 +52,15 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                     process::exit(1);
                 }
             }
+        },
+        "generate_address" => {
+            use address::c32::c32_address;
+            use rand::Rng;
+            // random 20 bytes
+            let random_bytes = rand::thread_rng().gen::<[u8; 20]>();
+            // version = 22
+            let addr = c32_address(22, &random_bytes).expect("Failed to generate address");
+            println!("{}", addr);
         },
         "mine_block" => {
             // TODO: add optional args for specifying timestamps and number of blocks to mine.

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use std::io;
 use std::io::{Read, Write};
 use std::fs;
@@ -11,6 +12,8 @@ use vm::database::{ContractDatabase, ContractDatabaseConnection, ContractDatabas
 use vm::{SymbolicExpression, SymbolicExpressionType};
 use vm::checker::{type_check, AnalysisDatabase, AnalysisDatabaseConnection};
 use vm::types::Value;
+
+use address::c32::c32_address;
 
 use serde::Serialize;
 
@@ -55,8 +58,6 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             }
         },
         "generate_address" => {
-            use address::c32::c32_address;
-            use rand::Rng;
             // random 20 bytes
             let random_bytes = rand::thread_rng().gen::<[u8; 20]>();
             // version = 22

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -33,6 +33,7 @@ where command is one of:
     process::exit(1);
 }
 
+#[cfg_attr(tarpaulin, skip)]
 pub fn invoke_command(invoked_by: &str, args: &[String]) {
     if args.len() < 1 {
         print_usage(invoked_by)


### PR DESCRIPTION
This adds a CLI command to the `local` commands (and the `clarity-cli`) for generating a random Stacks address for testing purposes:


```
$ clarity-cli generate_address
SPGQ9PNGMSN4B5NVZB265FT5BSGZ1Z7T0EMWJBWS
```

Implements #1008 