### PR TITLE
Add `defines` to vm::docs

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -543,7 +543,7 @@ The `header-hash`, `burnchain-header-hash`, and `vrf-seed` properties return a 3
 const DEFINE_PUBLIC_API: SpecialAPI = SpecialAPI {
     name: "define-public",
     input_type: "MethodSignature, MethodBody",
-    output_type: "",
+    output_type: "Not Applicable",
     signature: "(define-public (function-name (arg-name-0 arg-type-0) (arg-name-1 arg-type-1) ...) function-body)",
     description: "`define-public` is used to define a _public_ function and transaction for a smart contract. Public
 functions are callable from other smart contracts, and may be invoked directly by users by submitting a transaction
@@ -565,7 +565,7 @@ contracts via `contract-call!`.",
 const DEFINE_PRIVATE_API: SpecialAPI = SpecialAPI {
     name: "define",
     input_type: "MethodSignature, MethodBody",
-    output_type: "",
+    output_type: "Not Applicable",
     signature: "(define (function-name (arg-name-0 arg-type-0) (arg-name-1 arg-type-1) ...) function-body)",
     description: "`define` is used to define _private_ functions for a smart contract. Private
 functions may not be called from other smart contracts, nor may they be invoked directly by users.
@@ -587,7 +587,7 @@ Private functions may return any type.",
 const DEFINE_READ_ONLY_API: SpecialAPI = SpecialAPI {
     name: "define-read-only",
     input_type: "MethodSignature, MethodBody",
-    output_type: "",
+    output_type: "Not Applicable",
     signature: "(define-read-only (function-name (arg-name-0 arg-type-0) (arg-name-1 arg-type-1) ...) function-body)",
     description: "`define-read-only` is used to define a _public read-only_ function for a smart contract. Such
 functions are callable from other smart contracts.
@@ -608,7 +608,7 @@ be invoked by other contracts via `contract-call!`.",
 const DEFINE_MAP_API: SpecialAPI = SpecialAPI {
     name: "define-map",
     input_type: "MapName, KeyTupleDefinition, MapTupleDefinition",
-    output_type: "",
+    output_type: "Not Applicable",
     signature: "(define-map map-name ((key-name-0 key-type-0) ...) ((val-name-0 val-type-0) ...))",
     description: "`define-map` is used to define a new datamap for use in a smart contract. Such
 maps are only modifiable by the current smart contract.

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -703,3 +703,15 @@ pub fn make_json_api_reference() -> String {
     format!("{}", serde_json::to_string(&json_references)
             .expect("Failed to serialize documentation"))
 }
+
+#[cfg(test)]
+mod test {
+    use super::make_json_api_reference;
+
+    #[test]
+    fn ensure_docgen_runs() {
+        // add a test to make sure that we don't inadvertently break
+        //  docgen in a panic-y way.
+        make_json_api_reference();
+    }
+}

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -141,16 +141,6 @@ const LEQ_API: SimpleFunctionAPI = SimpleFunctionAPI {
 "
 };
 
-const EQUALS_API: SimpleFunctionAPI = SimpleFunctionAPI {
-    name: "eq?",
-    signature: "(eq? v1 v2...)",
-    description: "Compares the inputted values, returning `true` if they are all equal. Note that _unlike_ the `(and ...)` function, `(eq? ...)` will _not_ short-circuit.",
-    example: "(eq? 1 1) ;; Returns 'true
-(eq? 1 'false) ;; Returns 'false
-(eq? \"abc\" 234 234) ;; Returns 'false
-"
-};
-
 const GREATER_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: "> (greater than)",
     signature: "(> i1 i2)",
@@ -191,7 +181,7 @@ fn make_for_simple_native(api: &SimpleFunctionAPI, function: &NativeFunctions) -
             };
             (input_type, output_type)
         } else {
-            panic!("Attempted to auto-generate docs for non-simple native function.")
+            panic!("Attempted to auto-generate docs for non-simple native function: {}", api.name)
         }
     };
 
@@ -204,6 +194,18 @@ fn make_for_simple_native(api: &SimpleFunctionAPI, function: &NativeFunctions) -
         example: api.example.to_string()
     }
 }
+
+const EQUALS_API: SpecialAPI = SpecialAPI {
+    name: "eq?",
+    input_type: "A, A, ...",
+    output_type: "bool",
+    signature: "(eq? v1 v2...)",
+    description: "Compares the inputted values, returning `true` if they are all equal. Note that _unlike_ the `(and ...)` function, `(eq? ...)` will _not_ short-circuit.",
+    example: "(eq? 1 1) ;; Returns 'true
+(eq? 1 'false) ;; Returns 'false
+(eq? \"abc\" 234 234) ;; Returns 'false
+"
+};
 
 const IF_API: SpecialAPI = SpecialAPI {
     name: "if",
@@ -538,6 +540,96 @@ The `header-hash`, `burnchain-header-hash`, and `vrf-seed` properties return a 3
 "
 };
 
+const DEFINE_PUBLIC_API: SpecialAPI = SpecialAPI {
+    name: "define-public",
+    input_type: "MethodSignature, MethodBody",
+    output_type: "",
+    signature: "(define-public (function-name (arg-name-0 arg-type-0) (arg-name-1 arg-type-1) ...) function-body)",
+    description: "`define-public` is used to define a _public_ function and transaction for a smart contract. Public
+functions are callable from other smart contracts, and may be invoked directly by users by submitting a transaction
+to the Stacks blockchain.
+
+Like other kinds of definition statements, `define-public` may only be used at the top level of a smart contract
+definition (i.e., you cannot put a define statement in the middle of a function body).
+
+Public functions _must_ return a ResponseType (using either `ok` or `err`). Any datamap modifications performed by
+a public function will be aborted if the function returns an `err` type. Public functions may be invoked by other
+contracts via `contract-call!`.",
+    example: "
+(define-public (hello-world (input int))
+  (begin (print (+ 2 input))
+         (ok input)))
+"
+};
+
+const DEFINE_PRIVATE_API: SpecialAPI = SpecialAPI {
+    name: "define",
+    input_type: "MethodSignature, MethodBody",
+    output_type: "",
+    signature: "(define (function-name (arg-name-0 arg-type-0) (arg-name-1 arg-type-1) ...) function-body)",
+    description: "`define` is used to define _private_ functions for a smart contract. Private
+functions may not be called from other smart contracts, nor may they be invoked directly by users.
+Instead, these functions may only be invoked by other functions defined in the same smart contract.
+
+Like other kinds of definition statements, `define` may only be used at the top level of a smart contract
+definition (i.e., you cannot put a define statement in the middle of a function body).
+
+Private functions may return any type.",
+    example: "
+(define (max-of (i1 int) (i2 int))
+  (if (> i1 i2)
+      i1
+      i2))
+(max-of 4 6) ;; returns 6
+"
+};
+
+const DEFINE_READ_ONLY_API: SpecialAPI = SpecialAPI {
+    name: "define-read-only",
+    input_type: "MethodSignature, MethodBody",
+    output_type: "",
+    signature: "(define-read-only (function-name (arg-name-0 arg-type-0) (arg-name-1 arg-type-1) ...) function-body)",
+    description: "`define-read-only` is used to define a _public read-only_ function for a smart contract. Such
+functions are callable from other smart contracts.
+
+Like other kinds of definition statements, `define-read-only` may only be used at the top level of a smart contract
+definition (i.e., you cannot put a define statement in the middle of a function body).
+
+Read-only functions may return any type. However, read-only functions
+may not perform any datamap modifications, or call any functions which
+perform such modifications. This is enforced both during type checks and during
+the execution of the function. Public read-only functions may
+be invoked by other contracts via `contract-call!`.",
+    example: "
+(define-read-only (just-return-one-hundred) 
+  (* 10 10))"
+};
+
+const DEFINE_MAP_API: SpecialAPI = SpecialAPI {
+    name: "define-map",
+    input_type: "MapName, KeyTupleDefinition, MapTupleDefinition",
+    output_type: "",
+    signature: "(define-map map-name ((key-name-0 key-type-0) ...) ((val-name-0 val-type-0) ...))",
+    description: "`define-map` is used to define a new datamap for use in a smart contract. Such
+maps are only modifiable by the current smart contract.
+
+Maps are defined with a key tuple type and value tuple type. These are defined using a list
+of name and type pairs, e.g., a key type might be `((id int))`, which is a tuple with a single \"id\"
+field of type `int`.
+
+Like other kinds of definition statements, `define-map` may only be used at the top level of a smart contract
+definition (i.e., you cannot put a define statement in the middle of a function body).",
+    example: "
+(define-map squares ((x int)) ((square int)))
+(define (add-entry (x int))
+  (insert-entry! squares ((x 2)) ((square (* x x)))))
+(add-entry 1)
+(add-entry 2)
+(add-entry 3)
+(add-entry 4)
+(add-entry 5)
+"
+};
 
 fn make_for_special(api: &SpecialAPI) -> FunctionAPI {
     FunctionAPI {
@@ -568,7 +660,7 @@ fn make_api_reference(function: &NativeFunctions) -> FunctionAPI {
         And => make_for_simple_native(&AND_API, &And),
         Or => make_for_simple_native(&OR_API, &Or),
         Not => make_for_simple_native(&NOT_API, &Not),
-        Equals => make_for_simple_native(&EQUALS_API, &Equals),
+        Equals => make_for_special(&EQUALS_API),
         If => make_for_special(&IF_API),
         Let => make_for_special(&LET_API),
         Map => make_for_special(&MAP_API),
@@ -601,9 +693,13 @@ fn make_api_reference(function: &NativeFunctions) -> FunctionAPI {
 
 pub fn make_json_api_reference() -> String {
     use vm::functions::NativeFunctions;
-    let json_references: Vec<_> = NativeFunctions::ALL.iter()
+    let mut json_references: Vec<_> = NativeFunctions::ALL.iter()
         .map(|x| make_api_reference(x))
         .collect();
+    json_references.push(make_for_special(&DEFINE_MAP_API));
+    json_references.push(make_for_special(&DEFINE_PUBLIC_API));
+    json_references.push(make_for_special(&DEFINE_PRIVATE_API));
+    json_references.push(make_for_special(&DEFINE_READ_ONLY_API));
     format!("{}", serde_json::to_string(&json_references)
             .expect("Failed to serialize documentation"))
 }


### PR DESCRIPTION
This PR:

* Fixes `eq?` in the current docgen
* Adds `define`, `define-map`, `define-read-only`, `define-public` to `vm::docs::make_json_api_reference()`

Resolves Issue #1016 

You can test this either locally or with the built docker image for this branch. For example:

```
$ docker run -it quay.io/blockstack/blockstack-core:feature_add-defines-to-docs blockstack-core docgen
```