### PR TITLE
Hotfix/faster name update

### DIFF
--- a/blockstack/lib/nameset/namedb.py
+++ b/blockstack/lib/nameset/namedb.py
@@ -1227,7 +1227,7 @@ class BlockstackDB(virtualchain.StateEngine):
         from re-sending the same preorder with the same preorder hash).
         """
         # name registered and not expired?
-        name_rec = self.get_name( name )
+        name_rec = self.get_name( name, include_history=False)
         if name_rec is not None and not include_failed:
             return None
 
@@ -1276,7 +1276,7 @@ class BlockstackDB(virtualchain.StateEngine):
         Return the string on success
         Return None if the name doesn't exist.
         """
-        name_rec = self.get_name( name )
+        name_rec = self.get_name( name, include_history=False )
         if name_rec is None:
             return None
 
@@ -1446,7 +1446,7 @@ class BlockstackDB(virtualchain.StateEngine):
         Given the fully-qualified name, is it registered, not revoked, and not expired
         at the current block?
         """
-        name_rec = self.get_name( name )    # won't return the name if expired
+        name_rec = self.get_name( name, include_history=False )    # won't return the name if expired
         if name_rec is None:
             return False 
 
@@ -1543,7 +1543,7 @@ class BlockstackDB(virtualchain.StateEngine):
         """
         Determine if a name is revoked at this block.
         """
-        name = self.get_name( name )
+        name = self.get_name( name, include_history=False )
         if name is None:
             return False 
 

--- a/blockstack/lib/operations/update.py
+++ b/blockstack/lib/operations/update.py
@@ -124,7 +124,7 @@ def check(state_engine, nameop, block_id, checked_ops ):
         log.error("FATAL: no such namespace {}".format(namespace_id))
         os.abort()
 
-    if namespace['lifetime'] != NAMESPACE_LIFETIME_INFINITE:
+    if namespace['lifetime'] != NAMESPACE_LIFE_INFINITE:
         # name must not be expired as of the *last block processed*
         if state_engine.is_name_expired( name, state_engine.lastblock ):
             log.warning("Name '%s' is expired" % name)

--- a/blockstack/version.py
+++ b/blockstack/version.py
@@ -2,4 +2,4 @@
 __version_major__ = '21'
 __version_minor__ = '0'
 __version_patch__ = '0'
-__version__ = '{}.{}.{}.3'.format(__version_major__, __version_minor__, __version_patch__)
+__version__ = '{}.{}.{}.4'.format(__version_major__, __version_minor__, __version_patch__)


### PR DESCRIPTION
This small fix makes processing `NAME_UPDATE` transactions a _lot_ faster by removing unnecessary database queries that, on deeper inspection, are _O(n)_ time complexity for _n_ name operations (e.g. querying the name's history).  This is particularly relevant to processing updates on `id.blockstack` and other names used mainly for registering off-chain usernames.