### PR TITLE
Track function arg names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,10 +33,10 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--bin=clarity"
+                    "--bin=clarity-cli"
                 ],
                 "filter": {
-                    "name": "clarity",
+                    "name": "clarity-cli",
                     "kind": "bin"
                 }
             },

--- a/src/vm/checker/typecheck/mod.rs
+++ b/src/vm/checker/typecheck/mod.rs
@@ -4,7 +4,7 @@ pub mod natives;
 
 use vm::representations::{SymbolicExpression};
 use vm::representations::SymbolicExpressionType::{AtomValue, Atom, List};
-use vm::types::{AtomTypeIdentifier, TypeSignature, TupleTypeSignature, parse_name_type_pairs};
+use vm::types::{AtomTypeIdentifier, TypeSignature, TupleTypeSignature, FunctionArg, parse_name_type_pairs};
 use vm::functions::NativeFunctions;
 use vm::variables::NativeVariables;
 
@@ -41,7 +41,7 @@ pub type TypeResult = CheckResult<TypeSignature>;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FunctionType {
     Variadic(TypeSignature, TypeSignature),
-    Fixed(Vec<TypeSignature>, TypeSignature)
+    Fixed(Vec<FunctionArg>, TypeSignature)
 }
 
 pub struct TypeChecker <'a, 'b> {
@@ -71,7 +71,7 @@ impl FunctionType {
                     return Err(CheckError::new(CheckErrors::IncorrectArgumentCount(
                         arg_types.len(), args.len())))
                 }
-                for (expected_type, found_type) in arg_types.iter().zip(args) {
+                for (expected_type, found_type) in arg_types.iter().map(|x| &x.signature).zip(args) {
                     if !expected_type.admits_type(found_type) {
                         return Err(CheckError::new(CheckErrors::TypeError(
                             expected_type.clone(), found_type.clone())))
@@ -281,10 +281,10 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
 
                 self.function_return_tracker = None;
 
-                let arg_types: Vec<TypeSignature> = args.drain(..)
-                    .map(|(_, arg_type)| arg_type).collect();
+                let func_args: Vec<FunctionArg> = args.drain(..)
+                    .map(|(arg_name, arg_type)| FunctionArg::new(arg_type, &arg_name)).collect();
 
-                Ok((function_name.to_string(), FunctionType::Fixed(arg_types, return_type)))
+                Ok((function_name.to_string(), FunctionType::Fixed(func_args, return_type)))
             }
         }
     }

--- a/src/vm/checker/typecheck/natives/mod.rs
+++ b/src/vm/checker/typecheck/natives/mod.rs
@@ -1,7 +1,7 @@
 use vm::errors::{ErrType as InterpError};
 use vm::functions::NativeFunctions;
 use vm::representations::{SymbolicExpression};
-use vm::types::{TypeSignature, AtomTypeIdentifier, TupleTypeSignature, BlockInfoProperty};
+use vm::types::{TypeSignature, AtomTypeIdentifier, TupleTypeSignature, BlockInfoProperty, FunctionArg};
 use super::{TypeChecker, TypingContext, TypeResult, FunctionType, no_type, check_atomic_type}; 
 use vm::checker::errors::{CheckError, CheckErrors, CheckResult};
 
@@ -21,15 +21,15 @@ fn arithmetic_type(variadic: bool) -> FunctionType {
         FunctionType::Variadic(TypeSignature::new_atom( AtomTypeIdentifier::IntType ),
                                TypeSignature::new_atom( AtomTypeIdentifier::IntType ))
     } else {
-        FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::IntType ),
-                                 TypeSignature::new_atom( AtomTypeIdentifier::IntType )],
+        FunctionType::Fixed(vec![FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::IntType ), "i1"),
+                                 FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::IntType ), "i2")],
                             TypeSignature::new_atom( AtomTypeIdentifier::IntType ))
     }
 }
 
 fn arithmetic_comparison() -> FunctionType {
-    FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::IntType ),
-                             TypeSignature::new_atom( AtomTypeIdentifier::IntType )],
+    FunctionType::Fixed(vec![FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::IntType ), "i1"),
+                             FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::IntType ), "i2")],
                         TypeSignature::new_atom( AtomTypeIdentifier::BoolType ))    
 }
 
@@ -321,16 +321,16 @@ impl TypedNativeFunction {
                 Simple(SimpleNativeFunction(FunctionType::Variadic(TypeSignature::new_atom( AtomTypeIdentifier::BoolType ),
                                                                    TypeSignature::new_atom( AtomTypeIdentifier::BoolType )))),
             Not =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::BoolType )],
+                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::BoolType ), "value")],
                                                                 TypeSignature::new_atom( AtomTypeIdentifier::BoolType )))),
             Hash160 =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::AnyType )],
+                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::AnyType ), "value")],
                                                                 TypeSignature::new_atom( AtomTypeIdentifier::BufferType(20) )))),
             Sha256 =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::AnyType )],
+                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::AnyType ), "value")],
                                                                 TypeSignature::new_atom( AtomTypeIdentifier::BufferType(32) )))),
             Keccak256 =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::AnyType )],
+                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![FunctionArg::new(TypeSignature::new_atom( AtomTypeIdentifier::AnyType ), "value")],
                                                                 TypeSignature::new_atom( AtomTypeIdentifier::BufferType(32) )))),
             Equals =>
                 Simple(SimpleNativeFunction(FunctionType::Variadic(TypeSignature::new_atom( AtomTypeIdentifier::AnyType ),

--- a/src/vm/checker/typecheck/tests/mod.rs
+++ b/src/vm/checker/typecheck/tests/mod.rs
@@ -1,6 +1,6 @@
 use vm::parser::parse;
 use vm::representations::SymbolicExpression;
-use vm::checker::typecheck::{TypeResult, TypeChecker, TypingContext};
+use vm::checker::typecheck::{TypeResult, TypeChecker, TypingContext, FunctionType};
 use vm::checker::{AnalysisDatabase, AnalysisDatabaseConnection, identity_pass};
 
 mod contracts;
@@ -197,6 +197,60 @@ fn test_define() {
     
     for mut bad_test in bad.iter().map(|x| parse(x).unwrap()) {
         assert!(type_check(&":transient:", &mut bad_test, &mut analysis_db, false).is_err());
+    }
+}
+
+#[test]
+#[cfg(feature = "developer-mode")]
+fn test_function_arg_names() {
+    use vm::checker::type_check;
+    
+    let functions = vec![
+        "(define (test (x int)) (ok 0))
+         (define-public (test-pub (x int)) (ok 0))
+         (define-read-only (test-ro (x int)) (ok 0))",
+
+        "(define (test (x int) (y bool)) (ok 0))
+         (define-public (test-pub (x int) (y bool)) (ok 0))
+         (define-read-only (test-ro (x int) (y bool)) (ok 0))",
+
+        "(define (test (name-1 int) (name-2 int) (name-3 int)) (ok 0))
+         (define-public (test-pub (name-1 int) (name-2 int) (name-3 int)) (ok 0))
+         (define-read-only (test-ro (name-1 int) (name-2 int) (name-3 int)) (ok 0))",
+
+        "(define (test) (ok 0))
+         (define-public (test-pub) (ok 0))
+         (define-read-only (test-ro) (ok 0))",
+    ];
+
+    let expected_arg_names: Vec<Vec<&str>> = vec![
+        vec!["x"],
+        vec!["x", "y"],
+        vec!["name-1", "name-2", "name-3"],
+        vec![],
+    ];
+
+    let mut analysis_conn = AnalysisDatabaseConnection::memory();
+    let mut analysis_db = analysis_conn.begin_save_point();
+
+    for (func_test, arg_names) in functions.iter().zip(expected_arg_names.iter()) {
+        let mut func_expr = parse(func_test).unwrap();
+        let contract_analysis = type_check(&":transient:", &mut func_expr, &mut analysis_db, false).unwrap();
+
+        let func_type_priv = contract_analysis.get_private_function("test").unwrap();
+        let func_type_pub = contract_analysis.get_public_function_type("test-pub").unwrap();
+        let func_type_ro = contract_analysis.get_read_only_function_type("test-ro").unwrap();
+
+        for func_type in &[func_type_priv, func_type_pub, func_type_ro] {
+            let func_args = match func_type {
+                FunctionType::Fixed(args, _) => args,
+                _ => panic!("Unexpected function type")
+            };
+            
+            for (expected_name, actual_name) in arg_names.iter().zip(func_args.iter().map(|x| &x.name)) {
+                assert_eq!(*expected_name, actual_name);
+            }
+        }
     }
 }
 

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -177,7 +177,7 @@ fn make_for_simple_native(api: &SimpleFunctionAPI, function: &NativeFunctions) -
                     format!("{}, ...", in_type)
                 },
                 FunctionType::Fixed(ref in_types, _) => {
-                    let in_types: Vec<String> = in_types.iter().map(|x| format!("{}", x)).collect();
+                    let in_types: Vec<String> = in_types.iter().map(|x| format!("{}", x.signature)).collect();
                     in_types.join(", ")
                 },
             };

--- a/src/vm/types.rs
+++ b/src/vm/types.rs
@@ -41,6 +41,14 @@ pub struct TypeSignature {
     //       high dimensional lists are _expensive_ --- use lists of tuples!
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FunctionArg {
+    #[serde(flatten)]
+    pub signature: TypeSignature,
+    #[cfg(feature = "developer-mode")]
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Eq, Serialize, Deserialize)]
 pub struct TupleData {
     type_signature: TupleTypeSignature,
@@ -291,6 +299,12 @@ impl fmt::Display for AtomTypeIdentifier {
                 write!(f, "))")
             }
         }
+    }
+}
+
+impl fmt::Display for FunctionArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.signature)
     }
 }
 
@@ -561,6 +575,21 @@ impl fmt::Display for TupleData {
             write!(f, "({} {})", name, value)?;
         }
         write!(f, ")")
+    }
+}
+
+impl FunctionArg {
+    #[cfg(feature = "developer-mode")]
+    pub fn new(sig: TypeSignature, name: &str) -> FunctionArg {
+        FunctionArg { 
+            signature: sig, 
+            name: name.to_owned() }
+    }
+
+    #[cfg(not(feature = "developer-mode"))]
+    pub fn new(sig: TypeSignature, name: &str) -> FunctionArg {
+        FunctionArg { 
+            signature: sig }
     }
 }
 


### PR DESCRIPTION
https://github.com/blockstack/blockstack-core/issues/990

Track the parsed function arg names when the `developer-mode` flag is on. This gets serialized and returned in the `clarity-cli check [...] --output_analysis` json. 

Note: this PR does not include a new ABI struct mentioned in the linked issue.