### PR TITLE
High level Clarity interface

### DIFF
--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -668,6 +668,13 @@ impl MARF {
             })
     }
 
+    /// Drop the current trie from the MARF. This rolls back all
+    ///   changes in the block, and closes the current chain tip.
+    pub fn drop_current(&mut self) {
+        self.storage.drop_extending_trie();
+        self.open_chain_tip = None;
+    }
+
     /// Finish writing the next trie in the MARF.  This persists all changes.
     pub fn commit(&mut self) -> Result<(), Error> {
         match self.open_chain_tip.take() {

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -1273,6 +1273,10 @@ impl TrieFileStorage {
         Ok(())
     }
 
+    pub fn drop_extending_trie(&mut self) {
+        self.last_extended = None;
+    }
+
     pub fn last_ptr(&mut self) -> Result<u32, Error> {
         if let Some((_, ref mut trie_ram)) = self.last_extended {
             trie_ram.last_ptr()

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -137,7 +137,6 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                     let mut marf = friendly_expect(sqlite_marf(&args[2], None), "Failed to open VM database.");
                     let result = { let mut db = AnalysisDatabase::new(Box::new(&mut marf));
                                    run_analysis(&contract_id, &mut ast, &mut db, false) };
-                    marf.commit();
                     result
                 } else {
                     let memory = friendly_expect(SqliteConnection::memory(), "Could not open in-memory analysis DB");

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -13,7 +13,7 @@ use chainstate::stacks::index::storage::{TrieFileStorage};
 
 use vm::ast::parse;
 use vm::contexts::OwnedEnvironment;
-use vm::database::{ClarityDatabase, SqliteStore, SqliteConnection, KeyValueStorage,
+use vm::database::{ClarityDatabase, SqliteConnection, KeyValueStorage,
                    MarfedKV, memory_db, sqlite_marf};
 use vm::errors::{InterpreterResult};
 use vm::{SymbolicExpression, SymbolicExpressionType, Value};

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -71,15 +71,16 @@ fn friendly_expect_opt<A>(input: Option<A>, msg: &str) -> A {
     })
 }
 
-fn clarity_db(marf_kv: &mut MarfedKV) -> ClarityDatabase {
+fn clarity_db<S: KeyValueStorage>(marf_kv: &mut MarfedKV<S>) -> ClarityDatabase {
     ClarityDatabase::new(Box::new(marf_kv))
 }
 
 
 // This function is pretty weird! But it helps cut down on
 //   repeating a lot of block initialization for the simulation commands.
-fn in_block<F,R>(mut marf_kv: MarfedKV, f: F) -> R
-where F: FnOnce(MarfedKV) -> (MarfedKV, R) {
+fn in_block<F,R,S>(mut marf_kv: MarfedKV<S>, f: F) -> R
+where F: FnOnce(MarfedKV<S>) -> (MarfedKV<S>, R),
+      S: KeyValueStorage {
     let from = marf_kv.get_chain_tip().clone();
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
     let to = friendly_expect_opt(BlockHeaderHash::from_bytes(&random_bytes),

--- a/src/vm/analysis/mod.rs
+++ b/src/vm/analysis/mod.rs
@@ -6,7 +6,7 @@ pub mod read_only_checker;
 pub mod analysis_db;
 pub mod contract_interface_builder;
 
-use self::types::{ContractAnalysis, AnalysisPass};
+pub use self::types::{ContractAnalysis, AnalysisPass};
 use vm::representations::{SymbolicExpression};
 use vm::types::{TypeSignature, QualifiedContractIdentifier};
 

--- a/src/vm/ast/mod.rs
+++ b/src/vm/ast/mod.rs
@@ -3,19 +3,21 @@ pub mod expression_identifier;
 pub mod sugar_expander;
 pub mod types;
 pub mod errors;
-use vm::errors::Error;
+use vm::errors::{Error, RuntimeErrorType};
 
 use vm::representations::{SymbolicExpression};
 use vm::types::QualifiedContractIdentifier;
 
-use self::types::{ContractAST, BuildASTPass};
+pub use self::types::{ContractAST};
+use self::types::{BuildASTPass};
 use self::errors::{ParseResult};
 use self::expression_identifier::ExpressionIdentifier;
 use self::sugar_expander::SugarExpander;
 
 /// Legacy function
 pub fn parse(contract_identifier: &QualifiedContractIdentifier,source_code: &str) -> Result<Vec<SymbolicExpression>, Error> {
-    let ast = build_ast(contract_identifier, source_code).unwrap();
+    let ast = build_ast(contract_identifier, source_code)
+        .map_err(|e| RuntimeErrorType::ASTError(e))?;
     Ok(ast.expressions)
 }
 

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -95,6 +95,35 @@ impl <'a> ClarityBlockConnection <'a> {
         Ok((contract_ast, contract_analysis))
     }
 
+    fn with_abort_callback<F, A, R>(&mut self, to_do: F, abort_call_back: A) -> Result<R, Error>
+    where A: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool,
+          F: FnOnce(&mut OwnedEnvironment) -> Result<(R, AssetMap), Error> {
+        let mut db = ClarityDatabase::new(Box::new(&mut self.datastore));
+        // wrap the whole contract-call in a claritydb transaction,
+        //   so we can abort on call_back's boolean retun
+        db.begin();
+        let mut vm_env = OwnedEnvironment::new(db);
+        let result = to_do(&mut vm_env);
+        let mut db = vm_env.destruct()
+            .expect("Failed to recover database reference after executing transaction");
+
+        match result {
+            Ok((value, asset_map)) => {
+                if abort_call_back(&asset_map, &mut db) {
+                    db.roll_back();
+                } else {
+                    db.commit();
+                }
+                Ok(value)
+            },
+            Err(e) => {
+                db.roll_back();
+                Err(e)
+            }
+        }
+    }
+    
+
     /// An error here would indicate that something has gone terribly wrong in the processing of a contract insert.
     ///   the caller should likely abort the whole block or panic
     pub fn save_analysis(&mut self, identifier: &QualifiedContractIdentifier, contract_analysis: &ContractAnalysis) -> Result<(), CheckError> {
@@ -112,39 +141,20 @@ impl <'a> ClarityBlockConnection <'a> {
     pub fn run_contract_call <F> (&mut self, sender: &PrincipalData, contract: &QualifiedContractIdentifier, public_function: &str,
                                   args: &[Value], abort_call_back: F) -> Result<Value, Error>
     where F: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool {
-        let mut db = ClarityDatabase::new(Box::new(&mut self.datastore));
-        // wrap the whole contract-call in a claritydb transaction,
-        //   so we can abort on call_back's boolean retun
-        db.begin();
-        let mut vm_env = OwnedEnvironment::new(db);
         let expr_args: Vec<_> = args.iter().map(|x| SymbolicExpression::atom_value(x.clone())).collect();
-        let (value, asset_map) = vm_env.execute_transaction(Value::Principal(sender.clone()), contract.clone(), public_function, &expr_args)?;
-        let mut db = vm_env.destruct()
-            .expect("Failed to recover database reference after executing transaction");
-        if abort_call_back(&asset_map, &mut db) {
-            db.roll_back();
-        } else {
-            db.commit();
-        }
-        Ok(value)
+
+        self.with_abort_callback(
+            |vm_env| { vm_env.execute_transaction(Value::Principal(sender.clone()), contract.clone(), public_function, &expr_args)
+                       .map_err(Error::from) },
+            abort_call_back)
     }
 
     pub fn initialize_smart_contract <F> (&mut self, identifier: &QualifiedContractIdentifier, contract_ast: &ContractAST, abort_call_back: F) -> Result<(), Error>
     where F: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool {
-        let mut db = ClarityDatabase::new(Box::new(&mut self.datastore));
-        // wrap the whole initialize in a claritydb transaction,
-        //   so we can abort on call_back's boolean retun
-        db.begin();
-        let mut vm_env = OwnedEnvironment::new(db);
-        let (_, asset_map) = vm_env.initialize_contract_from_ast(identifier.clone(), contract_ast)?;
-        let mut db = vm_env.destruct()
-            .expect("Failed to recover database reference after executing transaction");
-        if abort_call_back(&asset_map, &mut db) {
-            db.roll_back();
-        } else {
-            db.commit();
-        }
-        Ok(())
+        self.with_abort_callback(
+            |vm_env| { vm_env.initialize_contract_from_ast(identifier.clone(), contract_ast)
+                       .map_err(Error::from) },
+            abort_call_back)
     }
 }
 
@@ -216,4 +226,65 @@ mod tests {
                    sql.mut_conn()
                    .query_row::<u32,_,_>("SELECT COUNT(value) FROM data_table", NO_PARAMS, |row| row.get(0)).unwrap());
     }
+
+    #[test]
+    pub fn test_tx_roll_backs() {
+        let marf = marf::in_memory_marf();
+        let mut clarity_instance = ClarityInstance::new(marf);
+        let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
+        let sender = StandardPrincipalData::transient().into();
+
+        {
+            let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
+                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
+
+            let contract = "
+            (define-data-var bar int 0)
+            (define-public (get-bar) (ok (var-get bar)))
+            (define-public (set-bar (x int) (y int))
+              (begin (var-set! bar (/ x y)) (ok (var-get bar))))";
+
+            let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+            conn.initialize_smart_contract(
+                &contract_identifier, &ct_ast, |_,_| false).unwrap();
+            conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
+
+            assert_eq!(
+                conn.run_contract_call(&sender, &contract_identifier, "get-bar", &[],
+                                       |_, _| false).unwrap(),
+                Value::okay(Value::Int(0)));
+
+            assert_eq!(
+                conn.run_contract_call(&sender, &contract_identifier, "set-bar", &[Value::Int(1), Value::Int(1)],
+                                       |_, _| false).unwrap(),
+                Value::okay(Value::Int(1)));
+
+            assert_eq!(
+                conn.run_contract_call(&sender, &contract_identifier, "set-bar", &[Value::Int(10), Value::Int(1)],
+                                       |_, _| true).unwrap(),
+                Value::okay(Value::Int(10)));
+
+            // prior transaction should have rolled back due to abort call back!
+            assert_eq!(
+                conn.run_contract_call(&sender, &contract_identifier, "get-bar", &[],
+                                       |_, _| false).unwrap(),
+                Value::okay(Value::Int(1)));
+
+            assert!(
+                format!("{:?}",
+                        conn.run_contract_call(&sender, &contract_identifier, "set-bar", &[Value::Int(10), Value::Int(0)],
+                                               |_, _| true).unwrap_err())
+                    .contains("DivisionByZero"));
+
+            // prior transaction should have rolled back due to runtime error
+            assert_eq!(
+                conn.run_contract_call(&StandardPrincipalData::transient().into(), &contract_identifier, "get-bar", &[],
+                                       |_, _| false).unwrap(),
+                Value::okay(Value::Int(1)));
+
+            
+            conn.commit_block();
+        }
+    }
+
 }

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -1,0 +1,182 @@
+use vm::representations::SymbolicExpression;
+use vm::types::{Value, AssetIdentifier, PrincipalData, QualifiedContractIdentifier, TypeSignature};
+use vm::contexts::{OwnedEnvironment, AssetMap};
+use vm::database::{MarfedKV, ClarityDatabase};
+use vm::analysis::{AnalysisDatabase};
+use vm::errors::{Error as InterpreterError};
+use vm::ast::{ContractAST, errors::ParseError};
+use vm::analysis::{ContractAnalysis, errors::CheckError};
+use vm::ast;
+use vm::analysis;
+
+use chainstate::burn::BlockHeaderHash;
+
+pub struct ClarityInstance {
+    datastore: Option<MarfedKV>,
+}
+
+pub struct ClarityBlockConnection<'a> {
+    datastore: MarfedKV,
+    parent: &'a mut ClarityInstance
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Analysis(CheckError),
+    Parse(ParseError),
+    Interpreter(InterpreterError),
+}
+
+impl From<CheckError> for Error {
+    fn from(e: CheckError) -> Self {
+        Error::Analysis(e)
+    }
+}
+
+impl From<InterpreterError> for Error {
+    fn from(e: InterpreterError) -> Self {
+        Error::Interpreter(e)
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(e: ParseError) -> Self {
+        Error::Parse(e)
+    }
+}
+
+impl ClarityInstance {
+    pub fn new(datastore: MarfedKV) -> ClarityInstance {
+        ClarityInstance { datastore: Some(datastore) }
+    }
+
+    pub fn begin_block(&mut self, current: &BlockHeaderHash, next: &BlockHeaderHash) -> ClarityBlockConnection {
+        let mut datastore = self.datastore.take()
+            // this is a panicking failure, because there should be _no instance_ in which a ClarityBlockConnection
+            //   doesn't restore it's parent's datastore
+            .expect("FAIL: use of begin_block while prior block neither committed nor rolled back.");
+
+        datastore.begin(current, next);
+
+        ClarityBlockConnection {
+            datastore: datastore,
+            parent: self
+        }
+    }
+
+    pub fn destroy(mut self) -> MarfedKV {
+        let mut datastore = self.datastore.take()
+            .expect("FAIL: attempt to recover database connection from clarity instance which is still open");
+
+        datastore
+    }
+}
+
+impl <'a> ClarityBlockConnection <'a> {
+    pub fn rollback_block(mut self) {
+        self.datastore.rollback();
+
+        self.parent.datastore.replace(self.datastore);
+    }
+
+    pub fn commit_block(mut self) {
+        self.datastore.commit();
+
+        self.parent.datastore.replace(self.datastore);
+    }
+
+    pub fn analyze_smart_contract(&mut self, identifier: &QualifiedContractIdentifier, contract_content: &str)
+                                  -> Result<(ContractAST, ContractAnalysis), Error> {
+        let mut db = AnalysisDatabase::new(Box::new(&mut self.datastore));
+
+        let mut contract_ast = ast::build_ast(identifier, contract_content)?;
+        let contract_analysis = analysis::run_analysis(identifier, &mut contract_ast.expressions,
+                                                       &mut db, false)?;
+        Ok((contract_ast, contract_analysis))
+    }
+
+    /// An error here would indicate that something has gone terribly wrong in the processing of a contract insert.
+    ///   the caller should likely abort the whole block or panic
+    pub fn save_analysis(&mut self, identifier: &QualifiedContractIdentifier, contract_analysis: &ContractAnalysis) -> Result<(), CheckError> {
+        let mut db = AnalysisDatabase::new(Box::new(&mut self.datastore));
+        db.begin();
+        let result = db.insert_contract(identifier, contract_analysis);
+        if result.is_err() {
+            db.roll_back();
+        } else {
+            db.commit();
+        }
+        result
+    }
+
+    pub fn run_contract_call <F> (&mut self, sender: &PrincipalData, contract: &QualifiedContractIdentifier, public_function: &str,
+                                  args: &[Value], abort_call_back: F) -> Result<Value, Error>
+    where F: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool {
+        let mut db = ClarityDatabase::new(Box::new(&mut self.datastore));
+        // wrap the whole contract-call in a claritydb transaction,
+        //   so we can abort on call_back's boolean retun
+        db.begin();
+        let mut vm_env = OwnedEnvironment::new(db);
+        let expr_args: Vec<_> = args.iter().map(|x| SymbolicExpression::atom_value(x.clone())).collect();
+        let (value, asset_map) = vm_env.execute_transaction(Value::Principal(sender.clone()), contract.clone(), public_function, &expr_args)?;
+        let mut db = vm_env.destruct()
+            .expect("Failed to recover database reference after executing transaction");
+        if abort_call_back(&asset_map, &mut db) {
+            db.roll_back();
+        } else {
+            db.commit();
+        }
+        Ok(value)
+    }
+
+    pub fn initialize_smart_contract <F> (&mut self, identifier: &QualifiedContractIdentifier, contract_ast: &ContractAST, abort_call_back: F) -> Result<(), Error>
+    where F: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool {
+        let mut db = ClarityDatabase::new(Box::new(&mut self.datastore));
+        // wrap the whole initialize in a claritydb transaction,
+        //   so we can abort on call_back's boolean retun
+        db.begin();
+        let mut vm_env = OwnedEnvironment::new(db);
+        let (_, asset_map) = vm_env.initialize_contract_from_ast(identifier.clone(), contract_ast)?;
+        let mut db = vm_env.destruct()
+            .expect("Failed to recover database reference after executing transaction");
+        if abort_call_back(&asset_map, &mut db) {
+            db.roll_back();
+        } else {
+            db.commit();
+        }
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vm::types::{Value, StandardPrincipalData};
+    use vm::database::marf;
+    use chainstate::stacks::index::storage::{TrieFileStorage};
+
+    #[test]
+    pub fn simple_test() {
+        let marf = marf::in_memory_marf(true);
+        let mut clarity_instance = ClarityInstance::new(marf);
+
+        let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
+                                                &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
+
+        let contract = "(define-public (foo (x int)) (ok (+ x x)))";
+        let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
+
+        let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+        conn.initialize_smart_contract(
+            &contract_identifier, &ct_ast, |_,_| false).unwrap();
+        conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
+
+        assert_eq!(
+            conn.run_contract_call(&StandardPrincipalData::transient().into(), &contract_identifier, "foo", &[Value::Int(1)],
+                                   |_, _| false).unwrap(),
+            Value::okay(Value::Int(2)));
+
+        conn.commit_block();
+    }
+}

--- a/src/vm/contracts.rs
+++ b/src/vm/contracts.rs
@@ -4,7 +4,7 @@ use vm::representations::{SymbolicExpression};
 use vm::errors::{InterpreterResult as Result};
 use vm::callables::CallableType;
 use vm::contexts::{Environment, LocalContext, ContractContext, GlobalContext};
-use vm::ast;
+use vm::ast::ContractAST;
 use vm::types::QualifiedContractIdentifier;
 
 #[derive(Serialize, Deserialize)]
@@ -15,12 +15,12 @@ pub struct Contract {
 // AARON: this is an increasingly useless wrapper around a ContractContext struct.
 //          will probably be removed soon.
 impl Contract {
-    pub fn initialize (contract_identifier: QualifiedContractIdentifier, contract: &str, global_context: &mut GlobalContext) -> Result<Contract> {
-        let parsed: Vec<_> = ast::parse(&contract_identifier, contract)?;
+    pub fn initialize_from_ast (contract_identifier: QualifiedContractIdentifier, contract: &ContractAST, global_context: &mut GlobalContext) -> Result<Contract> {
         let mut contract_context = ContractContext::new(contract_identifier);
 
-        eval_all(&parsed, &mut contract_context, global_context)?;
+        eval_all(&contract.expressions, &mut contract_context, global_context)?;
 
         Ok(Contract { contract_context: contract_context })
     }
+
 }

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -14,9 +14,12 @@ pub trait KeyValueStorage {
     ///    not all backends will implement this! this is used to clean up
     ///     any data from aborted blocks (not aborted transactions! that is handled
     ///      by the clarity vm directly).
-    fn begin(&mut self, key: &str) {}
-    fn commit(&mut self, key: &str) {}
-    fn rollback(&mut self, key: &str) {}
+    /// The block header hash is used for identifying savepoints.
+    ///     this _cannot_ be used to rollback to arbitrary prior block hash, because that
+    ///     blockhash would already have committed and no longer exist in the save point stack.
+    fn begin(&mut self, key: &BlockHeaderHash) {}
+    fn commit(&mut self, key: &BlockHeaderHash) {}
+    fn rollback(&mut self, key: &BlockHeaderHash) {}
 
     /// returns the previous block header hash on success
     fn set_block_hash(&mut self, bhh: BlockHeaderHash) -> Result<BlockHeaderHash> {

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -10,6 +10,14 @@ pub trait KeyValueStorage {
     fn get(&mut self, key: &str) -> Option<String>;
     fn has_entry(&mut self, key: &str) -> bool;
 
+    /// begin, commit, rollback a save point identified by key
+    ///    not all backends will implement this! this is used to clean up
+    ///     any data from aborted blocks (not aborted transactions! that is handled
+    ///      by the clarity vm directly).
+    fn begin(&mut self, key: &str) {}
+    fn commit(&mut self, key: &str) {}
+    fn rollback(&mut self, key: &str) {}
+
     /// returns the previous block header hash on success
     fn set_block_hash(&mut self, bhh: BlockHeaderHash) -> Result<BlockHeaderHash> {
         panic!("Attempted to evaluate changed block height with a generic backend");

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -17,6 +17,8 @@ pub trait KeyValueStorage {
     /// The block header hash is used for identifying savepoints.
     ///     this _cannot_ be used to rollback to arbitrary prior block hash, because that
     ///     blockhash would already have committed and no longer exist in the save point stack.
+    /// this is a "lower-level" rollback than the roll backs performed in
+    ///   ClarityDatabase or AnalysisDatabase -- this is done at the backing store level.
     fn begin(&mut self, key: &BlockHeaderHash) {}
     fn commit(&mut self, key: &BlockHeaderHash) {}
     fn rollback(&mut self, key: &BlockHeaderHash) {}

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -100,15 +100,15 @@ impl <S> MarfedKV <S> where S: KeyValueStorage {
         self.chain_tip = self.marf.get_open_chain_tip()
             .expect("ERROR: Failed to get open MARF")
             .clone();
-        self.side_store.begin(&self.chain_tip.to_hex());
+        self.side_store.begin(&self.chain_tip);
     }
     pub fn rollback(&mut self) {
         self.marf.drop_current();
-        self.side_store.rollback(&self.chain_tip.to_hex());
+        self.side_store.rollback(&self.chain_tip);
         self.chain_tip = TrieFileStorage::block_sentinel();
     }
     pub fn commit(&mut self) {
-        self.side_store.commit(&self.chain_tip.to_hex());
+        self.side_store.commit(&self.chain_tip);
         self.marf.commit()
             .expect("ERROR: Failed to commit MARF block");
     }

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -10,7 +10,7 @@ pub use self::key_value_wrapper::{
     KeyValueStorage, RollbackWrapper };
 pub use self::clarity_db::{ClarityDatabase};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable };
-pub use self::sqlite::{SqliteStore, SqliteConnection};
+pub use self::sqlite::{SqliteConnection};
 pub use self::marf::{sqlite_marf, MarfedKV};
 
 impl KeyValueStorage for HashMap<String, String> {

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -47,6 +47,21 @@ impl <'a> KeyValueStorage for SqliteStore<'a> {
     fn has_entry(&mut self, key: &str) -> bool {
         sqlite_has_entry(&self.conn, key)
     }
+
+    fn begin(&mut self, key: &str) {
+        self.conn.execute("SAVEPOINT ?", &[key])
+            .expect(SQL_FAIL_MESSAGE);
+    }
+
+    fn rollback(&mut self, key: &str) {
+        self.conn.execute("ROLLBACK TO SAVEPOINT ?", &[key])
+            .expect(SQL_FAIL_MESSAGE);
+    }
+
+    fn commit(&mut self, key: &str) {
+        self.conn.execute("RELEASE SAVEPOINT ?", &[key])
+            .expect(SQL_FAIL_MESSAGE);
+    }
 }
 
 impl KeyValueStorage for SqliteConnection {
@@ -102,7 +117,4 @@ impl SqliteConnection {
         Ok(SqliteConnection { conn })
     }
 
-    pub fn begin_save_point_raw<'a>(&'a mut self) -> Savepoint<'a> {
-        self.conn.savepoint().unwrap()
-    }
 }

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::error;
+use vm::ast::errors::ParseError;
 pub use vm::analysis::errors::{CheckErrors};
 pub use vm::analysis::errors::{check_argument_count, check_arguments_at_least};
 use vm::types::{Value, TypeSignature};
@@ -55,7 +56,10 @@ pub enum RuntimeErrorType {
     ArithmeticUnderflow,
     SupplyOverflow(i128, i128),
     DivisionByZero,
+    // error in parsing types
     ParseError(String),
+    // error in parsing the AST
+    ASTError(ParseError),
     MaxStackDepthReached,
     MaxContextDepthReached,
     ListDimensionTooHigh,

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10,6 +10,7 @@ mod representations;
 pub mod ast;
 pub mod contexts;
 pub mod database;
+pub mod clarity;
 
 mod functions;
 mod variables;

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -91,8 +91,6 @@ fn test_get_block_info_eval(){
 
     for i in 0..contracts.len() {
         let mut owned_env = OwnedEnvironment::memory();
-        // start an initial transaction.
-        owned_env.begin();
         let contract_identifier = QualifiedContractIdentifier::local("test-contract").unwrap();
         owned_env.initialize_contract(contract_identifier, contracts[i]).unwrap();
 
@@ -621,7 +619,6 @@ fn test_at_unknown_block() {
         let contract = "(define-data-var foo int 3)
                         (at-block 0x0202020202020202020202020202020202020202020202020202020202020202
                           (+ 1 2))";
-        owned_env.begin();
         let err = owned_env.initialize_contract(QualifiedContractIdentifier::local("contract").unwrap(), &contract).unwrap_err();
         eprintln!("{}", err);
         match err {
@@ -631,7 +628,7 @@ fn test_at_unknown_block() {
         }
     }
 
-    with_marfed_environment(test, false);
+    with_marfed_environment(test, true);
 }
 
 #[test]

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -42,9 +42,7 @@ fn test_at_block_good() {
                  (ok (var-get datum))))";
 
         eprintln!("Initializing contract...");
-        owned_env.begin();
         owned_env.initialize_contract(c.clone(), &contract).unwrap();
-        owned_env.commit().unwrap();
     }
 
 
@@ -100,9 +98,7 @@ fn test_at_block_missing_defines() {
                  (ok current)))";
 
         eprintln!("Initializing contract...");
-        owned_env.begin();
         owned_env.initialize_contract(c_a.clone(), &contract).unwrap();
-        owned_env.commit().unwrap();
     }
 
     fn initialize_2(owned_env: &mut OwnedEnvironment) -> Error {
@@ -117,9 +113,7 @@ fn test_at_block_missing_defines() {
             ";
 
         eprintln!("Initializing contract...");
-        owned_env.begin();
         let e = owned_env.initialize_contract(c_b.clone(), &contract).unwrap_err();
-        owned_env.commit().unwrap();
         e
     }
 
@@ -135,9 +129,7 @@ fn test_at_block_missing_defines() {
             ";
 
         eprintln!("Initializing contract...");
-        owned_env.begin();
         let e = owned_env.initialize_contract(c_b.clone(), &contract).unwrap_err();
-        owned_env.commit().unwrap();
         e
     }
 
@@ -254,11 +246,9 @@ fn initialize_contract(owned_env: &mut OwnedEnvironment) {
          (ft-mint! stackaroos 10 {})", p1_str);
 
     eprintln!("Initializing contract...");
-    owned_env.begin();
 
     let contract_identifier = QualifiedContractIdentifier::new(p1_address, "tokens".into());
     owned_env.initialize_contract(contract_identifier, &contract).unwrap();
-    owned_env.commit().unwrap();
 }
 
 fn branched_execution(owned_env: &mut OwnedEnvironment, expect_success: bool) {


### PR DESCRIPTION
Provide a high-level interface for interacting with Clarity:


`vm::clarity::ClarityInstance`:

This struct owns a MARF connection. To begin interacting with the Clarity VM, you call `begin_block` on this struct, which begins a new block, and returns a `ClarityBlockConnection`

`vm::clarity::ClarityBlockConnection`:

This struct is used for interactions within a single block and must be either committed or rolled back before any other block can be started from the parent `ClarityInstance`. It exposes:

* analyze_smart_contract
* initialize_smart_contract
* save_analysis
* run_contract_call

And:

* rollback_block
* commit_block

Both of which consume the instance.