### PR TITLE
`eq?` type enforcement

### DIFF
--- a/src/vm/checker/read_only/tests.rs
+++ b/src/vm/checker/read_only/tests.rs
@@ -56,7 +56,7 @@ fn test_contract_call_read_only_violations() {
             (contract-call! contract1 mint))";
     let ok_caller =
         "(define-read-only (is-reading-only)
-            (eq? 0 (contract-call! contract1 get-balance)))";
+            (eq? 0 (expects! (contract-call! contract1 get-balance) 'false)))";
 
     let mut contract1 = parse(contract1).unwrap();
     let mut bad_caller = parse(bad_caller).unwrap();

--- a/src/vm/checker/typecheck/mod.rs
+++ b/src/vm/checker/typecheck/mod.rs
@@ -133,7 +133,7 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
                 let new_type = match tracker.take() {
                     Some(expected_type) => {
                         TypeSignature::most_admissive(expected_type, return_type)
-                            .ok_or(CheckError::new(CheckErrors::ReturnTypesMustMatch))?
+                            .map_err(|_| CheckError::new(CheckErrors::ReturnTypesMustMatch))?
                     },
                     None => return_type
                 };
@@ -273,7 +273,7 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
                         // check if the computed return type matches the return type
                         //   of any early exits from the call graph (e.g., (expects ...) calls)
                         TypeSignature::most_admissive(expected.clone(), return_type)
-                            .ok_or(CheckError::new(CheckErrors::ReturnTypesMustMatch))?
+                            .map_err(|_| CheckError::new(CheckErrors::ReturnTypesMustMatch))?
                     } else {
                         return_type
                     }

--- a/src/vm/checker/typecheck/natives/options.rs
+++ b/src/vm/checker/typecheck/natives/options.rs
@@ -65,8 +65,8 @@ pub fn check_special_default_to(checker: &mut TypeChecker, args: &[SymbolicExpre
 
     if let Some(AtomTypeIdentifier::OptionalType(input_type)) = input.match_atomic() {
         let contained_type = (**input_type).clone();
-        TypeSignature::most_admissive(default.clone(), contained_type.clone())
-            .ok_or(CheckError::new(CheckErrors::DefaultTypesMustMatch(contained_type, default)))
+        TypeSignature::most_admissive(default, contained_type)
+            .map_err(|(a,b)| CheckError::new(CheckErrors::DefaultTypesMustMatch(a, b)))
     } else {
         return Err(CheckError::new(CheckErrors::ExpectedOptionalType))
     }

--- a/src/vm/checker/typecheck/tests/contracts.rs
+++ b/src/vm/checker/typecheck/tests/contracts.rs
@@ -53,7 +53,7 @@ const SIMPLE_NAMES: &str =
                           (buyer tx-sender)))
                  (ok 0) (err 2))
                (if (eq? (expects-err! xfer-result (err (- 1)))
-                        \"not enough balance\")
+                        2)
                    (err 1) (err 3)))))
 
          (define-public (register 

--- a/src/vm/checker/typecheck/tests/mod.rs
+++ b/src/vm/checker/typecheck/tests/mod.rs
@@ -34,7 +34,7 @@ fn test_get_block_info(){
 #[test]
 fn test_simple_arithmetic_checks() {
     let good = ["(>= (+ 1 2 3) (- 1 2))",
-                "(eq? (+ 1 2 3) 'true 'false)",
+                "(eq? (+ 1 2 3) 6 0)",
                 "(and (or 'true 'false) 'false)"];
     let bad = ["(+ 1 2 3 (>= 5 7))",
                "(-)",
@@ -88,6 +88,41 @@ fn test_simple_lets() {
     for mut bad_test in bad.iter().map(|x| parse(x).unwrap()) {
         identity_pass::identity_pass(&mut bad_test).unwrap();
         assert!(type_check(&bad_test[0]).is_err())
+    }
+}
+
+#[test]
+fn test_eqs() {
+    let good = ["(eq? (list 1 2 3 4 5) (list 1 2 3 4 5 6 7))",
+                "(eq? (tuple (good 1) (bad 2)) (tuple (good 2) (bad 3)))",
+                "(eq? \"abcdef\" \"abc\" \"a\")"];
+    let bad = [
+        "(eq? 1 2 'false)",
+        "(eq? 1 2 3 (list 2))",
+        "(list (list 1 2) (list 'true) (list 5 1 7))",
+        "(list 1 2 3 'true 'false 4 5 6)",
+        "(map mod (list 1 2 3 4 5))",
+        "(map - (list 'true 'false 'true 'false))",
+        "(map hash160 (+ 1 2))",];
+                   
+    for mut good_test in good.iter().map(|x| parse(x).unwrap()) {
+        identity_pass::identity_pass(&mut good_test).unwrap();
+        let t_out = type_check(&good_test[0]);
+        match t_out {
+            Err(ref t_out) => eprintln!("{}", t_out),
+            _ => {}
+        }
+        t_out.unwrap();
+    }
+    
+    for mut bad_test in bad.iter().map(|x| parse(x).unwrap()) {
+        identity_pass::identity_pass(&mut bad_test).unwrap();
+        let checked = type_check(&bad_test[0]);
+        match checked {
+            Err(ref t_out) => eprintln!("{}", t_out),
+            _ => {}
+        }
+        assert!(checked.is_err())
     }
 }
 

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -7,7 +7,7 @@ mod tuples;
 mod options;
 
 use vm::errors::{Error, ErrType, InterpreterResult as Result};
-use vm::types::{Value, PrincipalData, ResponseData};
+use vm::types::{Value, PrincipalData, ResponseData, TypeSignature};
 use vm::callables::CallableType;
 use vm::representations::{SymbolicExpression, SymbolicExpressionType};
 use vm::representations::SymbolicExpressionType::{List, Atom};
@@ -180,14 +180,22 @@ fn native_eq(args: &[Value]) -> Result<Value> {
     // TODO: this currently uses the derived equality checks of Value,
     //   however, that's probably not how we want to implement equality
     //   checks on the ::ListTypes
+
     if args.len() < 2 {
         Ok(Value::Bool(true))
     } else {
         let first = &args[0];
-        // Using `fold` rather than `all` to prevent short-circuiting. 
-        let result = args.iter()
-            .fold(true, |acc, x| acc && (*x == *first));
-        Ok(Value::Bool(result))
+        // check types:
+        let mut arg_type = TypeSignature::type_of(first);
+        for x in args.iter() {
+            arg_type = TypeSignature::most_admissive(TypeSignature::type_of(x), arg_type)
+                .map_err(|(a,b)| Error::new(
+                    ErrType::TypeError(format!("{}", a), x.clone())))?;
+            if x != first {
+                return Ok(Value::Bool(false))
+            }
+        }
+        Ok(Value::Bool(true))
     }
 }
 

--- a/src/vm/types.rs
+++ b/src/vm/types.rs
@@ -608,7 +608,7 @@ impl TypeSignature {
 
         let okay_type = TypeSignature::most_admissive(a_type_okay, b_type_okay);
         let error_type = TypeSignature::most_admissive(a_type_err, b_type_err);
-        if let (Some(okay_type), Some(error_type)) = (okay_type, error_type) {
+        if let (Ok(okay_type), Ok(error_type)) = (okay_type, error_type) {
             Some(TypeSignature::new_atom(
                 AtomTypeIdentifier::ResponseType(
                     Box::new((okay_type, error_type)))))
@@ -625,20 +625,22 @@ impl TypeSignature {
         }
     }
 
-    pub fn most_admissive(a: TypeSignature, b: TypeSignature) -> Option<TypeSignature> {
+    pub fn most_admissive(a: TypeSignature, b: TypeSignature) -> std::result::Result<TypeSignature, 
+                                                                                     (TypeSignature, TypeSignature)> {
         // if response type, we may need to return the union of a and b.
         if let (Some(AtomTypeIdentifier::ResponseType(ref response_type_a)),
                 Some(AtomTypeIdentifier::ResponseType(ref response_type_b))) =
             (a.match_atomic(), b.match_atomic()) {
                 return TypeSignature::make_union_response_type(response_type_a, response_type_b)
+                    .ok_or_else(|| (a.clone(), b.clone()))
             }
 
         if a.admits_type(&b) {
-            Some(a)
+            Ok(a)
         } else if b.admits_type(&a) {
-            Some(b)
+            Ok(b)
         } else {
-            None
+            Err((a,b))
         }
     }
 

--- a/src/vm/types.rs
+++ b/src/vm/types.rs
@@ -852,7 +852,7 @@ impl TypeSignature {
                 false
             }
         } else {
-            self.atomic_type.admits(&x_type.atomic_type)
+            self.list_dimensions.is_none() && self.atomic_type.admits(&x_type.atomic_type)
         }
     }
 


### PR DESCRIPTION
This PR:

* Forces all arguments to `eq?` to be of the same type. If they are not, this is a type error. Previously, `eq?` would have just returned `'false`.
* Fixes a bug in `TypeSignature::admits(...)` which would cause a list-type of the same atomic-type as the input to incorrectly return "true"

Addresses #998 