### PR TITLE
Check exact argument length in defined functions

### DIFF
--- a/src/vm/callables.rs
+++ b/src/vm/callables.rs
@@ -55,6 +55,10 @@ impl DefinedFunction {
 
     pub fn execute_apply(&self, args: &[Value], env: &mut Environment) -> Result<Value> {
         let mut context = LocalContext::new();
+        if args.len() != self.arguments.len() {
+            Err(CheckErrors::IncorrectArgumentCount(self.arguments.len(), args.len()))?
+        }
+
         let arg_iterator = self.arguments.iter().zip(self.arg_types.iter()).zip(args.iter());
         for ((arg, type_sig), value) in arg_iterator {
             if !type_sig.admits(value) {

--- a/src/vm/tests/defines.rs
+++ b/src/vm/tests/defines.rs
@@ -18,6 +18,13 @@ fn test_defines() {
     assert_eq!(Ok(Some(Value::Int(29))), execute(&tests));
 
     let tests =
+        "(define-private (f (a int) (b int)) (+ a b))
+         (f 3 1 4)";
+
+    assert_eq!(execute(&tests).unwrap_err(),
+               CheckErrors::IncorrectArgumentCount(2, 3).into());
+
+    let tests =
         "1";
 
     assert_eq!(Ok(Some(Value::Int(1))), execute(&tests));


### PR DESCRIPTION
This patch ensures that the interpreter will throw a CheckedError when a defined function is passed a non-exact argument match. Previously, it allowed extra arguments (which would go unused) to be supplied.
