### PR TITLE
Classifying Interpreter Errors

### DIFF
--- a/src/vm/checker/errors.rs
+++ b/src/vm/checker/errors.rs
@@ -14,6 +14,8 @@ pub enum CheckErrors {
 
     // simple type expectation mismatch
     TypeError(TypeSignature, TypeSignature),
+    // union type mismatch
+    UnionTypeError(Vec<TypeSignature>, TypeSignature),
     ExpectedOptionalType,
     ExpectedResponseType,
     CouldNotDetermineResponseOkType,

--- a/src/vm/checker/typecheck/natives/mod.rs
+++ b/src/vm/checker/typecheck/natives/mod.rs
@@ -1,7 +1,7 @@
 use vm::errors::{Error as InterpError, RuntimeErrorType};
 use vm::functions::NativeFunctions;
 use vm::representations::{SymbolicExpression};
-use vm::types::{TypeSignature, AtomTypeIdentifier, TupleTypeSignature, BlockInfoProperty};
+use vm::types::{TypeSignature, AtomTypeIdentifier, TupleTypeSignature, BlockInfoProperty, MAX_VALUE_SIZE};
 use super::{TypeChecker, TypingContext, TypeResult, FunctionType, no_type, check_atomic_type}; 
 use vm::checker::errors::{CheckError, CheckErrors, CheckResult};
 
@@ -250,7 +250,7 @@ impl TypedNativeFunction {
         use self::TypedNativeFunction::{Special, Simple};
         match self {
             Special(SpecialNativeFunction(check)) => check(checker, args, context),
-            Simple(SimpleNativeFunction(function_type)) => checker.type_check_function_type(function_type, args, context)
+            Simple(SimpleNativeFunction(function_type)) => checker.type_check_function_type(function_type, args, context),
         }
     }
 
@@ -271,14 +271,20 @@ impl TypedNativeFunction {
                 Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::BoolType )],
                                                                 TypeSignature::new_atom( AtomTypeIdentifier::BoolType )))),
             Hash160 =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::AnyType )],
-                                                                TypeSignature::new_atom( AtomTypeIdentifier::BufferType(20) )))),
+                Simple(SimpleNativeFunction(FunctionType::UnionArgs(
+                    vec![TypeSignature::new_atom(AtomTypeIdentifier::BufferType(MAX_VALUE_SIZE as u32)),
+                         TypeSignature::new_atom(AtomTypeIdentifier::IntType),],
+                    TypeSignature::new_atom( AtomTypeIdentifier::BufferType(20) )))),
             Sha256 =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::AnyType )],
-                                                                TypeSignature::new_atom( AtomTypeIdentifier::BufferType(32) )))),
+                Simple(SimpleNativeFunction(FunctionType::UnionArgs(
+                    vec![TypeSignature::new_atom(AtomTypeIdentifier::BufferType(MAX_VALUE_SIZE as u32)),
+                         TypeSignature::new_atom(AtomTypeIdentifier::IntType),],
+                    TypeSignature::new_atom( AtomTypeIdentifier::BufferType(32) )))),
             Keccak256 =>
-                Simple(SimpleNativeFunction(FunctionType::Fixed(vec![TypeSignature::new_atom( AtomTypeIdentifier::AnyType )],
-                                                                TypeSignature::new_atom( AtomTypeIdentifier::BufferType(32) )))),
+                Simple(SimpleNativeFunction(FunctionType::UnionArgs(
+                    vec![TypeSignature::new_atom(AtomTypeIdentifier::BufferType(MAX_VALUE_SIZE as u32)),
+                         TypeSignature::new_atom(AtomTypeIdentifier::IntType),],
+                    TypeSignature::new_atom( AtomTypeIdentifier::BufferType(32) )))),
             Equals => Special(SpecialNativeFunction(&check_special_equals)),
             If => Special(SpecialNativeFunction(&check_special_if)),
             Let => Special(SpecialNativeFunction(&check_special_let)),

--- a/src/vm/checker/typecheck/natives/mod.rs
+++ b/src/vm/checker/typecheck/natives/mod.rs
@@ -39,8 +39,8 @@ fn check_special_list_cons(checker: &mut TypeChecker, args: &[SymbolicExpression
     TypeSignature::parent_list_type(&typed_args)
         .map_err(|x| {
             let error_type = match x {
-                InterpError::Runtime(ref runtime_err) => {
-                    match runtime_err.err_type {
+                InterpError::Runtime(ref runtime_err, _) => {
+                    match runtime_err {
                         RuntimeErrorType::BadTypeConstruction => CheckErrors::ListTypesMustMatch,
                         RuntimeErrorType::ListTooLarge => CheckErrors::ConstructedListTooLarge,
                         RuntimeErrorType::ListDimensionTooHigh => CheckErrors::ConstructedListTooLarge,

--- a/src/vm/checker/typecheck/natives/mod.rs
+++ b/src/vm/checker/typecheck/natives/mod.rs
@@ -1,4 +1,4 @@
-use vm::errors::{ErrType as InterpError};
+use vm::errors::{Error as InterpError, RuntimeErrorType};
 use vm::functions::NativeFunctions;
 use vm::representations::{SymbolicExpression};
 use vm::types::{TypeSignature, AtomTypeIdentifier, TupleTypeSignature, BlockInfoProperty};
@@ -38,10 +38,15 @@ fn check_special_list_cons(checker: &mut TypeChecker, args: &[SymbolicExpression
     let typed_args = checker.type_check_all(args, context)?;
     TypeSignature::parent_list_type(&typed_args)
         .map_err(|x| {
-            let error_type = match x.err_type {
-                InterpError::BadTypeConstruction => CheckErrors::ListTypesMustMatch,
-                InterpError::ListTooLarge => CheckErrors::ConstructedListTooLarge,
-                InterpError::ListDimensionTooHigh => CheckErrors::ConstructedListTooLarge,
+            let error_type = match x {
+                InterpError::Runtime(ref runtime_err) => {
+                    match runtime_err.err_type {
+                        RuntimeErrorType::BadTypeConstruction => CheckErrors::ListTypesMustMatch,
+                        RuntimeErrorType::ListTooLarge => CheckErrors::ConstructedListTooLarge,
+                        RuntimeErrorType::ListDimensionTooHigh => CheckErrors::ConstructedListTooLarge,
+                        _ => CheckErrors::UnknownListConstructionFailure
+                    }
+                },
                 _ => CheckErrors::UnknownListConstructionFailure
             };
             CheckError::new(error_type)

--- a/src/vm/checker/typecheck/tests/mod.rs
+++ b/src/vm/checker/typecheck/tests/mod.rs
@@ -60,6 +60,37 @@ fn test_simple_arithmetic_checks() {
 }
 
 #[test]
+fn test_simple_hash_checks() {
+    let good = ["(hash160 1)",
+                "(sha256 (keccak256 1))"];
+    let bad_types = ["(hash160 'true)",
+                     "(sha256 'false)",
+                     "(keccak256 (list 1 2 3))"];
+    let invalid_args = ["(sha256 1 2 3)"];
+
+    for mut good_test in good.iter().map(|x| parse(x).unwrap()) {
+        identity_pass::identity_pass(&mut good_test).unwrap();
+        type_check_helper(&good_test[0]).unwrap();
+    }
+    
+    for mut bad_test in bad_types.iter().map(|x| parse(x).unwrap()) {
+        identity_pass::identity_pass(&mut bad_test).unwrap();
+        assert!(match type_check_helper(&bad_test[0]).unwrap_err().err {
+            CheckErrors::UnionTypeError(_, _) => true,
+            _ => false
+        })
+    }
+
+    for mut bad_test in invalid_args.iter().map(|x| parse(x).unwrap()) {
+        identity_pass::identity_pass(&mut bad_test).unwrap();
+        assert!(match type_check_helper(&bad_test[0]).unwrap_err().err {
+            CheckErrors::IncorrectArgumentCount(_, _) => true,
+            _ => false
+        })
+    }
+}
+
+#[test]
 fn test_simple_ifs() {
     let good = ["(if (> 1 2) (+ 1 2 3) (- 1 2))",
                 "(if 'true 'true 'false)",

--- a/src/vm/contracts.rs
+++ b/src/vm/contracts.rs
@@ -1,6 +1,6 @@
 use vm::{Value, apply, eval_all};
 use vm::representations::{SymbolicExpression};
-use vm::errors::{Error, ErrType, InterpreterResult as Result, IncomparableError};
+use vm::errors::{InterpreterResult as Result};
 use vm::callables::CallableType;
 use vm::contexts::{Environment, LocalContext, ContractContext, GlobalContext};
 use vm::parser;

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, OptionalExtension, NO_PARAMS, Row, Savepoint};
 use rusqlite::types::ToSql;
 
 use vm::contracts::Contract;
-use vm::errors::{Error, RuntimeErrorType, UncheckedError, InterpreterResult as Result, IncomparableError};
+use vm::errors::{Error, InterpreterError, RuntimeErrorType, UncheckedError, InterpreterResult as Result, IncomparableError};
 use vm::types::{Value, OptionalData, TypeSignature, TupleTypeSignature, AtomTypeIdentifier};
 
 use chainstate::burn::{VRFSeed, BlockHeaderHash};
@@ -121,22 +121,22 @@ impl ContractDatabaseConnection {
         let sql = "SELECT sql FROM sqlite_master WHERE name=?";
         let _: String = self.conn.query_row(sql, &["maps_table"],
                                             |row| row.get(0))
-            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
         let _: String = self.conn.query_row(sql, &["contracts"],
                                             |row| row.get(0))
-            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
         let _: String = self.conn.query_row(sql, &["data_table"],
                                             |row| row.get(0))
-            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
         let _: String = self.conn.query_row(sql, &["simmed_block_table"],
                                             |row| row.get(0))
-            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
         Ok(())
     }
 
     pub fn inner_open(filename: &str) -> Result<ContractDatabaseConnection> {
         let conn = Connection::open(filename)
-            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
         Ok(ContractDatabaseConnection {
             conn: conn
         })

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, OptionalExtension, NO_PARAMS, Row, Savepoint};
 use rusqlite::types::ToSql;
 
 use vm::contracts::Contract;
-use vm::errors::{Error, ErrType, InterpreterResult as Result, IncomparableError};
+use vm::errors::{Error, RuntimeErrorType, UncheckedError, InterpreterResult as Result, IncomparableError};
 use vm::types::{Value, OptionalData, TypeSignature, TupleTypeSignature, AtomTypeIdentifier};
 
 use chainstate::burn::{VRFSeed, BlockHeaderHash};
@@ -121,22 +121,22 @@ impl ContractDatabaseConnection {
         let sql = "SELECT sql FROM sqlite_master WHERE name=?";
         let _: String = self.conn.query_row(sql, &["maps_table"],
                                             |row| row.get(0))
-            .map_err(|x| Error::new(ErrType::SqliteError(IncomparableError{ err: x })))?;
+            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
         let _: String = self.conn.query_row(sql, &["contracts"],
                                             |row| row.get(0))
-            .map_err(|x| Error::new(ErrType::SqliteError(IncomparableError{ err: x })))?;
+            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
         let _: String = self.conn.query_row(sql, &["data_table"],
                                             |row| row.get(0))
-            .map_err(|x| Error::new(ErrType::SqliteError(IncomparableError{ err: x })))?;
+            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
         let _: String = self.conn.query_row(sql, &["simmed_block_table"],
                                             |row| row.get(0))
-            .map_err(|x| Error::new(ErrType::SqliteError(IncomparableError{ err: x })))?;
+            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
         Ok(())
     }
 
     pub fn inner_open(filename: &str) -> Result<ContractDatabaseConnection> {
         let conn = Connection::open(filename)
-            .map_err(|x| Error::new(ErrType::SqliteError(IncomparableError{ err: x })))?;
+            .map_err(|x| RuntimeErrorType::SqliteError(IncomparableError{ err: x }))?;
         Ok(ContractDatabaseConnection {
             conn: conn
         })
@@ -197,7 +197,7 @@ impl <'a> ContractDatabase <'a> {
                 |row| {
                     (row.get(0), row.get(1), row.get(2))
                 })
-            .ok_or(Error::new(ErrType::UndefinedMap(map_name.to_string())))?;
+            .ok_or(UncheckedError::UndefinedMap(map_name.to_string()))?;
 
         Ok(SqliteDataMap {
             map_identifier: map_identifier,
@@ -232,7 +232,7 @@ impl <'a> ContractDatabase <'a> {
     pub fn fetch_entry(&self, contract_name: &str, map_name: &str, key: &Value) -> Result<Option<Value>> {
         let map_descriptor = self.load_map(contract_name, map_name)?;
         if !map_descriptor.key_type.admits(key) {
-            return Err(Error::new(ErrType::TypeError(format!("{:?}", map_descriptor.key_type), (*key).clone())))
+            return Err(UncheckedError::TypeError(format!("{:?}", map_descriptor.key_type), (*key).clone()).into())
         }
 
         let params: [&ToSql; 2] = [&map_descriptor.map_identifier,
@@ -259,10 +259,10 @@ impl <'a> ContractDatabase <'a> {
     pub fn set_entry(&mut self, contract_name: &str, map_name: &str, key: Value, value: Value) -> Result<Value> {
         let map_descriptor = self.load_map(contract_name, map_name)?;
         if !map_descriptor.key_type.admits(&key) {
-            return Err(Error::new(ErrType::TypeError(format!("{:?}", map_descriptor.key_type), key)))
+            return Err(UncheckedError::TypeError(format!("{:?}", map_descriptor.key_type), key).into())
         }
         if !map_descriptor.value_type.admits(&value) {
-            return Err(Error::new(ErrType::TypeError(format!("{:?}", map_descriptor.value_type), value)))
+            return Err(UncheckedError::TypeError(format!("{:?}", map_descriptor.value_type), value).into())
         }
 
         let params: [&ToSql; 3] = [&map_descriptor.map_identifier,
@@ -279,10 +279,10 @@ impl <'a> ContractDatabase <'a> {
     pub fn insert_entry(&mut self, contract_name: &str, map_name: &str, key: Value, value: Value) -> Result<Value> {
         let map_descriptor = self.load_map(contract_name, map_name)?;
         if !map_descriptor.key_type.admits(&key) {
-            return Err(Error::new(ErrType::TypeError(format!("{:?}", map_descriptor.key_type), key)))
+            return Err(UncheckedError::TypeError(format!("{:?}", map_descriptor.key_type), key).into())
         }
         if !map_descriptor.value_type.admits(&value) {
-            return Err(Error::new(ErrType::TypeError(format!("{:?}", map_descriptor.value_type), value)))
+            return Err(UncheckedError::TypeError(format!("{:?}", map_descriptor.value_type), value).into())
         }
 
         let exists = self.fetch_entry(contract_name, map_name, &key)?.is_some();
@@ -309,7 +309,7 @@ impl <'a> ContractDatabase <'a> {
 
         let map_descriptor = self.load_map(contract_name, map_name)?;
         if !map_descriptor.key_type.admits(key) {
-            return Err(Error::new(ErrType::TypeError(format!("{:?}", map_descriptor.key_type), (*key).clone())))
+            return Err(UncheckedError::TypeError(format!("{:?}", map_descriptor.key_type), (*key).clone()).into())
         }
 
         let none: Option<String> = None;
@@ -327,7 +327,7 @@ impl <'a> ContractDatabase <'a> {
 
     pub fn get_contract(&mut self, contract_name: &str) -> Result<Contract> {
         self.load_contract(contract_name)
-            .ok_or_else(|| { Error::new(ErrType::UndefinedContract(contract_name.to_string())) })
+            .ok_or_else(|| { UncheckedError::UndefinedContract(contract_name.to_string()).into() })
     }
 
     pub fn insert_contract(&mut self, contract_name: &str, contract: Contract) {
@@ -348,7 +348,7 @@ impl <'a> ContractDatabase <'a> {
             .expect("Failed to fetch simulated block height");
 
         u64::try_from(block_height)
-            .map_err(|_| Error::new(ErrType::Arithmetic("Overflowed fetching block height".to_string())))
+            .map_err(|_| RuntimeErrorType::Arithmetic("Overflowed fetching block height".to_string()).into())
     }
 
     pub fn get_simmed_block_time(&self, block_height: u64) -> Result<u64> {
@@ -361,7 +361,7 @@ impl <'a> ContractDatabase <'a> {
             .expect("Failed to fetch simulated block time");
 
         u64::try_from(block_time)
-            .map_err(|_| Error::new(ErrType::Arithmetic("Overflowed fetching block time".to_string())))
+            .map_err(|_| RuntimeErrorType::Arithmetic("Overflowed fetching block time".to_string()).into())
     }
 
     pub fn get_simmed_block_header_hash(&self, block_height: u64) -> Result<BlockHeaderHash> {
@@ -374,7 +374,7 @@ impl <'a> ContractDatabase <'a> {
             .expect("Failed to fetch simulated block header hash");
         
         BlockHeaderHash::from_bytes(&block_header_hash)
-            .ok_or(Error::new(ErrType::ParseError("Failed to instantiate BlockHeaderHash from simmed db data".to_string())))
+            .ok_or(RuntimeErrorType::ParseError("Failed to instantiate BlockHeaderHash from simmed db data".to_string()).into())
     }
 
     pub fn get_simmed_burnchain_block_header_hash(&self, block_height: u64) -> Result<BurnchainHeaderHash> {
@@ -387,7 +387,7 @@ impl <'a> ContractDatabase <'a> {
             .expect("Failed to fetch simulated block header hash");
         
         BurnchainHeaderHash::from_bytes(&block_header_hash)
-            .ok_or(Error::new(ErrType::ParseError("Failed to instantiate BurnchainHeaderHash from simmed db data".to_string())))
+            .ok_or(RuntimeErrorType::ParseError("Failed to instantiate BurnchainHeaderHash from simmed db data".to_string()).into())
     }
 
     pub fn get_simmed_block_vrf_seed(&self, block_height: u64) -> Result<VRFSeed> {
@@ -399,7 +399,7 @@ impl <'a> ContractDatabase <'a> {
                 |row| row.get(0))
             .expect("Failed to fetch simulated block vrf seed");
         VRFSeed::from_bytes(&block_vrf_seed)
-            .ok_or(Error::new(ErrType::ParseError("Failed to instantiate VRF seed from simmed db data".to_string())))
+            .ok_or(RuntimeErrorType::ParseError("Failed to instantiate VRF seed from simmed db data".to_string()).into())
     }
 
     pub fn sim_mine_block_with_time(&mut self, block_time: u64) {

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -170,14 +170,15 @@ fn make_for_simple_native(api: &SimpleFunctionAPI, function: &NativeFunctions) -
                     let in_types: Vec<String> = in_types.iter().map(|x| format!("{}", x)).collect();
                     in_types.join(", ")
                 },
+                FunctionType::UnionArgs(ref in_types, _) => {
+                    let in_types: Vec<String> = in_types.iter().map(|x| format!("{}", x)).collect();
+                    in_types.join(" | ")
+                },
             };
             let output_type = match function_type {
-                FunctionType::Variadic(_, ref out_type) => {
-                    format!("{}", out_type)
-                },
-                FunctionType::Fixed(_, ref out_type) => {
-                    format!("{}", out_type)
-            },
+                FunctionType::Variadic(_, ref out_type) => format!("{}", out_type),
+                FunctionType::Fixed(_, ref out_type) => format!("{}", out_type),
+                FunctionType::UnionArgs(_, ref out_type) => format!("{}", out_type)
             };
             (input_type, output_type)
         } else {

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -157,8 +157,30 @@ impl Into<Value> for ShortReturnType {
 #[cfg(test)]
 mod test {
     use super::*;
+    use vm::{execute};
 
     #[test]
     fn error_formats() {
+        let t = "(/ 10 0)";
+        let expected = "Arithmetic(\"Divide by 0\")
+ Stack Trace: 
+_native_:native_div
+";
+
+        assert_eq!(
+            format!("{}", execute(t).unwrap_err()),
+            expected);
     }
+
+    #[test]
+    fn equality() {
+        assert_eq!(Error::ShortReturn(ShortReturnType::ExpectedValue(Value::Bool(true))),
+                   Error::ShortReturn(ShortReturnType::ExpectedValue(Value::Bool(true))));
+        assert_eq!(Error::Interpreter(InterpreterError::InterpreterError("".to_string())),
+                   Error::Interpreter(InterpreterError::InterpreterError("".to_string())));
+        assert!(Error::ShortReturn(ShortReturnType::ExpectedValue(Value::Bool(true))) !=
+                Error::Interpreter(InterpreterError::InterpreterError("".to_string())));
+
+    }
+
 }

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -48,6 +48,7 @@ pub enum InterpreterError {
     BadSender(Value),
     BadSymbolicRepresentation(String),
     InterpreterError(String),
+    SqliteError(IncomparableError<SqliteError>),
 }
 
 
@@ -67,7 +68,6 @@ pub enum RuntimeErrorType {
     InvalidTypeDescription,
     BadBlockHeight(String),
     NotImplemented,
-    SqliteError(IncomparableError<SqliteError>),
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/vm/functions/arithmetic.rs
+++ b/src/vm/functions/arithmetic.rs
@@ -1,10 +1,10 @@
 use vm::types::Value;
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, RuntimeErrorType, InterpreterResult as Result};
 
 fn type_force_integer(value: &Value) -> Result<i128> {
     match *value {
         Value::Int(int) => Ok(int),
-        _ => Err(Error::new(ErrType::TypeError("IntType".to_string(), value.clone())))
+        _ => Err(UncheckedError::TypeError("IntType".to_string(), value.clone()).into())
     }
 }
 
@@ -15,13 +15,15 @@ where F: Fn(i128, i128) -> bool {
         let arg2 = type_force_integer(&args[1])?;
         Ok(Value::Bool((*function)(arg1, arg2)))
     } else {
-        Err(Error::new(ErrType::InvalidArguments("Binary comparison must be called with exactly 2 arguments".to_string())))
+        Err(UncheckedError::InvalidArguments("Binary comparison must be called with exactly 2 arguments".to_string())
+            .into())
     }
 }
 
 pub fn native_xor(args: &[Value]) -> Result<Value> {
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("(xor ...) must be called with exactly 2 arguments".to_string())))
+        return Err(UncheckedError::InvalidArguments("(xor ...) must be called with exactly 2 arguments".to_string())
+                   .into())
     }
     let x = type_force_integer(&args[0])?;
     let y = type_force_integer(&args[1])?;
@@ -53,7 +55,7 @@ pub fn native_add(args: &[Value]) -> Result<Value> {
     if let Some(result) = checked_result{
         Ok(Value::Int(result))
     } else {
-        Err(Error::new(ErrType::Arithmetic("Overflowed in addition".to_string())))
+        Err(RuntimeErrorType::Arithmetic("Overflowed in addition".to_string()).into())
     }
 }
 
@@ -73,10 +75,10 @@ pub fn native_sub(args: &[Value]) -> Result<Value> {
         if let Some(result) = checked_result{
             Ok(Value::Int(result))
         } else {
-            Err(Error::new(ErrType::Arithmetic("Underflowed in subtraction".to_string())))
+            Err(RuntimeErrorType::Arithmetic("Underflowed in subtraction".to_string()).into())
         }
     } else {
-        Err(Error::new(ErrType::InvalidArguments("(- ...) must be called with at least 1 argument".to_string())))
+        Err(UncheckedError::InvalidArguments("(- ...) must be called with at least 1 argument".to_string()).into())
     }
 }
 
@@ -91,7 +93,7 @@ pub fn native_mul(args: &[Value]) -> Result<Value> {
     if let Some(result) = checked_result{
         Ok(Value::Int(result))
     } else {
-        Err(Error::new(ErrType::Arithmetic("Overflowed in multiplication".to_string())))
+        Err(RuntimeErrorType::Arithmetic("Overflowed in multiplication".to_string()).into())
     }
 }
 
@@ -107,10 +109,10 @@ pub fn native_div(args: &[Value]) -> Result<Value> {
         if let Some(result) = checked_result{
             Ok(Value::Int(result))
         } else {
-            Err(Error::new(ErrType::Arithmetic("Divide by 0".to_string())))
+            Err(RuntimeErrorType::Arithmetic("Divide by 0".to_string()).into())
         }
     } else {
-        Err(Error::new(ErrType::InvalidArguments("(/ ...) must be called with at least 1 argument".to_string())))
+        Err(UncheckedError::InvalidArguments("(/ ...) must be called with at least 1 argument".to_string()).into())
     }
 }
 
@@ -142,7 +144,7 @@ pub fn native_pow(args: &[Value]) -> Result<Value> {
         let base = type_force_integer(&args[0])?;
         let power_i128 = type_force_integer(&args[1])?;
         if power_i128 < 0 || power_i128 > (u32::max_value() as i128) {
-            return Err(Error::new(ErrType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string())))
+            return Err(RuntimeErrorType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string()).into())
         }
 
         let power = power_i128 as u32;
@@ -151,10 +153,10 @@ pub fn native_pow(args: &[Value]) -> Result<Value> {
         if let Some(result) = checked_result{
             Ok(Value::Int(result))
         } else {
-            Err(Error::new(ErrType::Arithmetic("Overflowed in power".to_string())))
+            Err(RuntimeErrorType::Arithmetic("Overflowed in power".to_string()).into())
         }
     } else {
-        Err(Error::new(ErrType::InvalidArguments("(pow ...) must be called with exactly 2 arguments".to_string())))
+        Err(UncheckedError::InvalidArguments("(pow ...) must be called with exactly 2 arguments".to_string()).into())
     }
 }
 
@@ -167,9 +169,9 @@ pub fn native_mod(args: &[Value]) -> Result<Value> {
         if let Some(result) = checked_result{
             Ok(Value::Int(result))
         } else {
-            Err(Error::new(ErrType::Arithmetic("Modulus by 0".to_string())))
+            Err(RuntimeErrorType::Arithmetic("Modulus by 0".to_string()).into())
         }
     } else {
-        Err(Error::new(ErrType::InvalidArguments("(mod ...) must be called with exactly 2 arguments".to_string())))
+        Err(UncheckedError::InvalidArguments("(mod ...) must be called with exactly 2 arguments".to_string()).into())
     }
 }

--- a/src/vm/functions/boolean.rs
+++ b/src/vm/functions/boolean.rs
@@ -1,18 +1,18 @@
 use vm::types::Value;
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, InterpreterResult as Result};
 use vm::representations::SymbolicExpression;
 use vm::{LocalContext, Environment, eval};
 
 fn type_force_bool(value: &Value) -> Result<bool> {
     match *value {
         Value::Bool(boolean) => Ok(boolean),
-        _ => Err(Error::new(ErrType::TypeError("BoolType".to_string(), value.clone())))
+        _ => Err(UncheckedError::TypeError("BoolType".to_string(), value.clone()).into())
     }
 }
 
 pub fn special_or(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     if args.len() < 1 {
-        return Err(Error::new(ErrType::InvalidArguments("(or ...) requires at least 1 argument".to_string())))
+        return Err(UncheckedError::InvalidArguments("(or ...) requires at least 1 argument".to_string()).into())
     }
 
     for arg in args.iter() {
@@ -28,7 +28,7 @@ pub fn special_or(args: &[SymbolicExpression], env: &mut Environment, context: &
 
 pub fn special_and(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     if args.len() < 1 {
-        return Err(Error::new(ErrType::InvalidArguments("(and ...) requires at least 1 argument".to_string())))
+        return Err(UncheckedError::InvalidArguments("(and ...) requires at least 1 argument".to_string()).into())
     }
 
     for arg in args.iter() {
@@ -44,7 +44,7 @@ pub fn special_and(args: &[SymbolicExpression], env: &mut Environment, context: 
 
 pub fn native_not(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
-        return Err(Error::new(ErrType::InvalidArguments("(not ...) requires exactly 1 argument".to_string())))
+        return Err(UncheckedError::InvalidArguments("(not ...) requires exactly 1 argument".to_string()).into())
     }
     let value = type_force_bool(&args[0])?;
     Ok(Value::Bool(!value))

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -5,22 +5,22 @@ use vm::functions::tuples::TupleDefinitionType::{Implicit, Explicit};
 
 use vm::types::{Value, BuffData, BlockInfoProperty};
 use vm::representations::{SymbolicExpression};
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, RuntimeErrorType, InterpreterResult as Result};
 use vm::{eval, LocalContext, Environment};
 
 pub fn special_contract_call(args: &[SymbolicExpression],
                          env: &mut Environment,
                          context: &LocalContext) -> Result<Value> {
     if args.len() < 2 {
-        return Err(Error::new(ErrType::InvalidArguments(
-            "(contract-call ...) requires at least 2 arguments: the contract name and the public function name".to_string())))
+        return Err(UncheckedError::InvalidArguments(
+            "(contract-call ...) requires at least 2 arguments: the contract name and the public function name".to_string()).into())
     }
 
     let contract_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument to (contract-call ...) must be contract name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument to (contract-call ...) must be contract name".to_string()))?;
 
     let function_name = args[1].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("Second argument to (contract-call ...) must be function name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Second argument to (contract-call ...) must be function name".to_string()))?;
 
     let rest_args = &args[2..];
 
@@ -29,9 +29,9 @@ pub fn special_contract_call(args: &[SymbolicExpression],
     let rest_args: Vec<_> = rest_args.drain(..).map(|x| { SymbolicExpression::atom_value(x) }).collect();
 
     if env.sender.is_none() {
-        return Err(Error::new(ErrType::InvalidArguments(
+        return Err(UncheckedError::InvalidArguments(
             "No sender in current context. Did you attempt to (contract-call ...) from a non-contract aware environment?"
-                .to_string())));
+                .to_string()).into());
     }
 
     env.execute_contract(
@@ -44,11 +44,11 @@ pub fn special_fetch_entry(args: &[SymbolicExpression],
     // arg0 -> map name
     // arg1 -> key
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("(fetch-entry ...) requires exactly 2 arguments".to_string())))
+        return Err(UncheckedError::InvalidArguments("(fetch-entry ...) requires exactly 2 arguments".to_string()).into())
     }
 
     let map_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument in data functions must be the map name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument in data functions must be the map name".to_string()))?;
 
 
     let key = match tuples::get_definition_type_of_tuple_argument(&args[1]) {
@@ -71,13 +71,13 @@ pub fn special_fetch_contract_entry(args: &[SymbolicExpression],
     // arg1 -> map name
     // arg2 -> key
     if args.len() != 3 {
-        return Err(Error::new(ErrType::InvalidArguments("(fetch-contract-entry ...) requires exactly 3 arguments".to_string())))
+        return Err(UncheckedError::InvalidArguments("(fetch-contract-entry ...) requires exactly 3 arguments".to_string()).into())
     }
 
     let contract_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument in fetch-contract-entry must be contract name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument in fetch-contract-entry must be contract name".to_string()))?;
     let map_name = args[1].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("Second argument in fetch-contract-entry must be the map name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Second argument in fetch-contract-entry must be the map name".to_string()))?;
 
     let key = match tuples::get_definition_type_of_tuple_argument(&args[2]) {
         Implicit(ref expr) => tuples::tuple_cons(expr, env, context)?,
@@ -95,14 +95,14 @@ pub fn special_set_entry(args: &[SymbolicExpression],
                          env: &mut Environment,
                          context: &LocalContext) -> Result<Value> {
     if env.global_context.is_read_only() {
-        return Err(Error::new(ErrType::WriteFromReadOnlyContext))
+        return Err(UncheckedError::WriteFromReadOnlyContext.into())
     }
 
     // arg0 -> map name
     // arg1 -> key
     // arg2 -> value
     if args.len() != 3 {
-        return Err(Error::new(ErrType::InvalidArguments("(set-entry! ...) requires exactly 3 arguments".to_string())))
+        return Err(UncheckedError::InvalidArguments("(set-entry! ...) requires exactly 3 arguments".to_string()).into())
     }
 
     let key = match tuples::get_definition_type_of_tuple_argument(&args[1]) {
@@ -116,7 +116,7 @@ pub fn special_set_entry(args: &[SymbolicExpression],
     };
 
     let map_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument in data functions must be the map name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument in data functions must be the map name".to_string()))?;
 
     env.global_context.database.set_entry(&env.contract_context.name, map_name, key, value)
 }
@@ -125,14 +125,14 @@ pub fn special_insert_entry(args: &[SymbolicExpression],
                             env: &mut Environment,
                             context: &LocalContext) -> Result<Value> {
     if env.global_context.is_read_only() {
-        return Err(Error::new(ErrType::WriteFromReadOnlyContext))
+        return Err(UncheckedError::WriteFromReadOnlyContext.into())
     }
 
     // arg0 -> map name
     // arg1 -> key
     // arg2 -> value
     if args.len() != 3 {
-        return Err(Error::new(ErrType::InvalidArguments("(insert-entry! ...) requires exactly 3 arguments".to_string())))
+        return Err(UncheckedError::InvalidArguments("(insert-entry! ...) requires exactly 3 arguments".to_string()).into())
     }
     
     let key = match tuples::get_definition_type_of_tuple_argument(&args[1]) {
@@ -146,7 +146,7 @@ pub fn special_insert_entry(args: &[SymbolicExpression],
     };
 
     let map_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument in data functions must be the map name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument in data functions must be the map name".to_string()))?;
 
     env.global_context.database.insert_entry(&env.contract_context.name, map_name, key, value)
 }
@@ -155,13 +155,13 @@ pub fn special_delete_entry(args: &[SymbolicExpression],
                             env: &mut Environment,
                             context: &LocalContext) -> Result<Value> {
     if env.global_context.is_read_only() {
-        return Err(Error::new(ErrType::WriteFromReadOnlyContext))
+        return Err(UncheckedError::WriteFromReadOnlyContext.into())
     }
 
     // arg0 -> map name
     // arg1 -> key
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("(delete-entry! ...) requires exactly 2 arguments".to_string())))
+        return Err(UncheckedError::InvalidArguments("(delete-entry! ...) requires exactly 2 arguments".to_string()).into())
     }
 
     let key = match tuples::get_definition_type_of_tuple_argument(&args[1]) {
@@ -170,7 +170,7 @@ pub fn special_delete_entry(args: &[SymbolicExpression],
     };
 
     let map_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument in data functions must be the map name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument in data functions must be the map name".to_string()))?;
 
     env.global_context.database.delete_entry(&env.contract_context.name, map_name, &key)
 }
@@ -182,33 +182,33 @@ pub fn special_get_block_info(args: &[SymbolicExpression],
     // (get-block-info property-name block-height-int)
 
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments(
-            "(get-block-info ...) requires at least 2 arguments: the block property name and the block height expression".to_string())))
+        return Err(UncheckedError::InvalidArguments(
+            "(get-block-info ...) requires at least 2 arguments: the block property name and the block height expression".to_string()).into())
     }
 
     // Handle the block property name input arg.
     let property_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument to (get-block-info ...) must be block property name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument to (get-block-info ...) must be block property name".to_string()))?;
 
     let block_info_prop = BlockInfoProperty::from_str(property_name)
-        .ok_or(Error::new(ErrType::InvalidArguments("First argument to (get-block-info ...) is not a valid block property name".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("First argument to (get-block-info ...) is not a valid block property name".to_string()))?;
 
 
     // Handle the block-height input arg clause.
     let height_eval = eval(&args[1], env, context)?;
     let height_value = match height_eval {
         Value::Int(result) => Ok(result),
-        _ => Err(Error::new(ErrType::TypeError("IntType".to_string(), height_eval)))
+        _ => Err(UncheckedError::TypeError("IntType".to_string(), height_eval))
     }?;
 
     let height_value = match u64::try_from(height_value) {
         Ok(result) => result,
-        _ => return Err(Error::new(ErrType::BadBlockHeight(height_value.to_string())))
+        _ => return Err(RuntimeErrorType::BadBlockHeight(height_value.to_string()).into())
     };
 
     let current_block_height = env.global_context.get_block_height();
     if height_value > current_block_height {
-        return Err(Error::new(ErrType::BadBlockHeight(height_value.to_string())));
+        return Err(RuntimeErrorType::BadBlockHeight(height_value.to_string()).into());
     }
 
     use self::BlockInfoProperty::*;

--- a/src/vm/functions/define.rs
+++ b/src/vm/functions/define.rs
@@ -2,7 +2,7 @@ use vm::types::{Value, TupleTypeSignature, parse_name_type_pairs};
 use vm::callables::{DefinedFunction, DefineType};
 use vm::representations::SymbolicExpression;
 use vm::representations::SymbolicExpressionType::{Atom, AtomValue, List};
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, InterpreterResult as Result};
 use vm::contexts::{ContractContext, LocalContext, Environment};
 use vm::eval;
 
@@ -17,9 +17,9 @@ fn check_legal_define(name: &str, contract_context: &ContractContext) -> Result<
     use vm::is_reserved;
 
     if is_reserved(name) {
-        Err(Error::new(ErrType::ReservedName(name.to_string())))
+        Err(UncheckedError::ReservedName(name.to_string()).into())
     } else if contract_context.variables.contains_key(name) || contract_context.functions.contains_key(name) {
-        Err(Error::new(ErrType::VariableDefinedMultipleTimes(name.to_string())))
+        Err(UncheckedError::VariableDefinedMultipleTimes(name.to_string()).into())
     } else {
         Ok(())
     }
@@ -38,10 +38,10 @@ fn handle_define_function(signature: &[SymbolicExpression],
                           env: &Environment,
                           define_type: DefineType) -> Result<DefineResult> {
     let (function_symbol, arg_symbols) = signature.split_first()
-        .ok_or(Error::new(ErrType::InvalidArguments("Must supply atleast a name argument to define a function".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Must supply atleast a name argument to define a function".to_string()))?;
 
     let function_name = function_symbol.match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments(format!("Invalid function name {:?}", function_symbol))))?;
+        .ok_or(UncheckedError::InvalidArguments(format!("Invalid function name {:?}", function_symbol)))?;
 
     check_legal_define(&function_name, &env.contract_context)?;
 
@@ -62,7 +62,7 @@ fn handle_define_map(map_name: &SymbolicExpression,
                      value_type: &SymbolicExpression,
                      env: &Environment) -> Result<DefineResult> {
     let map_str = map_name.match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("Non-name argument to define-map".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Non-name argument to define-map".to_string()))?;
 
     check_legal_define(&map_str, &env.contract_context)?;
 
@@ -83,12 +83,12 @@ pub fn evaluate_define(expression: &SymbolicExpression, env: &mut Environment) -
             return match func_name.as_str() {
                 "define" => {
                     if elements.len() != 3 {
-                        Err(Error::new(ErrType::InvalidArguments("(define ...) requires 2 arguments".to_string())))
+                        Err(UncheckedError::InvalidArguments("(define ...) requires 2 arguments".to_string()).into())
                     } else {
                         match elements[1].expr {
                             Atom(ref variable) => handle_define_variable(variable, &elements[2], env),
-                            AtomValue(ref _value) => Err(Error::new(ErrType::InvalidArguments(
-                                "Illegal operation: attempted to re-define a value type.".to_string()))),
+                            AtomValue(ref _value) => Err(UncheckedError::InvalidArguments(
+                                "Illegal operation: attempted to re-define a value type.".to_string()).into()),
                             List(ref function_signature) =>
                                 handle_define_function(&function_signature, &elements[2], env, DefineType::Private)
                         }
@@ -96,27 +96,27 @@ pub fn evaluate_define(expression: &SymbolicExpression, env: &mut Environment) -
                 },
                 "define-read-only" => {
                     if elements.len() != 3 {
-                        Err(Error::new(ErrType::InvalidArguments("(define-read-only ...) must be supplied an argument list and a function body".to_string())))
+                        Err(UncheckedError::InvalidArguments("(define-read-only ...) must be supplied an argument list and a function body".to_string()).into())
                     } else {
                         let function_signature = elements[1].match_list()
-                            .ok_or(Error::new(ErrType::InvalidArguments(
-                                "Illegal operation: attempted to define-read-only a non-function.".to_string())))?;
+                            .ok_or(UncheckedError::InvalidArguments(
+                                "Illegal operation: attempted to define-read-only a non-function.".to_string()))?;
                         handle_define_function(&function_signature, &elements[2], env, DefineType::ReadOnly)
                     }
                 },
                 "define-public" => {
                     if elements.len() != 3 {
-                        Err(Error::new(ErrType::InvalidArguments("(define-public ...) must be supplied an argument list and a function body".to_string())))
+                        Err(UncheckedError::InvalidArguments("(define-public ...) must be supplied an argument list and a function body".to_string()).into())
                     } else {
                         let function_signature = elements[1].match_list()
-                            .ok_or(Error::new(ErrType::InvalidArguments(
-                                "Illegal operation: attempted to define-public a non-function.".to_string())))?;
+                            .ok_or(UncheckedError::InvalidArguments(
+                                "Illegal operation: attempted to define-public a non-function.".to_string()))?;
                         handle_define_function(&function_signature, &elements[2], env, DefineType::Public)
                     }
                 },
                 "define-map" => {
                     if elements.len() != 4 {
-                        Err(Error::new(ErrType::InvalidArguments("(define-map ...) must be supplied a name, a list of key fields, and a list of value fields".to_string())))
+                        Err(UncheckedError::InvalidArguments("(define-map ...) must be supplied a name, a list of key fields, and a list of value fields".to_string()).into())
                     } else {
                         handle_define_map(&elements[1], &elements[2], &elements[3], env)
                     }

--- a/src/vm/functions/lists.rs
+++ b/src/vm/functions/lists.rs
@@ -1,4 +1,4 @@
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, InterpreterResult as Result};
 use vm::types::Value;
 use vm::representations::{SymbolicExpression, SymbolicExpressionType};
 use vm::{LocalContext, Environment, eval, apply, lookup_function};
@@ -9,10 +9,10 @@ pub fn list_cons(args: &[Value]) -> Result<Value> {
 
 pub fn list_filter(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments(format!("Wrong number of arguments ({}) to filter", args.len()))))
+        return Err(UncheckedError::InvalidArguments(format!("Wrong number of arguments ({}) to filter", args.len())).into())
     }
     let function_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("Filter must be called with a function name. We do not support eval'ing to functions.".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Filter must be called with a function name. We do not support eval'ing to functions.".to_string()))?;
 
     let function = lookup_function(&function_name, env)?;
     let list = eval(&args[1], env, context)?;
@@ -26,21 +26,21 @@ pub fn list_filter(args: &[SymbolicExpression], env: &mut Environment, context: 
                     output.push(x);
                 } // else, filter out.
             } else {
-                return Err(Error::new(ErrType::TypeError("Bool".to_string(), filter_eval)))
+                return Err(UncheckedError::TypeError("Bool".to_string(), filter_eval).into())
             }
         }
         Value::list_from(output)
     } else {
-        Err(Error::new(ErrType::TypeError("List".to_string(), list)))
+        Err(UncheckedError::TypeError("List".to_string(), list).into())
     }
 }
 
 pub fn list_fold(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     if args.len() != 3 {
-        return Err(Error::new(ErrType::InvalidArguments(format!("Wrong number of arguments ({}) to fold", args.len()))))
+        return Err(UncheckedError::InvalidArguments(format!("Wrong number of arguments ({}) to fold", args.len())).into())
     }
     let function_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("Fold must be called with a function name. We do not support eval'ing to functions.".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Fold must be called with a function name. We do not support eval'ing to functions.".to_string()))?;
 
     let function = lookup_function(&function_name, env)?;
     let list = eval(&args[1], env, context)?;
@@ -54,16 +54,16 @@ pub fn list_fold(args: &[SymbolicExpression], env: &mut Environment, context: &L
                 apply(&function, &argument, env, context)
             })
     } else {
-        Err(Error::new(ErrType::TypeError("List".to_string(), list)))
+        Err(UncheckedError::TypeError("List".to_string(), list).into())
     }
 }
 
 pub fn list_map(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments(format!("Wrong number of arguments ({}) to map", args.len()))))
+        return Err(UncheckedError::InvalidArguments(format!("Wrong number of arguments ({}) to map", args.len())).into())
     }
     let function_name = args[0].match_atom()
-        .ok_or(Error::new(ErrType::InvalidArguments("Map must be called with a function name. We do not support eval'ing to functions.".to_string())))?;
+        .ok_or(UncheckedError::InvalidArguments("Map must be called with a function name. We do not support eval'ing to functions.".to_string()))?;
     let function = lookup_function(&function_name, env)?;
 
     let list = eval(&args[1], env, context)?;
@@ -74,6 +74,6 @@ pub fn list_map(args: &[SymbolicExpression], env: &mut Environment, context: &Lo
         }).collect();
         Value::list_from(mapped_vec?)
     } else {
-        Err(Error::new(ErrType::TypeError("List".to_string(), list)))
+        Err(UncheckedError::TypeError("List".to_string(), list).into())
     }
 }

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -211,7 +211,7 @@ fn native_hash160(args: &[Value]) -> Result<Value> {
     let bytes = match input {
         Value::Int(value) => Ok(value.to_le_bytes().to_vec()),
         Value::Buffer(value) => Ok(value.data.clone()),
-        _ => Err(RuntimeErrorType::NotImplemented)
+        _ => Err(UncheckedError::TypeError("Int|Buffer".to_string(), input.clone()))
     }?;
     let hash160 = Hash160::from_data(&bytes);
     Value::buff_from(hash160.as_bytes().to_vec())
@@ -227,7 +227,7 @@ fn native_sha256(args: &[Value]) -> Result<Value> {
     let bytes = match input {
         Value::Int(value) => Ok(value.to_le_bytes().to_vec()),
         Value::Buffer(value) => Ok(value.data.clone()),
-        _ => Err(RuntimeErrorType::NotImplemented)
+        _ => Err(UncheckedError::TypeError("Int|Buffer".to_string(), input.clone()))
     }?;
     let sha256 = Sha256Sum::from_data(&bytes);
     Value::buff_from(sha256.as_bytes().to_vec())
@@ -243,7 +243,7 @@ fn native_keccak256(args: &[Value]) -> Result<Value> {
     let bytes = match input {
         Value::Int(value) => Ok(value.to_le_bytes().to_vec()),
         Value::Buffer(value) => Ok(value.data.clone()),
-        _ => Err(RuntimeErrorType::NotImplemented)
+        _ => Err(UncheckedError::TypeError("Int|Buffer".to_string(), input.clone()))
     }?;
     let keccak256 = Keccak256Hash::from_data(&bytes);
     Value::buff_from(keccak256.as_bytes().to_vec())

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -6,7 +6,7 @@ mod boolean;
 mod database;
 mod options;
 
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, RuntimeErrorType, InterpreterResult as Result};
 use vm::types::{Value, PrincipalData, ResponseData, TypeSignature};
 use vm::callables::CallableType;
 use vm::representations::{SymbolicExpression, SymbolicExpressionType};
@@ -192,8 +192,7 @@ fn native_eq(args: &[Value]) -> Result<Value> {
         let mut arg_type = TypeSignature::type_of(first);
         for x in args.iter() {
             arg_type = TypeSignature::most_admissive(TypeSignature::type_of(x), arg_type)
-                .map_err(|(a,b)| Error::new(
-                    ErrType::TypeError(format!("{}", a), x.clone())))?;
+                .map_err(|(a,b)| UncheckedError::TypeError(format!("{}", a), x.clone()))?;
             if x != first {
                 return Ok(Value::Bool(false))
             }
@@ -206,13 +205,13 @@ fn native_hash160(args: &[Value]) -> Result<Value> {
     use util::hash::Hash160;
 
     if !(args.len() == 1) {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to hash160 (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to hash160 (expects 1)".to_string()).into())
     }
     let input = &args[0];
     let bytes = match input {
         Value::Int(value) => Ok(value.to_le_bytes().to_vec()),
         Value::Buffer(value) => Ok(value.data.clone()),
-        _ => Err(Error::new(ErrType::NotImplemented))
+        _ => Err(RuntimeErrorType::NotImplemented)
     }?;
     let hash160 = Hash160::from_data(&bytes);
     Value::buff_from(hash160.as_bytes().to_vec())
@@ -222,13 +221,13 @@ fn native_sha256(args: &[Value]) -> Result<Value> {
     use util::hash::Sha256Sum;
 
     if !(args.len() == 1) {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to sha256 (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to sha256 (expects 1)".to_string()).into())
     }
     let input = &args[0];
     let bytes = match input {
         Value::Int(value) => Ok(value.to_le_bytes().to_vec()),
         Value::Buffer(value) => Ok(value.data.clone()),
-        _ => Err(Error::new(ErrType::NotImplemented))
+        _ => Err(RuntimeErrorType::NotImplemented)
     }?;
     let sha256 = Sha256Sum::from_data(&bytes);
     Value::buff_from(sha256.as_bytes().to_vec())
@@ -238,13 +237,13 @@ fn native_keccak256(args: &[Value]) -> Result<Value> {
     use util::hash::Keccak256Hash;
 
     if !(args.len() == 1) {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to keccak256 (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to keccak256 (expects 1)".to_string()).into())
     }
     let input = &args[0];
     let bytes = match input {
         Value::Int(value) => Ok(value.to_le_bytes().to_vec()),
         Value::Buffer(value) => Ok(value.data.clone()),
-        _ => Err(Error::new(ErrType::NotImplemented))
+        _ => Err(RuntimeErrorType::NotImplemented)
     }?;
     let keccak256 = Keccak256Hash::from_data(&bytes);
     Value::buff_from(keccak256.as_bytes().to_vec())
@@ -253,13 +252,13 @@ fn native_keccak256(args: &[Value]) -> Result<Value> {
 fn native_begin(args: &[Value]) -> Result<Value> {
     match args.last() {
         Some(v) => Ok(v.clone()),
-        None => Err(Error::new(ErrType::InvalidArguments("Must pass at least 1 expression to (begin ...)".to_string())))
+        None => Err(UncheckedError::InvalidArguments("Must pass at least 1 expression to (begin ...)".to_string()).into())
     }
 }
 
 fn native_print(args: &[Value]) -> Result<Value> {
     if !(args.len() == 1) {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to print (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to print (expects 1)".to_string()).into())
     }
     if cfg!(feature = "developer-mode") {
         eprintln!("{:?}", args[0]);
@@ -269,7 +268,7 @@ fn native_print(args: &[Value]) -> Result<Value> {
 
 fn special_if(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     if args.len() != 3 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to if (expects 3)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to if (expects 3)".to_string()).into())
     }
     // handle the conditional clause.
     let conditional = eval(&args[0], env, context)?;
@@ -281,7 +280,7 @@ fn special_if(args: &[SymbolicExpression], env: &mut Environment, context: &Loca
                 eval(&args[2], env, context)
             }
         },
-        _ => Err(Error::new(ErrType::TypeError("BoolType".to_string(), conditional)))
+        _ => Err(UncheckedError::TypeError("BoolType".to_string(), conditional).into())
     }
 }
 
@@ -291,16 +290,16 @@ fn parse_eval_bindings(bindings: &[SymbolicExpression],
     for binding in bindings.iter() {
         if let List(ref binding_exps) = binding.expr {
             if binding_exps.len() != 2 {
-                return Err(Error::new(ErrType::InvalidArguments("Passed non 2-length list as a binding. Bindings should be of the form (name value).".to_string())))
+                return Err(UncheckedError::InvalidArguments("Passed non 2-length list as a binding. Bindings should be of the form (name value).".to_string()).into())
             }
             if let Atom(ref var_name) = binding_exps[0].expr {
                 let value = eval(&binding_exps[1], env, context)?;
                 result.push((var_name.clone(), value));
             } else {
-                return Err(Error::new(ErrType::InvalidArguments("Passed bad variable name as a binding. Bindings should be of the form (name value).".to_string())))
+                return Err(UncheckedError::InvalidArguments("Passed bad variable name as a binding. Bindings should be of the form (name value).".to_string()).into())
             }
         } else {
-            return Err(Error::new(ErrType::InvalidArguments("Passed non 2-length list as a binding. Bindings should be of the form (name value).".to_string())))
+            return Err(UncheckedError::InvalidArguments("Passed non 2-length list as a binding. Bindings should be of the form (name value).".to_string()).into())
         }
     }
 
@@ -314,7 +313,7 @@ fn special_let(args: &[SymbolicExpression], env: &mut Environment, context: &Loc
     // arg0 => binding list
     // arg1 => body
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to let (expect 2)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to let (expect 2)".to_string()).into())
     }
     // create a new context.
     let mut inner_context = context.extend()?;
@@ -324,10 +323,10 @@ fn special_let(args: &[SymbolicExpression], env: &mut Environment, context: &Loc
         let mut binding_results = parse_eval_bindings(bindings, env, context)?;
         for (binding_name, binding_value) in binding_results.drain(..) {
             if is_reserved(&binding_name) {
-                return Err(Error::new(ErrType::ReservedName(binding_name)))
+                return Err(UncheckedError::ReservedName(binding_name).into())
             }
             if inner_context.variables.contains_key(&binding_name) {
-                return Err(Error::new(ErrType::VariableDefinedMultipleTimes(binding_name)))
+                return Err(UncheckedError::VariableDefinedMultipleTimes(binding_name).into())
             }
             inner_context.variables.insert(binding_name, binding_value);
         }
@@ -335,7 +334,7 @@ fn special_let(args: &[SymbolicExpression], env: &mut Environment, context: &Loc
         // evaluate the let-body
         eval(&args[1], env, &inner_context)
     } else {
-        Err(Error::new(ErrType::InvalidArguments("Passed non-list as second argument to let expression.".to_string())))
+        Err(UncheckedError::InvalidArguments("Passed non-list as second argument to let expression.".to_string()).into())
     }
 }
 
@@ -345,7 +344,7 @@ fn special_as_contract(args: &[SymbolicExpression], env: &mut Environment, conte
     // (as-contract (..))
     // arg0 => body
     if args.len() != 1 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to as-contract (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to as-contract (expects 1)".to_string()).into())
     }
 
     // nest an environment.

--- a/src/vm/functions/options.rs
+++ b/src/vm/functions/options.rs
@@ -1,9 +1,9 @@
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, ShortReturnType, InterpreterResult as Result};
 use vm::types::{Value, ResponseData};
 
 pub fn native_expects(args: &[Value]) -> Result<Value> {
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to expects (expects! input-value thrown-value)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to expects (expects! input-value thrown-value)".to_string()).into())
     }
 
     let input = &args[0];
@@ -13,23 +13,23 @@ pub fn native_expects(args: &[Value]) -> Result<Value> {
         Value::Optional(data) => {
             match data.data {
                 Some(ref data) => Ok((**data).clone()),
-                None => Err(Error::new(ErrType::ExpectedValue(thrown.clone())))
+                None => Err(ShortReturnType::ExpectedValue(thrown.clone()).into())
             }
         },
         Value::Response(data) => {
             if data.committed {
                 Ok((*data.data).clone())
             } else {
-                Err(Error::new(ErrType::ExpectedValue(thrown.clone())))
+                Err(ShortReturnType::ExpectedValue(thrown.clone()).into())
             }
         },
-        _ => Err(Error::new(ErrType::TypeError("OptionalType|ResponseType".to_string(), input.clone())))
+        _ => Err(UncheckedError::TypeError("OptionalType|ResponseType".to_string(), input.clone()).into())
     }
 }
 
 pub fn native_expects_err(args: &[Value]) -> Result<Value> {
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to expects (expects-err! input-value thrown-value)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to expects (expects-err! input-value thrown-value)".to_string()).into())
     }
 
     let input = &args[0];
@@ -40,42 +40,42 @@ pub fn native_expects_err(args: &[Value]) -> Result<Value> {
             if !data.committed {
                 Ok((*data.data).clone())
             } else {
-                Err(Error::new(ErrType::ExpectedValue(thrown.clone())))
+                Err(ShortReturnType::ExpectedValue(thrown.clone()).into())
             }
         },
-        _ => Err(Error::new(ErrType::TypeError("ResponseType".to_string(), input.clone())))
+        _ => Err(UncheckedError::TypeError("ResponseType".to_string(), input.clone()).into())
     }
 }
 
 pub fn native_is_none(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to is-none? (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to is-none? (expects 1)".to_string()).into())
     }
 
     let input = &args[0];
 
     match input {
         Value::Optional(ref data) => Ok(Value::Bool(data.data.is_none())),
-        _ => Err(Error::new(ErrType::TypeError("OptionalType".to_string(), input.clone())))
+        _ => Err(UncheckedError::TypeError("OptionalType".to_string(), input.clone()).into())
     }
 }
 
 pub fn native_is_okay(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to is-ok? (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to is-ok? (expects 1)".to_string()).into())
     }
 
     let input = &args[0];
 
     match input {
         Value::Response(data) => Ok(Value::Bool(data.committed)),
-        _ => Err(Error::new(ErrType::TypeError("ResponseType".to_string(), input.clone())))
+        _ => Err(UncheckedError::TypeError("ResponseType".to_string(), input.clone()).into())
     }
 }
 
 pub fn native_okay(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to ok (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to ok (expects 1)".to_string()).into())
     }
 
     let input = &args[0];
@@ -84,7 +84,7 @@ pub fn native_okay(args: &[Value]) -> Result<Value> {
 
 pub fn native_error(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to err (expects 1)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to err (expects 1)".to_string()).into())
     }
 
     let input = &args[0];
@@ -93,7 +93,7 @@ pub fn native_error(args: &[Value]) -> Result<Value> {
 
 pub fn native_default_to(args: &[Value]) -> Result<Value> {
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments("Wrong number of arguments to default-to (expects 2)".to_string())))
+        return Err(UncheckedError::InvalidArguments("Wrong number of arguments to default-to (expects 2)".to_string()).into())
     }
 
     let default = &args[0];
@@ -106,6 +106,6 @@ pub fn native_default_to(args: &[Value]) -> Result<Value> {
                 None => Ok(default.clone())
             }
         },
-        _ => Err(Error::new(ErrType::TypeError("OptionalType".to_string(), input.clone())))
+        _ => Err(UncheckedError::TypeError("OptionalType".to_string(), input.clone()).into())
     }
 }

--- a/src/vm/functions/tuples.rs
+++ b/src/vm/functions/tuples.rs
@@ -1,4 +1,4 @@
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{UncheckedError, InterpreterResult as Result};
 use vm::types::{Value};
 use vm::representations::{SymbolicExpression,SymbolicExpressionType};
 use vm::representations::SymbolicExpressionType::{List};
@@ -14,7 +14,7 @@ pub fn tuple_cons(args: &[SymbolicExpression], env: &mut Environment, context: &
     use super::parse_eval_bindings;
 
     if args.len() < 1 {
-        return Err(Error::new(ErrType::InvalidArguments(format!("Tuples must be constructed with named-arguments and corresponding values"))))
+        return Err(UncheckedError::InvalidArguments(format!("Tuples must be constructed with named-arguments and corresponding values")).into())
     }
 
     let bindings = parse_eval_bindings(args, env, context)?;
@@ -27,11 +27,11 @@ pub fn tuple_get(args: &[SymbolicExpression], env: &mut Environment, context: &L
     //    if the tuple argument is an option type, then return option(field-name).
 
     if args.len() != 2 {
-        return Err(Error::new(ErrType::InvalidArguments(format!("(get ..) requires exactly 2 arguments"))))
+        return Err(UncheckedError::InvalidArguments(format!("(get ..) requires exactly 2 arguments")).into())
     }
     let arg_name = match args[0].expr {
         SymbolicExpressionType::Atom(ref name) => Ok(name),
-        _ => Err(Error::new(ErrType::InvalidArguments(format!("Second argument to (get ..) must be a name, found: {:?}", args[0]))))
+        _ => Err(UncheckedError::InvalidArguments(format!("Second argument to (get ..) must be a name, found: {:?}", args[0])))
     }?;
 
     let value = eval(&args[1], env, context)?;
@@ -44,14 +44,14 @@ pub fn tuple_get(args: &[SymbolicExpression], env: &mut Environment, context: &L
                     if let Value::Tuple(tuple_data) = data {
                         Ok(Value::some(tuple_data.get(arg_name)?))
                     } else {
-                        Err(Error::new(ErrType::TypeError("TupleType".to_string(), data.clone())))
+                        Err(UncheckedError::TypeError("TupleType".to_string(), data.clone()).into())
                     }
                 },
                 None => Ok(value.clone()) // just pass through none-types.
             }
         },
         Value::Tuple(tuple_data) => tuple_data.get(arg_name),
-        _ => Err(Error::new(ErrType::TypeError("TupleType".to_string(), value.clone())))
+        _ => Err(UncheckedError::TypeError("TupleType".to_string(), value.clone()).into())
     }
 }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -59,9 +59,9 @@ pub fn lookup_function(name: &str, env: &Environment)-> Result<CallableType> {
 }
 
 fn add_stack_trace(result: &mut Result<Value>, env: &Environment) {
-    if let Err(Error::Runtime(ref mut e)) = result {
-        if e.stack_trace.is_none() {
-            e.stack_trace.replace(env.call_stack.make_stack_trace());
+    if let Err(Error::Runtime(_, ref mut stack_trace)) = result {
+        if stack_trace.is_none() {
+            stack_trace.replace(env.call_stack.make_stack_trace());
         }
     }
 }

--- a/src/vm/parser.rs
+++ b/src/vm/parser.rs
@@ -337,7 +337,7 @@ mod test {
 
     #[test]
     fn test_parse_failures() {
-        use vm::errors::ErrType;
+        use vm::errors::{Error, RuntimeErrorType};
 
         let too_much_closure = "(let ((x 1) (y 2))))";
         let not_enough_closure = "(let ((x 1) (y 2))";
@@ -345,32 +345,32 @@ mod test {
         let unicode = "(let ((x🎶 1)) (eq x🎶 1))";
         let split_tokens = "(let ((023ab13 1)))";
 
-        assert!(match parser::parse(&split_tokens).unwrap_err().err_type {
-            ErrType::ParseError(_) => true,
+        assert!(match parser::parse(&split_tokens).unwrap_err() {
+            Error::Runtime(RuntimeErrorType::ParseError(_), _) => true,
             _ => false
         }, "Should have failed to parse with an expectation of whitespace or parens");
 
-        assert!(match parser::parse(&too_much_closure).unwrap_err().err_type {
-            ErrType::ParseError(_) => true,
+        assert!(match parser::parse(&too_much_closure).unwrap_err() {
+            Error::Runtime(RuntimeErrorType::ParseError(_), _) => true,
             _ => false
         }, "Should have failed to parse with too many right parens");
         
-        assert!(match parser::parse(&not_enough_closure).unwrap_err().err_type {
-            ErrType::ParseError(_) => true,
+        assert!(match parser::parse(&not_enough_closure).unwrap_err() {
+            Error::Runtime(RuntimeErrorType::ParseError(_), _) => true,
             _ => false
         }, "Should have failed to parse with too few right parens");
         
-        let x = parser::parse(&middle_hash).unwrap_err().err_type;
+        let x = parser::parse(&middle_hash).unwrap_err();
         assert!(match x {
-            ErrType::ParseError(_) => true,
+            Error::Runtime(RuntimeErrorType::ParseError(_), _) => true,
             _ => {
                 println!("Expected parser error. Unexpected value is:\n {:?}", x);
                 false
             }
         }, "Should have failed to parse with a middle hash");
 
-        assert!(match parser::parse(&unicode).unwrap_err().err_type {
-            ErrType::ParseError(_) => true,
+        assert!(match parser::parse(&unicode).unwrap_err() {
+            Error::Runtime(RuntimeErrorType::ParseError(_), _) => true,
             _ => false
         }, "Should have failed to parse a unicode variable name");
 

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -1,5 +1,5 @@
 use vm::execute as vm_execute;
-use vm::errors::{Error, ErrType};
+use vm::errors::{Error, UncheckedError};
 use vm::types::{Value, PrincipalData, ResponseData};
 use vm::contexts::{OwnedEnvironment,GlobalContext};
 use vm::database::{ContractDatabaseConnection};
@@ -499,11 +499,9 @@ fn test_factorial_contract() {
 
     let err_result = env.execute_contract("factorial", "init-factorial",
                                           &symbols_from_values(vec![Value::Int(9000),
-                                                                    Value::Int(15)]));
+                                                                    Value::Int(15)])).unwrap_err();
     match err_result {
-        Err(Error{
-            err_type: ErrType::NonPublicFunction(_),
-            stack_trace: _ }) => {},
+        Error::Unchecked(UncheckedError::NonPublicFunction(_)) => {},
         _ => {
             println!("{:?}", err_result);
             panic!("Attempt to call init-factorial should fail!")
@@ -511,11 +509,9 @@ fn test_factorial_contract() {
     }
 
     let err_result = env.execute_contract("factorial", "compute",
-                                          &symbols_from_values(vec![Value::Bool(true)]));
+                                          &symbols_from_values(vec![Value::Bool(true)])).unwrap_err();
     match err_result {
-        Err(Error{
-            err_type: ErrType::TypeError(_, _),
-            stack_trace: _ }) => {},
+        Error::Unchecked(UncheckedError::TypeError(_, _)) => {},
         _ => {
             println!("{:?}", err_result);
             assert!(false, "Attempt to call compute with void type should fail!")

--- a/src/vm/tests/datamaps.rs
+++ b/src/vm/tests/datamaps.rs
@@ -423,6 +423,18 @@ fn tuples_system() {
     let mut test_bad_tuple_1 = test1.to_string();
     test_bad_tuple_1.push_str("(insert-entry! tuples (tuple (name 1)) (tuple (contents (tuple (name \"abcde\") (owner \"abcdef\")))))");
 
+    let mut test_bad_tuple_2 = test1.to_string();
+    test_bad_tuple_2.push_str("(fetch-entry tuples (tuple (names 1)))");
+
+    let mut test_bad_tuple_3 = test1.to_string();
+    test_bad_tuple_3.push_str("(set-entry! tuples (tuple (names 1)) (tuple (contents (tuple (name \"abcde\") (owner \"abcde\")))))");
+
+    let mut test_bad_tuple_4 = test1.to_string();
+    test_bad_tuple_4.push_str("(set-entry! tuples (tuple (name 1)) (tuple (contents 1)))");
+
+    let mut test_bad_tuple_5 = test1.to_string();
+    test_bad_tuple_5.push_str("(delete-entry! tuples (tuple (names 1)))");
+
     let expected = || {
         let buff1 = Value::buff_from("abcde".to_string().into_bytes())?;
         let buff2 = Value::buff_from("abcd".to_string().into_bytes())?;
@@ -431,7 +443,10 @@ fn tuples_system() {
 
     assert_executes(expected(), test1);
 
-    for test in [test_list_too_big, test_bad_tuple_1].iter() {
+    let type_error_tests = [test_list_too_big, test_bad_tuple_1, test_bad_tuple_2, test_bad_tuple_3,
+                            test_bad_tuple_4, test_bad_tuple_5];
+
+    for test in type_error_tests.iter() {
         let expected_type_error = match execute(test) {
             Err(Error::Unchecked(UncheckedError::TypeError(_,_))) => true,
             _ => {

--- a/src/vm/tests/defines.rs
+++ b/src/vm/tests/defines.rs
@@ -48,6 +48,35 @@ fn test_bad_define_names() {
 }
 
 #[test]
+fn test_expects() {
+    let test0 =
+        "(define (foo) (expects! (ok 1) 2)) (foo)";
+    let test1 =
+        "(define (foo) (expects! (ok 1))) (foo)";
+    let test2 =
+        "(define (foo) (expects! 1 2)) (foo)";
+    let test3 =
+        "(define (foo) (expects-err! 1 2)) (foo)";
+    let test4 =
+        "(define (foo) (expects-err! (err 1) 2)) (foo)";
+    let test5 =
+        "(define (foo) (expects-err! (err 1))) (foo)";
+
+    assert_eq!(Ok(Some(Value::Int(1))), execute(&test0));
+    assert_eq_err(UncheckedError::InvalidArguments(
+        "Wrong number of arguments to expects (expects! input-value thrown-value)".to_string()),
+                  execute(&test1).unwrap_err());
+    assert_eq_err(UncheckedError::TypeError("OptionalType|ResponseType".to_string(), Value::Int(1)),
+                  execute(&test2).unwrap_err());
+    assert_eq_err(UncheckedError::TypeError("ResponseType".to_string(), Value::Int(1)),
+                  execute(&test3).unwrap_err());
+    assert_eq!(Ok(Some(Value::Int(1))), execute(&test4));
+    assert_eq_err(UncheckedError::InvalidArguments(
+        "Wrong number of arguments to expects (expects-err! input-value thrown-value)".to_string()),
+                  execute(&test5).unwrap_err());
+}
+
+#[test]
 fn test_define_read_only() {
     let test0 =
         "(define-read-only (silly) 1) (silly)";

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -284,6 +284,31 @@ fn test_options_errors() {
 }
 
 #[test]
+fn test_hash_errors() {
+    let tests = [
+        "(sha256 2 1)",
+        "(keccak256 3 1)",
+        "(hash160 2 1)",
+        "(sha256 'true)",
+        "(keccak256 'true)",
+        "(hash160 'true)",
+    ];
+
+    let expectations: &[Error] = &[
+        UncheckedError::InvalidArguments("Wrong number of arguments to sha256 (expects 1)".to_string()).into(),
+        UncheckedError::InvalidArguments("Wrong number of arguments to keccak256 (expects 1)".to_string()).into(),
+        UncheckedError::InvalidArguments("Wrong number of arguments to hash160 (expects 1)".to_string()).into(),
+        UncheckedError::TypeError("Int|Buffer".to_string(), Value::Bool(true)).into(),
+        UncheckedError::TypeError("Int|Buffer".to_string(), Value::Bool(true)).into(),
+        UncheckedError::TypeError("Int|Buffer".to_string(), Value::Bool(true)).into(),
+    ];
+
+    for (program, expectation) in tests.iter().zip(expectations.iter()) {
+        assert_eq!(*expectation, vm_execute(program).unwrap_err());
+    }
+}
+
+#[test]
 fn test_bool_functions() {
     let tests = [
         "'true",

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -1,6 +1,6 @@
 use vm::{eval, execute as vm_execute};
 use vm::database::ContractDatabaseConnection;
-use vm::errors::{ErrType};
+use vm::errors::{UncheckedError, RuntimeErrorType, Error};
 use vm::{Value, LocalContext, ContractContext, GlobalContext, Environment, CallStack};
 use vm::contexts::{OwnedEnvironment};
 use vm::callables::DefinedFunction;
@@ -230,25 +230,25 @@ fn test_arithmetic_errors() {
          "(pow 2 (pow 2 32))",
          "(pow 2 (- 1))"];
 
-    let expectations = [
-        ErrType::InvalidArguments("Binary comparison must be called with exactly 2 arguments".to_string()),
-        ErrType::TypeError("IntType".to_string(), Value::Bool(true)),
-        ErrType::Arithmetic("Divide by 0".to_string()),
-        ErrType::Arithmetic("Modulus by 0".to_string()),
-        ErrType::Arithmetic("Overflowed in power".to_string()),
-        ErrType::Arithmetic("Overflowed in multiplication".to_string()),
-        ErrType::Arithmetic("Overflowed in addition".to_string()),
-        ErrType::Arithmetic("Underflowed in subtraction".to_string()),
-        ErrType::InvalidArguments("(- ...) must be called with at least 1 argument".to_string()),
-        ErrType::InvalidArguments("(/ ...) must be called with at least 1 argument".to_string()),
-        ErrType::InvalidArguments("(mod ...) must be called with exactly 2 arguments".to_string()),
-        ErrType::InvalidArguments("(pow ...) must be called with exactly 2 arguments".to_string()),
-        ErrType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string()),
-        ErrType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string())
+    let expectations: &[Error] = &[
+        UncheckedError::InvalidArguments("Binary comparison must be called with exactly 2 arguments".to_string()).into(),
+        UncheckedError::TypeError("IntType".to_string(), Value::Bool(true)).into(),
+        RuntimeErrorType::Arithmetic("Divide by 0".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Modulus by 0".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Overflowed in power".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Overflowed in multiplication".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Overflowed in addition".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Underflowed in subtraction".to_string()).into(),
+        UncheckedError::InvalidArguments("(- ...) must be called with at least 1 argument".to_string()).into(),
+        UncheckedError::InvalidArguments("(/ ...) must be called with at least 1 argument".to_string()).into(),
+        UncheckedError::InvalidArguments("(mod ...) must be called with exactly 2 arguments".to_string()).into(),
+        UncheckedError::InvalidArguments("(pow ...) must be called with exactly 2 arguments".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string()).into(),
+        RuntimeErrorType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string()).into()
     ];
 
     for (program, expectation) in tests.iter().zip(expectations.iter()) {
-        assert_eq!(*expectation, vm_execute(program).unwrap_err().err_type);
+        assert_eq!(*expectation, vm_execute(program).unwrap_err());
     }
 }
 
@@ -283,11 +283,11 @@ fn test_bad_lets() {
         "(let ((* 1)) (+ * *))",
         "(let ((a 1) (a 2)) (+ a a))"];
 
-    let expectations = [
-        ErrType::ReservedName("tx-sender".to_string()),
-        ErrType::ReservedName("*".to_string()),
-        ErrType::VariableDefinedMultipleTimes("a".to_string())];
+    let expectations: &[Error] = &[
+        UncheckedError::ReservedName("tx-sender".to_string()).into(),
+        UncheckedError::ReservedName("*".to_string()).into(),
+        UncheckedError::VariableDefinedMultipleTimes("a".to_string()).into()];
 
     tests.iter().zip(expectations.iter())
-        .for_each(|(program, expectation)| assert_eq!(*expectation, vm_execute(program).unwrap_err().err_type));
+        .for_each(|(program, expectation)| assert_eq!((*expectation), vm_execute(program).unwrap_err()));
 }

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -227,6 +227,7 @@ fn test_arithmetic_errors() {
         "(/)",
         "(mod 1)",
         "(pow 1)",
+        "(xor 1)",
          "(pow 2 (pow 2 32))",
          "(pow 2 (- 1))"];
 
@@ -243,8 +244,38 @@ fn test_arithmetic_errors() {
         UncheckedError::InvalidArguments("(/ ...) must be called with at least 1 argument".to_string()).into(),
         UncheckedError::InvalidArguments("(mod ...) must be called with exactly 2 arguments".to_string()).into(),
         UncheckedError::InvalidArguments("(pow ...) must be called with exactly 2 arguments".to_string()).into(),
+        UncheckedError::InvalidArguments("(xor ...) must be called with exactly 2 arguments".to_string()).into(),
         RuntimeErrorType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string()).into(),
         RuntimeErrorType::Arithmetic("Power argument to (pow ...) must be a u32 integer".to_string()).into()
+    ];
+
+    for (program, expectation) in tests.iter().zip(expectations.iter()) {
+        assert_eq!(*expectation, vm_execute(program).unwrap_err());
+    }
+}
+
+#[test]
+fn test_options_errors() {
+    let tests = [
+        "(is-none? 2 1)",
+        "(is-none? 'true)",
+        "(is-ok? 2 1)",
+        "(is-ok? 'true)",
+        "(ok 2 3)",
+        "(err 4 5)",
+        "(default-to 4 5 7)",
+        "(default-to 4 'true)",
+        ];
+
+    let expectations: &[Error] = &[
+        UncheckedError::InvalidArguments("Wrong number of arguments to is-none? (expects 1)".to_string()).into(),
+        UncheckedError::TypeError("OptionalType".to_string(), Value::Bool(true)).into(),
+        UncheckedError::InvalidArguments("Wrong number of arguments to is-ok? (expects 1)".to_string()).into(),
+        UncheckedError::TypeError("ResponseType".to_string(), Value::Bool(true)).into(),
+        UncheckedError::InvalidArguments("Wrong number of arguments to ok (expects 1)".to_string()).into(),
+        UncheckedError::InvalidArguments("Wrong number of arguments to err (expects 1)".to_string()).into(),
+        UncheckedError::InvalidArguments("Wrong number of arguments to default-to (expects 2)".to_string()).into(),
+        UncheckedError::TypeError("OptionalType".to_string(), Value::Bool(true)).into(),
     ];
 
     for (program, expectation) in tests.iter().zip(expectations.iter()) {

--- a/src/vm/types.rs
+++ b/src/vm/types.rs
@@ -7,7 +7,7 @@ use vm::representations::{SymbolicExpression, SymbolicExpressionType};
 use vm::errors::{RuntimeErrorType, UncheckedError, InterpreterResult as Result, IncomparableError};
 use util::hash;
 
-const MAX_VALUE_SIZE: i128 = 1024 * 1024; // 1MB
+pub const MAX_VALUE_SIZE: i128 = 1024 * 1024; // 1MB
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TupleTypeSignature {

--- a/src/vm/variables.rs
+++ b/src/vm/variables.rs
@@ -1,7 +1,7 @@
 use::std::convert::TryFrom;
 use vm::types::Value;
 use vm::contexts::{LocalContext, Environment};
-use vm::errors::{Error, ErrType, InterpreterResult as Result};
+use vm::errors::{RuntimeErrorType, UncheckedError, InterpreterResult as Result};
 
 pub enum NativeVariables {
     TxSender, BlockHeight, BurnBlockHeight
@@ -28,9 +28,9 @@ pub fn lookup_reserved_variable(name: &str, _context: &LocalContext, env: &Envir
         match variable {
             NativeVariables::TxSender => {
                 let sender = env.sender.clone()
-                    .ok_or(Error::new(ErrType::InvalidArguments(
+                    .ok_or(UncheckedError::InvalidArguments(
                         "No sender in current context. Did you attempt to (contract-call ...) from a non-contract aware environment?"
-                            .to_string())))?;
+                            .to_string()))?;
                 Ok(Some(sender))
             },
             NativeVariables::BlockHeight => {
@@ -38,7 +38,7 @@ pub fn lookup_reserved_variable(name: &str, _context: &LocalContext, env: &Envir
                 Ok(Some(Value::Int(block_height as i128)))
             },
             NativeVariables::BurnBlockHeight => {
-                Err(Error::new(ErrType::NotImplemented))
+                Err(RuntimeErrorType::NotImplemented.into())
             }
         }
     } else {


### PR DESCRIPTION
This PR refactors the `vm::errors` types so that they are categorized as:

* Interpreter Errors: these are errors in the interpreter's implementation. they should perhaps be replaced by panics.
* Unchecked Errors: these are errors that should be caught by the TypeChecker before execution. They should only occur when testing the interpreter runtime separately from the TypeChecker.
* Runtime Errors: these are errors that may occur during the execution of a smart contract.

As the codebase matures further, I expect some of those RuntimeErrors to migrate to UncheckedErrors (bad type descriptions, in particular). Additionally, ParserErrors may get their own categorization as well. In general, this PR isn't meant to be the final say in the error handling in the interpreter, but rather a necessary first step to wrangling the error handling.

Addresses #977 