### PR TITLE
Friendlier panics

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -60,4 +60,5 @@ workflows:
   build-deploy:
     jobs:
       - build
+      - test_demo
       - deploy

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,26 @@ jobs:
       - store_artifacts:
           path: /build/dist/
           destination: dist/
+  test_demo:
+    working_directory: /test
+    docker:
+      - image: rust:1.34.0-stretch
+    steps:
+      - checkout
+      - run:
+          command: |
+            cargo build --release && cargo install --path . 
+      - run:
+          command: |
+            blockstack-core local initialize db &&
+            blockstack-core local check sample-programs/tokens.clar db &&
+            blockstack-core local launch tokens sample-programs/tokens.clar db &&
+            blockstack-core local check sample-programs/names.clar db &&
+            blockstack-core local launch names sample-programs/names.clar db &&
+            blockstack-core local execute db tokens mint! SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 100000
+      - run:
+          command: |
+            echo "(get-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)" | blockstack-core local eval tokens db
   build:
     machine: true
     working_directory: ~/blockstack

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -17,6 +17,7 @@ use address::c32::c32_address;
 
 use serde::Serialize;
 
+#[cfg_attr(tarpaulin, skip)]
 fn print_usage(invoked_by: &str) {
     eprintln!("Usage: {} [command]
 where command is one of:
@@ -36,6 +37,7 @@ where command is one of:
     process::exit(1);
 }
 
+#[cfg_attr(tarpaulin, skip)]
 fn friendly_expect<A,B: std::fmt::Display>(input: Result<A,B>, msg: &str) -> A {
     input.unwrap_or_else(|e| {
         eprintln!("{}\nCaused by: {}", msg, e);
@@ -43,6 +45,7 @@ fn friendly_expect<A,B: std::fmt::Display>(input: Result<A,B>, msg: &str) -> A {
     })
 }
 
+#[cfg_attr(tarpaulin, skip)]
 fn friendly_expect_opt<A>(input: Option<A>, msg: &str) -> A {
     input.unwrap_or_else(|| {
         eprintln!("{}", msg);

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -53,7 +53,6 @@ fn friendly_expect_opt<A>(input: Option<A>, msg: &str) -> A {
     })
 }
 
-#[cfg_attr(tarpaulin, skip)]
 pub fn invoke_command(invoked_by: &str, args: &[String]) {
     if args.len() < 1 {
         print_usage(invoked_by)
@@ -460,5 +459,21 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
         _ => {
             print_usage(invoked_by)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_samples() {
+        let db_name = format!("/tmp/db_{}", rand::thread_rng().gen::<i32>());
+        invoke_command("test", &["initialize".to_string(), db_name.clone()]);
+        invoke_command("test", &["check".to_string(), "sample-programs/tokens.clar".to_string(), db_name.clone()]);
+        invoke_command("test", &["launch".to_string(), "tokens".to_string(),
+                                 "sample-programs/tokens.clar".to_string(), db_name.clone()]);
+        invoke_command("test", &["execute".to_string(), db_name.clone(), "tokens".to_string(),
+                                 "mint!".to_string(), "SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR".to_string(),
+                                 "1000".to_string()]);
     }
 }


### PR DESCRIPTION
This addresses:

1. #1011 as well as other `.expects` usage in the CLI.
2. #1003 

This PR also adds a job to Circle definition to test the CLI against the "okay" executions in the demo markdown.

