### PR TITLE
Reading SIP 003

### DIFF
--- a/sip/sip-003-peer-network.md
+++ b/sip/sip-003-peer-network.md
@@ -403,7 +403,7 @@ pub struct HandshakeData {
     /// This peer's public key
     pub node_public_key: Secp256k1PublicKey,
 
-    /// Burn chain block height at which this handshake will expire
+    /// Burn chain block height at which this key will expire
     pub expire_block_height: u64
 }
 ```


### PR DESCRIPTION
And it was fascinating!
I have a few questions:

> 1.  The sender creates a `GetBlocksInv` message for a range of blocks it wants,
    and sends it to the receiver.

How can the range be known, initially? Can you pass a wildcard?

> The Stacks peer network implements a flooding network for blocks and transactions in order to ensure that all peers receive a full copy of the chain state as it arrives on the network.

Is there a specific behavior for the propagation of the transactions, where the goal would probably to hit the miners / validators ASAP?  

As a developer, if I'm running my node, is the propagation of my users' transactions being prioritized (vs relaying)?

> If the data has not been seen before by the peer, and the data is valid, then the peer forwards it to a subset of its neighbors (excluding the one that sent the data).

If the data is invalid, is the peer caching it?


I might be missing something, but combining:

> A peer that receives a message that contains duplicate entries in the relayers vector (or sees itself in the relayers vector) must not forward the message either, since the message has been passed in a cycle.

&&

> In addition, the relaying peer appends the
upstream peer's message signature and previous sequence number in the
message's `relayers` vector. 

&&

> A peer that relays messages _must_ include itself at the end of the
`relayers` vector when it forwards a message.

might be an issue :)

Do we already have an idea of `struct` for `relayers`? 
