### PR TITLE
More compact Clarity value serialization

### DIFF
--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -58,6 +58,31 @@ macro_rules! define_named_enum {
     }
 }
 
+/// Define a "u8" enum
+///  gives you a try_from(u8) -> Option<Self> function
+macro_rules! define_u8_enum {
+    ($Name:ident { $($Variant:ident,)* }) =>
+    {
+        #[derive(PartialEq)]
+        #[repr(u8)]
+        enum $Name {
+            $($Variant),*,
+        }
+        impl $Name {
+            pub const ALL: &'static [$Name] = &[$($Name::$Variant),*];
+
+            pub fn from_u8(v: u8) -> Option<Self> {
+                match v {
+                    $(
+                        v if v == $Name::$Variant as u8 => Some($Name::$Variant),
+                    )*
+                    _ => None
+                }
+            }
+        }
+    }
+}
+
 /// Borrowed from Andrew Poelstra's rust-bitcoin
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {

--- a/src/vm/analysis/errors.rs
+++ b/src/vm/analysis/errors.rs
@@ -164,10 +164,16 @@ impl CheckError {
     }
 }
 
+impl fmt::Display for CheckErrors {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl fmt::Display for CheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.err {
-            _ =>  write!(f, "{:?}", self.err)
+            _ =>  write!(f, "{}", self.err)
         }?;
 
         if let Some(ref e) = self.expressions {
@@ -180,9 +186,13 @@ impl fmt::Display for CheckError {
 
 impl error::Error for CheckError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self.err {
-            _ => None
-        }
+        None
+    }
+}
+
+impl error::Error for CheckErrors {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
     }
 }
 

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -16,7 +16,7 @@ pub struct IncomparableError<T> {
     pub err: T
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
 /// UncheckedErrors are errors that *should* be caught by the
 ///   TypeChecker and other check passes. Test executions may
@@ -88,6 +88,18 @@ pub type InterpreterResult <R> = Result<R, Error>;
 impl <T> PartialEq<IncomparableError<T>> for IncomparableError<T> {
     fn eq(&self, _other: &IncomparableError<T>) -> bool {
         return false
+    }
+}
+
+impl PartialEq<Error> for Error {
+    fn eq(&self, other: &Error) -> bool {
+        match (self, other) {
+            (Error::Runtime(x, _), Error::Runtime(y, _)) => x == y,
+            (Error::Unchecked(x), Error::Unchecked(y)) => x == y,
+            (Error::ShortReturn(x), Error::ShortReturn(y)) => x == y,
+            (Error::Interpreter(x), Error::Interpreter(y)) => x == y,
+            _ => false
+        }
     }
 }
 

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -41,9 +41,11 @@ pub enum InterpreterError {
     FailedToCreateDataDirectory,
     MarfFailure(IncomparableError<MarfError>),
     DeserializeExpected(TypeSignature),
-    DeserializeUnexpectedTypeField(String),
+    DeserializationFailure(String),
+    DeserializedBadType(CheckErrors),
+    IOError(IncomparableError<std::io::Error>),
     FailureConstructingTupleWithType,
-    FailureConstructingListWithType
+    FailureConstructingListWithType,
 }
 
 

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -16,7 +16,7 @@ pub struct IncomparableError<T> {
     pub err: T
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
 /// UncheckedErrors are errors that *should* be caught by the
 ///   TypeChecker and other check passes. Test executions may
@@ -40,10 +40,6 @@ pub enum InterpreterError {
     BadFileName,
     FailedToCreateDataDirectory,
     MarfFailure(IncomparableError<MarfError>),
-    DeserializeExpected(TypeSignature),
-    DeserializationFailure(String),
-    DeserializedBadType(CheckErrors),
-    IOError(IncomparableError<std::io::Error>),
     FailureConstructingTupleWithType,
     FailureConstructingListWithType,
 }
@@ -92,18 +88,6 @@ pub type InterpreterResult <R> = Result<R, Error>;
 impl <T> PartialEq<IncomparableError<T>> for IncomparableError<T> {
     fn eq(&self, _other: &IncomparableError<T>) -> bool {
         return false
-    }
-}
-
-impl PartialEq<Error> for Error {
-    fn eq(&self, other: &Error) -> bool {
-        match (self, other) {
-            (Error::Runtime(x, _), Error::Runtime(y, _)) => x == y,
-            (Error::Unchecked(x), Error::Unchecked(y)) => x == y,
-            (Error::ShortReturn(x), Error::ShortReturn(y)) => x == y,
-            (Error::Interpreter(x), Error::Interpreter(y)) => x == y,
-            _ => false
-        }
     }
 }
 

--- a/src/vm/representations.rs
+++ b/src/vm/representations.rs
@@ -29,6 +29,12 @@ macro_rules! guarded_string {
             }
         }
 
+        impl $Name {
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
         impl Deref for $Name {
             type Target = str;
             fn deref(&self) -> &Self::Target {
@@ -38,7 +44,7 @@ macro_rules! guarded_string {
 
         impl Borrow<str> for $Name {
             fn borrow(&self) -> &str {
-                &self.0
+                self.as_str()
             }
         }
 

--- a/src/vm/representations.rs
+++ b/src/vm/representations.rs
@@ -33,6 +33,10 @@ macro_rules! guarded_string {
             pub fn as_str(&self) -> &str {
                 &self.0
             }
+
+            pub fn len(&self) -> u8 {
+                u8::try_from(self.as_str().len()).unwrap()
+            }
         }
 
         impl Deref for $Name {

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -251,6 +251,18 @@ impl Value {
     }
 }
 
+impl BuffData {
+    pub fn len(&self) -> BufferLength {
+        self.data.len().try_into().unwrap()
+    }
+}
+
+impl ListData {
+    pub fn len(&self) -> u32 {
+        self.data.len().try_into().unwrap()
+    }
+}
+
 impl fmt::Display for OptionalData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.data {
@@ -343,6 +355,12 @@ impl fmt::Display for PrincipalData {
 impl From<StandardPrincipalData> for Value {
     fn from(principal: StandardPrincipalData) -> Self {
         Value::Principal(PrincipalData::from(principal))
+    }
+}
+
+impl From<QualifiedContractIdentifier> for Value {
+    fn from(principal: QualifiedContractIdentifier) -> Self {
+        Value::Principal(PrincipalData::Contract(principal))
     }
 }
 

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use serde_json::{Value as JSONValue};
 use util::hash::{hex_bytes, to_hex};
 
+use std::{error, fmt};
 use std::io::{Write, Read};
 
 
@@ -26,6 +27,28 @@ pub enum SerializationError {
     BadTypeError(CheckErrors),
     DeserializationError(String),
     DeserializeExpected(TypeSignature),
+}
+
+
+impl std::fmt::Display for SerializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            SerializationError::IOError(e) => write!(f, "Serialization error caused by IO: {}", e.err),
+            SerializationError::BadTypeError(e) => write!(f, "Deserialization error, bad type, caused by: {}", e),
+            SerializationError::DeserializationError(e) => write!(f, "Deserialization error: {}", e),
+            SerializationError::DeserializeExpected(e) => write!(f, "Deserialization expected the type of the input to be: {}", e),
+        }
+    }
+}
+
+impl error::Error for SerializationError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            SerializationError::IOError(e) => Some(&e.err),
+            SerializationError::BadTypeError(e) => Some(e),
+            _ => None
+        }
+    }
 }
 
 impl From<std::io::Error> for SerializationError {

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -1,4 +1,5 @@
-use vm::errors::{RuntimeErrorType, InterpreterResult, InterpreterError, Error as ClarityError, CheckErrors};
+use vm::errors::{RuntimeErrorType, InterpreterResult, InterpreterError, 
+                 IncomparableError, Error as ClarityError, CheckErrors};
 use vm::types::{Value, StandardPrincipalData, OptionalData, PrincipalData, BufferLength,
                 TypeSignature, TupleData, QualifiedContractIdentifier, ResponseData};
 use vm::database::{ClaritySerializable, ClarityDeserializable};
@@ -8,134 +9,56 @@ use std::borrow::Borrow;
 use std::convert::{TryFrom, TryInto};
 use std::collections::HashMap;
 use serde_json::{Value as JSONValue};
-use util::hash;
+use util::hash::{hex_bytes, to_hex};
 
 use std::io::{Write, Read};
 
-const TYPE_I128: &str = "i128";
-const TYPE_U128: &str = "u128";
-const TYPE_BOOL: &str = "bool";
-const TYPE_BUFF: &str = "buff";
-const TYPE_STANDARD_PRINCIPAL: &str = "principal";
-const TYPE_CONTRACT_PRINCIPAL: &str = "contract_principal";
-const TYPE_RESP_OK: &str = "ok";
-const TYPE_RESP_ERR: &str = "err";
-const TYPE_OPT_SOME: &str = "some";
-const TYPE_OPT_NONE: &str = "none";
-const TYPE_TUPLE: &str = "tuple";
-const TYPE_LIST: &str = "list";
+define_u8_enum!(TypePrefix {
+    Int,
+    UInt,
+    Buffer,
+    BoolTrue,
+    BoolFalse,
+    PrincipalStandard,
+    PrincipalContract,
+    ResponseOk,
+    ResponseErr,
+    OptionalNone,
+    OptionalSome,
+    List,
+    Tuple,
+});
 
-enum ContainerTypes { OPT_SOME, RESP_OK, RESP_ERR }
+impl From<&Value> for TypePrefix {
+    fn from(v: &Value) -> TypePrefix {
+        use super::Value::*;
+        use super::PrincipalData::*;
 
-#[derive(Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
-enum JSONParser {
-    None {
-        #[serde(rename="type")]
-        type_n: String },
-    Bool { 
-        #[serde(rename="type")]
-        type_n: String,
-        value: bool },
-    Simple { 
-        #[serde(rename="type")]
-        type_n: String,
-        value: String },
-    Container {
-        #[serde(rename="type")]
-        type_n: String,
-        value: Box<JSONParser> },
-    List {
-        #[serde(rename="type")]
-        type_n: String,
-        entries: Vec<JSONParser> },
-    Tuple {
-        #[serde(rename="type")]
-        type_n: String,
-        entries: HashMap<String, JSONParser> },
-    ContractPrincipal {
-        #[serde(rename="type")]
-        type_n: String,
-        issuer: String,
-        name: String
-    }
-}
-
-macro_rules! make_to_hex {
-    ($f_name:ident, $type:ty, $negation:expr) => {
-        #[allow(unused_comparisons)]
-        pub fn $f_name(mut val: $type) -> String {
-            let mut result = vec![];
-            let mut negated = "";
-            
-            if val < 0 {
-                let (new_negated, new_val) = $negation(val);
-                negated = new_negated;
-                val = new_val;
-            }
-
-            loop {
-                let digit = match (val % 16) as u8 {
-                    x @  0 ..=  9 => b'0' + x,
-                    x @ 10 ..= 15 => b'a' + (x - 10),
-                    _ => panic!("number not in the range 0..15")
-                };
-                result.push(digit.into());
-                val = val / 16;
-                if val == 0 {
-            break
+        match v {
+            Int(_) => TypePrefix::Int,
+            UInt(_) => TypePrefix::UInt,
+            Buffer(_) => TypePrefix::Buffer,
+            Bool(value) => {
+                if *value {
+                    TypePrefix::BoolTrue
+                } else {
+                    TypePrefix::BoolFalse
                 }
-            }
-            result.reverse();
-            format!("{}{}", negated, std::str::from_utf8(&result)
-                    .expect("ERROR: Hex serializer created non-utf8 string."))
+            },
+            Principal(Standard(_)) => TypePrefix::PrincipalStandard,
+            Principal(Contract(_)) => TypePrefix::PrincipalContract,
+            Response(response) => {
+                if response.committed {
+                    TypePrefix::ResponseOk
+                } else {
+                    TypePrefix::ResponseErr
+                }
+            },
+            Optional(OptionalData{ data: None }) => TypePrefix::OptionalNone,
+            Optional(OptionalData{ data: Some(value) }) => TypePrefix::OptionalSome,
+            List(_) => TypePrefix::List,
+            Tuple(_) => TypePrefix::Tuple
         }
-    }
-}
-
-make_to_hex!(i128_to_hex, i128, |x: i128| ("-", -x));
-make_to_hex!(u128_to_hex, u128, |_x: u128| panic!("Negative UINT"));
-
-fn json_simple_object(type_name: &str, val: &str) -> String {
-    format!(
-        r#"{{ "type": "{}", "value": "{}" }}"#,
-        type_name, val)
-}
-
-fn json_recursive_object(type_name: &str, val: &str) -> String {
-    format!(
-        r#"{{ "type": "{}", "value": {} }}"#,
-        type_name, val)
-}
-
-fn type_prefix(v: &Value) -> u8 {
-    use super::Value::*;
-    use super::PrincipalData::*;
-
-    match v {
-        Int(_) => 1,
-        UInt(_) => 2,
-        Buffer(_) => 3,
-        Bool(value) => {
-            if *value {
-                4
-            } else {
-                5
-            }
-        },
-        Principal(Standard(_)) => 6,
-        Principal(Contract(_)) => 7,
-        Response(response) => {
-            if response.committed {
-                8
-            } else {
-                9
-            }
-        },
-        Optional(OptionalData{ data: None }) => 10,
-        Optional(OptionalData{ data: Some(value) }) => 11,
-        List(_) => 12,
-        Tuple(_) => 13,
     }
 }
 
@@ -191,16 +114,20 @@ impl ClarityValueSerializable<$Name> for $Name {
 serialize_guarded_string!(ClarityName);
 serialize_guarded_string!(ContractName);
 
-enum SerializationError {
-    IoError(std::io::Error),
+#[derive(Debug, PartialEq)]
+pub enum SerializationError {
+    IoError(IncomparableError<std::io::Error>),
     BadTypeError(CheckErrors),
     DeserializationError(String),
+    DeserializeExpected(TypeSignature),
 }
 
 impl From<std::io::Error> for SerializationError {
-    fn from(e: std::io::Error) -> Self {
-        // todo:: UnexpectedEOF should become a ParseError.
-        SerializationError::IoError(e)
+    fn from(err: std::io::Error) -> Self {
+        match err.kind() {
+            std::io::ErrorKind::UnexpectedEof => "Unexpected end of byte stream".into(),
+            _ => SerializationError::IoError(IncomparableError { err })
+        }
     }
 }
 
@@ -216,30 +143,57 @@ impl From<CheckErrors> for SerializationError {
     }
 }
 
+macro_rules! check_match {
+    ($item:expr, $Pattern:pat) => {
+        match $item {
+            None => Ok(()),
+            Some($Pattern) => Ok(()),
+            Some(x) => Err(SerializationError::DeserializeExpected(x.clone()))
+        }
+    }
+}
 
 impl Value {
-    fn deserialize_read<R: Read>(r: &mut R) -> Result<Value, SerializationError> {
-         use super::Value::*;
+    fn deserialize_read<R: Read>(r: &mut R, expected_type: Option<&TypeSignature>) -> Result<Value, SerializationError> {
+        use super::Value::*;
         use super::PrincipalData::*;
 
         let mut header = [0];
         r.read_exact(&mut header)?;
-        match header[0] {
-            1 => {
+
+        let prefix = TypePrefix::from_u8(header[0])
+            .ok_or_else(|| "Bad type prefix")?;
+
+        match prefix {
+            TypePrefix::Int => {
+                check_match!(expected_type, TypeSignature::IntType)?;
                 let mut buffer = [0; 16];
                 r.read_exact(&mut buffer)?;
                 Ok(Int(i128::from_be_bytes(buffer)))
             },
-            2 => {
+            TypePrefix::UInt => {
+                check_match!(expected_type, TypeSignature::UIntType)?;
                 let mut buffer = [0; 16];
                 r.read_exact(&mut buffer)?;
                 Ok(UInt(u128::from_be_bytes(buffer)))
             },
-            3 => {
+            TypePrefix::Buffer => {
                 let mut buffer_len = [0; 4];
                 r.read_exact(&mut buffer_len)?;
                 let buffer_len = BufferLength::try_from(
                     u32::from_be_bytes(buffer_len))?;
+
+                if let Some(x) = expected_type {
+                    let passed_test = match x {
+                        TypeSignature::BufferType(expected_len) => {
+                            u32::from(&buffer_len) <= u32::from(expected_len)
+                        },
+                        _ => false
+                    };
+                    if !passed_test {
+                        return Err(SerializationError::DeserializeExpected(x.clone()))
+                    }
+                }
 
                 let mut data = vec![0; u32::from(buffer_len) as usize];
 
@@ -248,51 +202,133 @@ impl Value {
                 // can safely unwrap, because the buffer length was _already_ checked.
                 Ok(Value::buff_from(data).unwrap())
             },
-            4 => Ok(Bool(true)),
-            5 => Ok(Bool(false)),
-            6 => {
+            TypePrefix::BoolTrue => {
+                check_match!(expected_type, TypeSignature::BoolType)?;
+                Ok(Bool(true))
+            },
+            TypePrefix::BoolFalse => {
+                check_match!(expected_type, TypeSignature::BoolType)?;
+                Ok(Bool(false))
+            },
+            TypePrefix::PrincipalStandard => {
+                check_match!(expected_type, TypeSignature::PrincipalType)?;
                 StandardPrincipalData::deserialize_read(r)
                     .map(Value::from)
             },
-            7 => {
+            TypePrefix::PrincipalContract => {
+                check_match!(expected_type, TypeSignature::PrincipalType)?;
                 let issuer = StandardPrincipalData::deserialize_read(r)?;
                 let name = ContractName::deserialize_read(r)?;
                 Ok(Value::from(QualifiedContractIdentifier { issuer, name }))
             },
-            8 | 9 => {
-                let committed = header[0] == 7;
-                let data = Box::new(Value::deserialize_read(r)?);
+            TypePrefix::ResponseOk | TypePrefix::ResponseErr => {
+                let committed = prefix == TypePrefix::ResponseOk;
+
+                let expect_contained_type = match expected_type {
+                    None => None,
+                    Some(x) => {
+                        let contained_type = match (committed, x) {
+                            (true, TypeSignature::ResponseType(types)) => Ok(&types.0),
+                            (false, TypeSignature::ResponseType(types)) => Ok(&types.1),
+                            _ => Err(SerializationError::DeserializeExpected(x.clone()))
+                        }?;
+                        Some(contained_type)
+                    }
+                };
+
+                let data = Box::new(Value::deserialize_read(r, expect_contained_type)?);
                 Ok(Response(ResponseData { committed, data }))
             },
-            10 => Ok(Value::none()),
-            11 => Ok(Value::some(Value::deserialize_read(r)?)),
-            12 => {
+            TypePrefix::OptionalNone => {
+                check_match!(expected_type, TypeSignature::OptionalType(_))?;
+                Ok(Value::none())
+            },
+            TypePrefix::OptionalSome => {
+                let expect_contained_type = match expected_type {
+                    None => None,
+                    Some(x) => {
+                        let contained_type = match x {
+                            TypeSignature::OptionalType(some_type) => Ok(some_type.as_ref()),
+                            _ => Err(SerializationError::DeserializeExpected(x.clone()))
+                        }?;
+                        Some(contained_type)
+                    }
+                };
+
+                Ok(Value::some(Value::deserialize_read(r, expect_contained_type)?))
+            }
+            TypePrefix::List => {
                 let mut len = [0; 4];
                 r.read_exact(&mut len)?;
                 let len = u32::from_be_bytes(len);
+
+                let (list_type, entry_type) = match expected_type {
+                    None => (None, None),
+                    Some(TypeSignature::ListType(list_type)) => {
+                        if len > list_type.get_max_len() {
+                            return Err(SerializationError::DeserializeExpected(
+                                expected_type.unwrap().clone()))
+                        }
+                        (Some(list_type), Some(list_type.get_list_item_type()))
+                    },
+                    Some(x) => return Err(SerializationError::DeserializeExpected(x.clone()))
+                };
+
                 let mut items = Vec::with_capacity(len as usize);
                 for _i in 0..len {
-                    items.push(Value::deserialize_read(r)?);
+                    items.push(Value::deserialize_read(r, entry_type)?);
                 }
-                Value::list_from(items)
-                    .map_err(|_| "Illegal list type".into())
+
+                if let Some(list_type) = list_type {
+                    Value::list_with_type(items, list_type.clone())
+                        .map_err(|_| "Illegal list type".into())
+                } else {
+                    Value::list_from(items)
+                        .map_err(|_| "Illegal list type".into())
+                }
             },
-            13 => {
+            TypePrefix::Tuple => {
                 let mut len = [0; 4];
                 r.read_exact(&mut len)?;
                 let len = u32::from_be_bytes(len);
+
+                let tuple_type = match expected_type {
+                    None => None,
+                    Some(TypeSignature::TupleType(tuple_type)) => {
+                        if len as u64 != tuple_type.len() {
+                            return Err(SerializationError::DeserializeExpected(
+                                expected_type.unwrap().clone()))
+                        }
+                        Some(tuple_type)
+                    },
+                    Some(x) => return Err(SerializationError::DeserializeExpected(x.clone()))
+                };
+
                 let mut items = Vec::with_capacity(len as usize);
                 for _i in 0..len {
                     let key = ClarityName::deserialize_read(r)?;
-                    let value = Value::deserialize_read(r)?;
+
+                    let expected_field_type = match tuple_type {
+                        None => None,
+                        Some(some_tuple) => Some(
+                            some_tuple
+                                .field_type(&key)
+                                .ok_or_else(|| SerializationError::DeserializeExpected(expected_type.unwrap().clone()))?)
+                    };
+
+                    let value = Value::deserialize_read(r, expected_field_type)?;
                     items.push((key, value))
                 }
-                TupleData::from_data(items)
-                    .map_err(|_| "Illegal tuple type".into())
-                    .map(Value::from)
-            },
-            _ => {
-                panic!("Foo")
+
+                if let Some(tuple_type) = tuple_type {
+                    TupleData::from_data_typed(items, tuple_type)
+                        .map_err(|_| "Illegal tuple type".into())
+                        .map(Value::from)
+                } else {
+                    TupleData::from_data(items)
+                        .map_err(|_| "Illegal tuple type".into())
+                        .map(Value::from)
+                }
             }
         }
 
@@ -302,7 +338,7 @@ impl Value {
         use super::Value::*;
         use super::PrincipalData::*;
 
-        w.write_all(&[type_prefix(self)])?;
+        w.write_all(&[TypePrefix::from(self) as u8])?;
         match self {
             Int(value) => w.write_all(&value.to_be_bytes())?,
             UInt(value) => w.write_all(&value.to_be_bytes())?,
@@ -350,77 +386,12 @@ impl Value {
 
 impl ClaritySerializable for Value {
     fn serialize(&self) -> String {
-        use super::Value::*;
-        use super::PrincipalData::*;
-
-        match self {
-            Int(value) => json_simple_object(TYPE_I128, &i128_to_hex(*value)),
-            UInt(value) => json_simple_object(TYPE_U128, &u128_to_hex(*value)),
-            Buffer(value) => json_simple_object(TYPE_BUFF, &hash::bytes_to_hex(&value.data)),
-            Bool(value) => {
-                let str_value = if *value {
-                    "true"
-                } else {
-                    "false"
-                };
-                json_recursive_object(TYPE_BOOL, str_value)
-            },
-            Principal(Standard(data)) => {
-                json_simple_object(TYPE_STANDARD_PRINCIPAL, &data.to_address())
-            },
-            Principal(Contract(contract_identifier)) => {
-                format!(
-                    r#"{{ "type": "{}", "issuer": "{}", "name": "{}" }}"#,
-                    TYPE_CONTRACT_PRINCIPAL, contract_identifier.issuer.to_address(), contract_identifier.name.to_string())
-            },
-            Response(response) => {
-                let type_name = if response.committed {
-                    TYPE_RESP_OK
-                } else {
-                    TYPE_RESP_ERR
-                };
-                let value = response.data.serialize();
-                json_recursive_object(type_name, &value)
-            },
-            Optional(OptionalData{ data: None }) => {
-                format!(r#"{{ "type": "{}" }}"#, TYPE_OPT_NONE)
-            },
-            Optional(OptionalData{ data: Some(value) }) => {
-                json_recursive_object(TYPE_OPT_SOME, &value.serialize()) 
-           },
-            List(data) => {
-                let entries: Vec<String> = data.data
-                    .iter().map(|x| x.serialize())
-                    .collect();
-                let entries_str = entries.join(", ");
-                format!(
-                    r#"{{ "type": "{}", "entries": [ {} ] }}"#,
-                    TYPE_LIST, entries_str)
-            },
-            Tuple(data) => {
-                let entries: Vec<String> = data.data_map
-                    .iter().map(|(key, value)|
-                                format!(r#""{}": {}"#, &**key, value.serialize()))
-                    .collect();
-                let entries_str = entries.join(", ");
-                format!(
-                    r#"{{ "type": "{}", "entries": {{ {} }} }}"#,
-                    TYPE_TUPLE, entries_str)
-            }
-        }
+        let mut byte_serialization = Vec::new();
+        self.serialize_write(&mut byte_serialization)
+            .expect("IOError filling byte buffer.");
+        to_hex(byte_serialization.as_slice())
     }
 }
-
-macro_rules! check_match {
-    ($item:expr, $Pattern:pat) => {
-        match $item {
-            None => Ok(()),
-            Some($Pattern) => Ok(()),
-            Some(x) => Err(InterpreterError::DeserializeExpected(x.clone()))
-        }
-    }
-}
-
 
 impl Value {
     /// This function attempts to deserialize a JSONParser struct into a Clarity Value.
@@ -429,185 +400,39 @@ impl Value {
     ///   have their max-length and other type information set by the type declarations in the contract.
     ///   If passed `None`, the deserializer will construct the values as if they were literals in the contract, e.g.,
     ///     list max length = the length of the list.
-    fn try_deserialize_parsed(json: JSONParser, expected_type: Option<&TypeSignature>) -> InterpreterResult<Value> {
-        match json {
-            JSONParser::Simple { type_n, value } => {
-                match type_n.as_str() {
-                    TYPE_I128 => {
-                        check_match!(expected_type, TypeSignature::IntType)?;
-                        let value = i128::from_str_radix(&value, 16)
-                            .map_err(|_| RuntimeErrorType::ParseError("Failed to parse hexstring as integer".into()))?;
-                        Ok(Value::Int(value))
-                    },
-                    TYPE_U128 => {
-                        check_match!(expected_type, TypeSignature::UIntType)?;
-                        let value = u128::from_str_radix(&value, 16)
-                            .map_err(|_| RuntimeErrorType::ParseError("Failed to parse hexstring as integer".into()))?;
-                        Ok(Value::UInt(value))
-                    },
-                    TYPE_STANDARD_PRINCIPAL => {
-                        check_match!(expected_type, TypeSignature::PrincipalType)?;
-                        PrincipalData::parse_standard_principal(&value)
-                            .map(|principal| Value::from(principal))
-                    },
-                    TYPE_BUFF => {
-                        let bytes = hash::hex_bytes(&value)
-                            .map_err(|_| RuntimeErrorType::ParseError("Bad hex string".into()))?;
 
-                        match expected_type {
-                            None => {},
-                            Some(x) => {
-                                let passed_test = match x {
-                                    TypeSignature::BufferType(buff_len) => {
-                                        bytes.len() <= (u32::from(buff_len) as usize)
-                                    },
-                                    _ => false
-                                };
-                                if !passed_test {
-                                    return Err(InterpreterError::DeserializeExpected(x.clone()).into())
-                                }
-                            }
-                        };
-
-                        Value::buff_from(bytes)
-                    },
-                    _ => Err(InterpreterError::DeserializeUnexpectedTypeField(type_n).into())
-                }
-            },
-            JSONParser::Bool { type_n, value } => {
-                check_match!(expected_type, TypeSignature::BoolType)?;
-
-                if type_n == TYPE_BOOL {
-                    Ok(Value::Bool(value))
-                } else {
-                    Err(InterpreterError::DeserializeUnexpectedTypeField(type_n).into())
-                }
-            },
-            JSONParser::None { type_n } => {
-                check_match!(expected_type, TypeSignature::OptionalType(_))?;
-                if type_n == TYPE_OPT_NONE {
-                    Ok(Value::none())
-                } else {
-                    Err(InterpreterError::DeserializeUnexpectedTypeField(type_n).into())
-                }
-            },
-            JSONParser::Container { type_n, value } => {
-                let outer_type = match type_n.as_str() {
-                    TYPE_RESP_OK => Ok(ContainerTypes::RESP_OK),
-                    TYPE_RESP_ERR => Ok(ContainerTypes::RESP_ERR),
-                    TYPE_OPT_SOME => Ok(ContainerTypes::OPT_SOME),
-                    _ => Err(InterpreterError::DeserializeUnexpectedTypeField(type_n))
-                }?;
-
-                let expect_contained_type = match expected_type {
-                    None => None,
-                    Some(x) => {
-                        let contained_type = match (&outer_type, x) {
-                            (ContainerTypes::RESP_OK,  TypeSignature::ResponseType(types)) => Ok(&types.0),
-                            (ContainerTypes::RESP_ERR, TypeSignature::ResponseType(types)) => Ok(&types.1),
-                            (ContainerTypes::OPT_SOME, TypeSignature::OptionalType(some_type)) => Ok(some_type.as_ref()),
-                            _ => Err(InterpreterError::DeserializeExpected(x.clone()))
-                        }?;
-                        Some(contained_type)
-                    }
-                };
-
-                let deserialized_value = Value::try_deserialize_parsed(*value, expect_contained_type)?;
-                match outer_type {
-                    ContainerTypes::RESP_OK => Ok(Value::okay(deserialized_value)),
-                    ContainerTypes::RESP_ERR => Ok(Value::error(deserialized_value)),
-                    ContainerTypes::OPT_SOME => Ok(Value::some(deserialized_value))
-                }
-            },
-            JSONParser::List { type_n, mut entries } => {
-                if type_n != TYPE_LIST {
-                    return Err(InterpreterError::DeserializeUnexpectedTypeField(type_n).into())
-                }
-
-                let (list_type, entry_type) = match expected_type {
-                    None => (None, None),
-                    Some(TypeSignature::ListType(list_type)) => (Some(list_type), Some(list_type.get_list_item_type())),
-                    Some(x) => return Err(InterpreterError::DeserializeExpected(x.clone()).into())
-                };
-
-                let items: InterpreterResult<_> = entries
-                    .drain(..)
-                    .map(|value| Value::try_deserialize_parsed(value, entry_type))
-                    .collect();
-
-                if let Some(list_type) = list_type {
-                    Value::list_with_type(items?, list_type.clone())
-                } else {
-                    Value::list_from(items?)
-                }
-            },
-            JSONParser::Tuple { type_n, mut entries } => {
-                if type_n != TYPE_TUPLE {
-                    return Err(InterpreterError::DeserializeUnexpectedTypeField(type_n).into())
-                }
-                let tuple_type = match expected_type {
-                    None => None,
-                    Some(TypeSignature::TupleType(tuple_type)) => Some(tuple_type),
-                    Some(x) => return Err(InterpreterError::DeserializeExpected(x.clone()).into())
-                };
-
-                let deserialized_entries: InterpreterResult<_> = entries
-                    .drain()
-                    .map(|(key, json_val)| {
-                        let expected_field_type = match tuple_type {
-                            None => None,
-                            Some(some_tuple) => Some(
-                                some_tuple
-                                    .field_type(&key)
-                                    .ok_or_else(|| RuntimeErrorType::ParseError(
-                                        format!("Expected tuple type does not contain field '{}' but JSON does.", key)))?)
-                        };
-                        Ok((ClarityName::try_from(key)?, Value::try_deserialize_parsed(json_val, expected_field_type)?))
-                    })
-                    .collect();
-                if let Some(tuple_type) = tuple_type {
-                    TupleData::from_data_typed(deserialized_entries?, tuple_type)
-                        .map(Value::from)
-                } else {
-                    TupleData::from_data(deserialized_entries?)
-                        .map(Value::from)
-                }
-            },
-            JSONParser::ContractPrincipal { type_n, issuer, name } => {
-                if type_n != TYPE_CONTRACT_PRINCIPAL {
-                    return Err(InterpreterError::DeserializeUnexpectedTypeField(type_n).into())
-                }
-                check_match!(expected_type, TypeSignature::PrincipalType)?;
-                let name = name.try_into()?;
-                let issuer = PrincipalData::parse_standard_principal(&issuer)?;
-                let contract_identifier = QualifiedContractIdentifier::new(issuer, name);
-
-                Ok(Value::from(PrincipalData::Contract(contract_identifier)))
-            }
-        }
+    pub fn try_deserialize_hex(hex: &str, expected: &TypeSignature) -> Result<Value, SerializationError> {
+        let data = hex_bytes(hex)
+            .map_err(|_| "Bad hex string")?;
+        Value::deserialize_read(&mut data.as_slice(), Some(expected))
+            .map_err(|e| match e {
+                SerializationError::IoError(e) => panic!("Should not have received IO Error: {:?}", e),
+                _ => e
+            })
     }
 
-    pub fn try_deserialize(json: &str, expected: &TypeSignature) -> InterpreterResult<Value> {
-        let data: JSONParser = serde_json::from_str(json)?;
-        Value::try_deserialize_parsed(data, Some(expected))
-    }
-
-    pub fn try_deserialize_untyped(json: &str) -> InterpreterResult<Value> {
-        let data: JSONParser = serde_json::from_str(json)?;
-        Value::try_deserialize_parsed(data, None)
+    pub fn try_deserialize_hex_untyped(hex: &str) -> Result<Value, SerializationError> {
+        let data = hex_bytes(hex)
+            .map_err(|_| "Bad hex string")?;
+        Value::deserialize_read(&mut data.as_slice(), None)
+            .map_err(|e| match e {
+                SerializationError::IoError(e) => panic!("Should not have received IO Error: {:?}", e),
+                _ => e
+            })
     }
 }
 
 impl Value {
     pub fn deserialize(json: &str, expected: &TypeSignature) -> Self {
-        Value::try_deserialize(json, expected)
-            .expect("ERROR: Failed to parse Clarity JSON")
+        Value::try_deserialize_hex(json, expected)
+            .expect("ERROR: Failed to parse Clarity hex string")
     }
 }
 
 
 #[cfg(test)]
 mod tests {
+    use super::SerializationError;
     use vm::database::ClaritySerializable;
     use vm::errors::Error;
     use super::super::*;
@@ -617,403 +442,117 @@ mod tests {
         TypeSignature::BufferType(size.try_into().unwrap()).into()
     }
 
+
+    fn test_deser_ser(v: Value) {
+        assert_eq!(&v, &Value::deserialize(&v.serialize(), &TypeSignature::type_of(&v)));
+        assert_eq!(&v, &Value::try_deserialize_hex_untyped(&v.serialize())
+                   .unwrap());
+    }
+
+    fn test_bad_expectation(v: Value, e: TypeSignature) {
+        assert!(
+            match Value::try_deserialize_hex(&v.serialize(), &e).unwrap_err() {
+                SerializationError::DeserializeExpected(_) => true,
+                _ => false
+            })
+    }
+
     #[test]
     fn test_lists() {
-        let serialized_0 = r#"
-            { "type": "list",
-              "entries": [ { "type": "list", "entries": [ { "type": "i128", "value": "1" }, 
-                                                          { "type": "i128", "value": "2" }, 
-                                                          { "type": "i128", "value": "3" } ] },
-                           { "type": "list", "entries": [ { "type": "i128", "value": "1" }, 
-                                                          { "type": "i128", "value": "2" }, 
-                                                          { "type": "i128", "value": "3" } ] } ] }"#;
-
-        let serialized_1 = r#"
-            { "type": "list",
-              "entries": [ { "type": "list", "entries": [ { "type": "i128", "value": "1" }, 
-                                                          { "type": "i128", "value": "3" } ] },
-                           { "type": "list", "entries": [ { "type": "i128", "value": "1" }, 
-                                                          { "type": "i128", "value": "3" } ] },
-                           { "type": "list", "entries": [ { "type": "i128", "value": "1" }, 
-                                                          { "type": "i128", "value": "3" } ] } ] }"#;
+       
+        let list_list_int = Value::list_from(vec![
+            Value::list_from(vec![Value::Int(1), Value::Int(2), Value::Int(3)]).unwrap()
+        ]).unwrap();
 
         // Should be legal!
-        Value::try_deserialize(
-            serialized_0, &TypeSignature::from("(list 2 (list 3 int))")).unwrap();
-        Value::try_deserialize(
-            serialized_0, &TypeSignature::from("(list 3 (list 4 int))")).unwrap();
+        Value::try_deserialize_hex(
+            &Value::list_from(vec![]).unwrap().serialize(),
+            &TypeSignature::from("(list 2 (list 3 int))")).unwrap();
+        Value::try_deserialize_hex(
+            &list_list_int.serialize(),
+            &TypeSignature::from("(list 2 (list 3 int))")).unwrap();
+        Value::try_deserialize_hex(
+            &list_list_int.serialize(),
+            &TypeSignature::from("(list 1 (list 4 int))")).unwrap();
 
-        assert_eq!(
-            Value::try_deserialize(
-                serialized_0, &TypeSignature::from("(list 2 (list 3 int))")).unwrap(),
-            Value::try_deserialize_untyped(serialized_0).unwrap());
-
-        // Fail because the atomic type isn't correct
-        //  leads to an unexpected attempt to deserialize an int as bool.
-        assert_eq!(Value::try_deserialize(
-            serialized_0, &TypeSignature::from("(list 2 (list 3 bool))")).unwrap_err(),
-                   InterpreterError::DeserializeExpected(
-                       TypeSignature::BoolType).into());
-        
-        // Fail because the max_len isn't enough for the sublists
-        assert_eq!(Value::try_deserialize(
-            serialized_0, &TypeSignature::from("(list 2 (list 2 int))")).unwrap_err(),
-                   InterpreterError::FailureConstructingListWithType.into());
-        
-        // Fail because the max_len isn't enough for the outer-list
-        assert_eq!(Value::try_deserialize(
-            serialized_0, &TypeSignature::from("(list 1 (list 3 int))")).unwrap_err(),
-                   InterpreterError::FailureConstructingListWithType.into());
-        
-        // Fail because dimension is bad
-        //  leads to an unexpected attempt to deserialize an int as list.
-        assert!(match Value::try_deserialize(
-            serialized_1, &TypeSignature::from("(list 3 (list 3 (list 3 int)))")).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-        
-        // Fail because we look like a list but the "TYPE" field is wrong
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "listtt", "entries": []}"#,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize_untyped(
-            r#"{ "type": "listtt", "entries": []}"#).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        // Fail because we look like a list but the expected type is not a list
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "list", "entries": []}"#,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
+        test_deser_ser(list_list_int.clone());
+        test_deser_ser(Value::list_from(vec![]).unwrap());
+        test_bad_expectation(list_list_int.clone(), TypeSignature::BoolType);
+        // inner type isn't expected
+        test_bad_expectation(list_list_int.clone(), TypeSignature::from("(list 1 (list 4 uint))"));
+        // child list longer than expected
+        test_bad_expectation(list_list_int.clone(), TypeSignature::from("(list 1 (list 2 uint))"));
+        // parent list longer than expected
+        test_bad_expectation(list_list_int.clone(), TypeSignature::from("(list 0 (list 2 uint))"));
     }
 
     #[test]
     fn test_bools() {
-        assert_eq!(Value::Bool(false).serialize(), r#"{ "type": "bool", "value": false }"#);
-        assert_eq!(Value::Bool(true).serialize(), r#"{ "type": "bool", "value": true }"#);
+        test_deser_ser(Value::Bool(false));
+        test_deser_ser(Value::Bool(true));
 
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "bol", "value": false}"#,
-            &TypeSignature::BoolType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize_untyped(
-            r#"{ "type": "bol", "value": false}"#).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "bool", "value": false}"#,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert_eq!(
-            Value::try_deserialize(
-                r#"{ "type": "bool", "value": false}"#,
-                &TypeSignature::BoolType).unwrap(),
-            Value::try_deserialize_untyped(
-                r#"{ "type": "bool", "value": false}"#).unwrap());
+        test_bad_expectation(Value::Bool(false), TypeSignature::IntType);
+        test_bad_expectation(Value::Bool(true), TypeSignature::IntType);
     }
 
     #[test]
     fn test_ints() {
-        assert_eq!(Value::Int(-1).serialize(), r#"{ "type": "i128", "value": "-1" }"#);
-        assert_eq!(Value::Int(15).serialize(), r#"{ "type": "i128", "value": "f" }"#);
+        test_deser_ser(Value::Int(0));
+        test_deser_ser(Value::Int(1));
+        test_deser_ser(Value::Int(-1));
+        test_deser_ser(Value::Int(i128::max_value()));
+        test_deser_ser(Value::Int(i128::min_value()));
 
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "i125", "value": "-f"}"#,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize_untyped(
-            r#"{ "type": "i125", "value": "-f"}"#).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "i128", "value": "-f"}"#,
-            &TypeSignature::BoolType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "i128", "value": "-xf"}"#,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize_untyped(
-            r#"{ "type": "i128", "value": "-xf"}"#).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-            _ => false
-        });
-
-        assert_eq!(
-            Value::try_deserialize(
-                r#"{ "type": "i128", "value": "-1"}"#,
-                &TypeSignature::IntType).unwrap(),
-            Value::Int(-1));
-        assert_eq!(
-            Value::try_deserialize_untyped(
-                r#"{ "type": "i128", "value": "-1"}"#).unwrap(),
-            Value::Int(-1));
+        test_bad_expectation(Value::Int(1), TypeSignature::UIntType);
     }
 
     #[test]
     fn test_uints() {
-        assert_eq!(Value::UInt(1).serialize(), r#"{ "type": "u128", "value": "1" }"#);
-        assert_eq!(Value::UInt(15).serialize(), r#"{ "type": "u128", "value": "f" }"#);
+        test_deser_ser(Value::UInt(0));
+        test_deser_ser(Value::UInt(1));
+        test_deser_ser(Value::UInt(u128::max_value()));
+        test_deser_ser(Value::UInt(u128::min_value()));
 
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "u128", "value": "-f"}"#,
-            &TypeSignature::BoolType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "u128", "value": "-f"}"#,
-            &TypeSignature::UIntType).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "u128", "value": "xf"}"#,
-            &TypeSignature::UIntType).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-            _ => false
-        });
-
-        assert_eq!(
-            Value::try_deserialize(
-                r#"{ "type": "u128", "value": "1"}"#,
-                &TypeSignature::UIntType).unwrap(),
-            Value::UInt(1));
-        assert_eq!(
-            Value::try_deserialize_untyped(
-                r#"{ "type": "u128", "value": "1"}"#).unwrap(),
-            Value::UInt(1));
+        test_bad_expectation(Value::UInt(1), TypeSignature::IntType);
     }
 
     #[test]
     fn test_opts() {
-        let none =  r#"{ "type": "none" }"#;
-        let some_int = r#"{ "type": "some", "value": { "type": "i128", "value": "f" } }"#;
+        test_deser_ser(Value::none());
+        test_deser_ser(Value::some(Value::Int(15)));
 
-        assert_eq!(Value::some(Value::Int(15)).serialize(), some_int);
-        assert_eq!(Value::none().serialize(), none);
-
-        assert!(match Value::try_deserialize(
-            none,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            some_int,
-            &IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            some_int,
-            &TypeSignature::from("(list 2 int)")).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "s0me", "value": { "type": "i128", "value": "f" } }"#,
-            &TypeSignature::new_option(TypeSignature::IntType)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize_untyped(
-            r#"{ "type": "s0me", "value": { "type": "i128", "value": "f" } }"#).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize_untyped(
-            r#"{ "type": "n0ne" }"#).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "n0ne" }"#,
-            &TypeSignature::new_option(TypeSignature::IntType)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-            _ => false
-        });
-
-        // Bad expected _contained_ type
-        assert!(match Value::try_deserialize(
-            some_int,
-            &TypeSignature::new_option(TypeSignature::BoolType)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(x)) => x == TypeSignature::BoolType,
-            _ => false
-        });
-
-        assert_eq!(
-            Value::try_deserialize(
-                some_int,
-                &TypeSignature::new_option(TypeSignature::IntType)).unwrap(),
-            Value::some(Value::Int(15)));
-        assert_eq!(
-            Value::try_deserialize(
-                none,
-                &TypeSignature::new_option(TypeSignature::IntType)).unwrap(),
-            Value::none());
-        assert_eq!(
-            Value::try_deserialize(
-                some_int,
-                &TypeSignature::new_option(TypeSignature::IntType)).unwrap(),
-            Value::some(Value::Int(15)));
-        assert_eq!(
-            Value::try_deserialize_untyped(some_int).unwrap(),
-            Value::some(Value::Int(15)));
-        assert_eq!(
-            Value::try_deserialize_untyped(none).unwrap(),
-            Value::none());
-
+        test_bad_expectation(Value::none(), TypeSignature::IntType);
+        test_bad_expectation(Value::some(Value::Int(15)), TypeSignature::IntType);
+        // bad expected _contained_ type
+        test_bad_expectation(Value::some(Value::Int(15)), TypeSignature::from("(optional uint)"));
     }
 
     #[test]
     fn test_resp() {
-        let ok_int =  r#"{ "type": "ok", "value": { "type": "i128", "value": "f" } }"#;
-        let err_int = r#"{ "type": "err", "value": { "type": "i128", "value": "f" } }"#;
-
-        assert_eq!(Value::okay(Value::Int(15)).serialize(), ok_int);
-        assert_eq!(Value::error(Value::Int(15)).serialize(), err_int);
+        test_deser_ser(Value::okay(Value::Int(15)));
+        test_deser_ser(Value::error(Value::Int(15)));
 
         // Bad expected types.
-
-        assert!(match Value::try_deserialize(
-            err_int,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            ok_int,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-            _ => false
-        });
-
-        // Bad expected _contained_ type.
-
-        assert!(match Value::try_deserialize(
-            ok_int,
-            &TypeSignature::new_response(TypeSignature::BoolType, TypeSignature::IntType)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(x)) => x == TypeSignature::BoolType,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            err_int,
-            &TypeSignature::new_response(TypeSignature::IntType, TypeSignature::BoolType)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(x)) => x == TypeSignature::BoolType,
-            _ => false
-        });
-
-        assert_eq!(
-            Value::try_deserialize(
-                ok_int,
-                &TypeSignature::new_response(TypeSignature::IntType, TypeSignature::IntType)).unwrap(),
-            Value::okay(Value::Int(15)));
-        assert_eq!(
-            Value::try_deserialize(
-                err_int,
-                &TypeSignature::new_response(TypeSignature::IntType, TypeSignature::IntType)).unwrap(),
-            Value::error(Value::Int(15)));
-        assert_eq!(
-            Value::try_deserialize_untyped(ok_int).unwrap(),
-            Value::okay(Value::Int(15)));
-        assert_eq!(
-            Value::try_deserialize_untyped(err_int).unwrap(),
-            Value::error(Value::Int(15)));
-
-    }
-
-    #[test]
-    fn test_hex() {
-        use super::{i128_to_hex as to_hex};
-        assert_eq!(&to_hex(-0xdeadbeef), "-deadbeef");
-        assert_eq!(&to_hex(0xdeadbeef), "deadbeef");
-        assert_eq!(&to_hex(0xdeadbdf), "deadbdf");
-        assert_eq!(&to_hex(0xdadbc0ef), "dadbc0ef");
-        assert_eq!(&to_hex(0xf8743000), "f8743000");
-        assert_eq!(&to_hex(-0x00), "0");
+        test_bad_expectation(Value::okay(Value::Int(15)), TypeSignature::IntType);
+        test_bad_expectation(Value::okay(Value::Int(15)), TypeSignature::from("(response uint int)"));
+        test_bad_expectation(Value::error(Value::Int(15)), TypeSignature::from("(response int uint)"));
     }
 
     #[test]
     fn test_buffs() {
-        assert_eq!(Value::buff_from(vec![0,0,0,0]).unwrap().serialize(), 
-                   r#"{ "type": "buff", "value": "00000000" }"#);
-        assert_eq!(Value::buff_from(vec![0xde,0xad,0xbe,0xef]).unwrap().serialize(), 
-                   r#"{ "type": "buff", "value": "deadbeef" }"#);
-        assert_eq!(Value::buff_from(vec![0,0xde,0xad,0xbe,0xef,0]).unwrap().serialize(),
-                   r#"{ "type": "buff", "value": "00deadbeef00" }"#);
-        
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "buff", "value": "00deadbeef00" }"#,
-            &TypeSignature::BoolType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-             _ => false
-        });
+        test_deser_ser(Value::buff_from(vec![0,0,0,0]).unwrap());
+        test_deser_ser(Value::buff_from(vec![0xde,0xad,0xbe,0xef]).unwrap());
+        test_deser_ser(Value::buff_from(vec![0,0xde,0xad,0xbe,0xef,0]).unwrap());
+
+        test_bad_expectation(
+            Value::buff_from(vec![0,0xde,0xad,0xbe,0xef,0]).unwrap(),
+            TypeSignature::BoolType);
 
         // fail because we expect a shorter buffer
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "buff", "value": "00deadbeef00" }"#,
-            &buff_type(4)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-             _ => false
-        });
+        test_bad_expectation(
+            Value::buff_from(vec![0,0xde,0xad,0xbe,0xef,0]).unwrap(),
+            TypeSignature::from("(buff 2)"));
         
-        // fail because its a bad hex-string
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "buff", "value": "00deadbeef0" }"#,
-            &buff_type(6)).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-            _ => false
-        });
-
-        assert_eq!(
-            Value::try_deserialize(
-            r#"{ "type": "buff", "value": "00deadbeef00" }"#,
-            &buff_type(6)).unwrap(),
-            Value::buff_from(vec![0,0xde,0xad,0xbe,0xef,0]).unwrap());
-        assert_eq!(
-            Value::try_deserialize_untyped(
-                r#"{ "type": "buff", "value": "00deadbeef00" }"#).unwrap(),
-            Value::buff_from(vec![0,0xde,0xad,0xbe,0xef,0]).unwrap());
     }
 
     #[test]
@@ -1029,55 +568,45 @@ mod tests {
             ("b".into(), Value::Bool(true))]).unwrap());
         let t_3 = Value::from(TupleData::from_data(vec![
             ("a".into(), Value::Int(1))]).unwrap());
-        assert_eq!(t_0.serialize(), r#"{ "type": "tuple", "entries": { "a": { "type": "i128", "value": "1" }, "b": { "type": "i128", "value": "1" } } }"#);
-        assert_eq!(t_1.serialize(), r#"{ "type": "tuple", "entries": { "a": { "type": "i128", "value": "1" }, "b": { "type": "i128", "value": "1" } } }"#);
-        assert_eq!(t_2.serialize(), r#"{ "type": "tuple", "entries": { "a": { "type": "i128", "value": "1" }, "b": { "type": "bool", "value": true } } }"#);
-        assert_eq!(t_3.serialize(), r#"{ "type": "tuple", "entries": { "a": { "type": "i128", "value": "1" } } }"#);
+        let t_4 = Value::from(TupleData::from_data(vec![
+            ("a".into(), Value::Int(1)),
+            ("c".into(), Value::Bool(true))]).unwrap());
 
-        // JSON struct looks like tuple, but has bad type field.
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "tople", "entries": {} }"#,
+        test_deser_ser(t_0.clone());
+        test_deser_ser(t_1.clone());
+        test_deser_ser(t_2.clone());
+        test_deser_ser(t_3.clone());
+
+        test_bad_expectation(t_0.clone(), TypeSignature::BoolType);
+
+        // t_0 and t_1 are actually the same
+        assert_eq!(
+            Value::try_deserialize_hex(&t_1.serialize(), &TypeSignature::type_of(&t_0)).unwrap(),
+            Value::try_deserialize_hex(&t_0.serialize(), &TypeSignature::type_of(&t_0)).unwrap());
+
+        // field number not equal to expectations
+        assert!(match Value::try_deserialize_hex(
+            &t_3.serialize(),
             &TypeSignature::type_of(&t_1)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
+            SerializationError::DeserializeExpected(_) => true,
              _ => false
         });
 
-        // bad expected type
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "tuple", "entries": { "a": { "type": "i128", "value": "1" } } }"#,
-            &TypeSignature::IntType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
+        // field type mismatch
+        assert!(match Value::try_deserialize_hex(
+            &t_2.serialize(),
+            &TypeSignature::type_of(&t_1)).unwrap_err() {
+            SerializationError::DeserializeExpected(_) => true,
              _ => false
         });
 
-        // non-existent field ("b" is in serialization, but not in expected type)
-        assert!(match Value::try_deserialize(&t_0.serialize(), &TypeSignature::type_of(&t_3)).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_), _) => true,
+        // field not-present in expected
+        assert!(match Value::try_deserialize_hex(
+            &t_1.serialize(),
+            &TypeSignature::type_of(&t_4)).unwrap_err() {
+            SerializationError::DeserializeExpected(_) => true,
              _ => false
         });
-
-        // bad field type ("b" is int in serialization, but bool in expected type)
-        assert!(match Value::try_deserialize(&t_0.serialize(), &TypeSignature::type_of(&t_2)).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(x)) => x == TypeSignature::BoolType,
-             _ => false
-        });
-
-
-        assert_eq!(&t_0, &t_1);
-        assert_eq!(&Value::try_deserialize(&t_0.serialize(), &TypeSignature::type_of(&t_1)).unwrap(), &t_0);
-        assert_eq!(&Value::try_deserialize(&t_0.serialize(), &TypeSignature::type_of(&t_0)).unwrap(), &t_0);
-        assert_eq!(&Value::try_deserialize(&t_1.serialize(), &TypeSignature::type_of(&t_1)).unwrap(), &t_0);
-        assert_eq!(&Value::try_deserialize(&t_1.serialize(), &TypeSignature::type_of(&t_0)).unwrap(), &t_0);
-        assert_eq!(&Value::try_deserialize(&t_2.serialize(), &TypeSignature::type_of(&t_2)).unwrap(), &t_2);
-        assert_eq!(&Value::try_deserialize(&t_3.serialize(), &TypeSignature::type_of(&t_3)).unwrap(), &t_3);
-        assert_eq!(Value::try_deserialize(&t_3.serialize(), &TypeSignature::type_of(&t_3)).unwrap(), 
-                   Value::try_deserialize_untyped(&t_3.serialize()).unwrap());
-        assert_eq!(Value::try_deserialize(&t_2.serialize(), &TypeSignature::type_of(&t_2)).unwrap(), 
-                   Value::try_deserialize_untyped(&t_2.serialize()).unwrap());
-        assert_eq!(Value::try_deserialize(&t_1.serialize(), &TypeSignature::type_of(&t_1)).unwrap(), 
-                   Value::try_deserialize_untyped(&t_1.serialize()).unwrap());
-        assert_eq!(Value::try_deserialize(&t_0.serialize(), &TypeSignature::type_of(&t_0)).unwrap(), 
-                   Value::try_deserialize_untyped(&t_0.serialize()).unwrap());
     }
 
     #[test]
@@ -1088,68 +617,11 @@ mod tests {
         let contract_identifier = QualifiedContractIdentifier::new(issuer, "foo".into());
         let contract_p2 = Value::from(PrincipalData::Contract(contract_identifier));
 
-        assert_eq!(standard_p.serialize(), r#"{ "type": "principal", "value": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G" }"#);
-        assert_eq!(contract_p2.serialize(), r#"{ "type": "contract_principal", "issuer": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G", "name": "foo" }"#);
-        
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "principal", "value": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G" }"#,
-            &TypeSignature::BoolType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-             _ => false
-        });
+        test_deser_ser(contract_p2.clone());
+        test_deser_ser(standard_p.clone());
 
-        // fail because it looks like a contract principal, but has the wrong type field.
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "contract__principal", "issuer": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G", "name": "foo" }"#,
-            &TypeSignature::PrincipalType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeUnexpectedTypeField(_)) => true,
-             _ => false
-        });
-
-        // fail because of expected type mismatch
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "contract_principal", "issuer": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G", "name": "foo" }"#,
-            &TypeSignature::BoolType).unwrap_err() {
-            Error::Interpreter(InterpreterError::DeserializeExpected(_)) => true,
-             _ => false
-        });
-
-        // fail because its a bad address
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "principal", "value": "SM2J6ZY48GV1EZ5V2V5RB9MP63SW86PYKKQVX8X0G" }"#,
-            &TypeSignature::PrincipalType).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-            _ => false
-        });
-
-        assert!(match Value::try_deserialize(
-            r#"{ "type": "contract_principal", "issuer": "SM2J6ZY48GV1EZ5V2V5RB9MP62SW86PYKKQVX8X0G", "name": "foo" }"#,
-            &TypeSignature::PrincipalType).unwrap_err() {
-            Error::Runtime(RuntimeErrorType::ParseError(_),_) => true,
-             _ => false
-        });
-
-        assert_eq!(
-            &(Value::try_deserialize(
-                r#"{ "type": "principal", "value": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G" }"#,
-                &TypeSignature::PrincipalType).unwrap()),
-            &standard_p);
-
-        assert_eq!(
-            &(Value::try_deserialize(
-                r#"{ "type": "contract_principal", "issuer": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G", "name": "foo" }"#,
-                &TypeSignature::PrincipalType).unwrap()),
-            &contract_p2);
-
-        assert_eq!(
-            Value::try_deserialize_untyped(
-                r#"{ "type": "principal", "value": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G" }"#).unwrap(),
-            standard_p);
-
-        assert_eq!(
-            Value::try_deserialize_untyped(
-                r#"{ "type": "contract_principal", "issuer": "SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G", "name": "foo" }"#).unwrap(),
-            contract_p2);
+        test_bad_expectation(contract_p2, TypeSignature::BoolType);
+        test_bad_expectation(standard_p, TypeSignature::BoolType);
     }
 
 }


### PR DESCRIPTION
This implements a more compact Clarity value serialization:

All values have a 1-byte header indicating the type:

```
00 => int
01 => uint
02 => buff
03 => bool (true)
04 => bool (false)
05 => principal (standard)
06 => principal (contract)
07 => response (ok)
08 => response (err)
09 => optional (none)
10 => optional (some)
11 => list
12 => tuple
```

* `int` and `uint` types are followed by the big endian encoding of the 128-bit integer.
* `buff` types are followed by a 4-byte big endian length, and then the byte data.
* `bool` and `none` values are represented with only the 1-byte header.
* standard `principal`s are followed by a 1-byte version and 20-bytes of address data.
* contract `principal`s are followed by a standard principal, a 1-byte length for the contract name, and then the ascii representation of the contract name.
* `some` and `response` values are followed by the serialization of their contained values.
* `list`s are followed by a 4-byte big-endian length for the list, and then the serialization of each contained value.
* `tuple`s are followed by a 4-byte big-endian count for the number of items in the tuple, and then serializations of the tuple's entries, each of which is serialized as:
    * a 1-byte length for the key-name
    * followed by the ascii representation of the key-name
    * followed by the serialization of the value.

There are provided functions for serialization/deserialization to Write/Read interfaces, as well as wrappers for hex strings. The behavior of "type expected" versus "type not-expected" is preserved as well.