### PR TITLE
Set low cache-control policy for v1/info

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -147,13 +147,15 @@ CACHE_SPECIFIC = [ re.compile(regex) for regex in
                    [r'^/v1/node/ping/?$',
                     r'^/v1/accounts/[\w\.]+/history/?$',
                     r'^/v1/blockchains/bitcoin/consensus/?$',
+                    r'^/v1/info/?$',
                     r'^/v1/names/[\w\.]+/?$'] ]
 
 SPECIFIED = {
     0 : 'public, max-age=30',
     1 : 'public, max-age=60',
     2 : 'public, max-age=30',
-    3 : 'public, max-age=300' }
+    3 : 'public, max-age=30',
+    4 : 'public, max-age=300' }
 
 
 @app.route('/<path:path>', methods=['GET'])


### PR DESCRIPTION
This changes the cache-control setting for `/v1/info` from the default (which I think is 1800) to 30 seconds (in line with the consensus hash).

You can test this by starting up the API service (`./api/server.py`) with blockstack-core, and curling `/v1/info`