### PR TITLE
require cachetools 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'cryptography>=2.6',
         'pyparsing>=2.2.0',     # not required, but causes problems if not installed properly,
         'requests>=2.20',
+        'cachetools==2.0.0'
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
This forces cachetools 2.0.0 to be installed.  Cachetools 4.0.0 (currently the latest) is incompatible with Python 2.