### PR TITLE
Eval command should be expecting contract-id

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ jobs:
             blockstack-core local execute db S1G2081040G2081040G2081040G208105NK8PE5.tokens mint! SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 100000
       - run:
           command: |
-            echo "(get-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)" | blockstack-core local eval tokens db
+            echo "(get-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)" | blockstack-core local eval S1G2081040G2081040G2081040G208105NK8PE5.tokens db
   cargo_tests:
     machine: true
     working_directory: ~/blockstack

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -247,7 +247,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
         },
         "eval" => {
             if args.len() < 3 {
-                eprintln!("Usage: {} {} [context-contract-name] (program.clar) [vm-state.db]", invoked_by, args[0]);
+                eprintln!("Usage: {} {} [contract-identifier] (program.clar) [vm-state.db]", invoked_by, args[0]);
                 panic_test!();
             }
 
@@ -292,7 +292,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
         },
         "launch" => {
             if args.len() < 4 {
-                eprintln!("Usage: {} {} [contract-name] [contract-definition.clar] [vm-state.db]", invoked_by, args[0]);
+                eprintln!("Usage: {} {} [contract-identifier] [contract-definition.clar] [vm-state.db]", invoked_by, args[0]);
                 panic_test!();
             }
             let vm_filename = &args[3];

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -273,9 +273,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                 }
             };
 
-            let contract_name = &args[1];
-            let contract_identifier = friendly_expect(QualifiedContractIdentifier::local(contract_name), 
-                                                      "Failed to get contract name");
+            let contract_identifier = friendly_expect(QualifiedContractIdentifier::parse(&args[1]), "Failed to parse contract identifier.");
 
             let mut vm_env = OwnedEnvironment::new(db);
             


### PR DESCRIPTION
This PR is addressing an issue raised by @moxiegirl, where the eval command is expecting a contract-name instead of a contract-id.