### PR TITLE
Remove contract metadata from MARF

### DIFF
--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -250,8 +250,13 @@ impl<'a> ClarityTx<'a> {
         self.block.get_root_hash()
     }
 
+    #[cfg(test)]
     pub fn commit_block(self) -> () {
         self.block.commit_block()
+    }
+
+    pub fn commit_block_will_move(self, will_move: &str) -> () {
+        self.block.commit_block_will_move(will_move)
     }
 
     pub fn commit_to_block(self, burn_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash) -> () {

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -79,7 +79,6 @@ use vm::analysis::run_analysis;
 use vm::analysis::analysis_db::AnalysisDatabase;
 use vm::ast::build_ast;
 use vm::contexts::OwnedEnvironment;
-use vm::database::marf::sqlite_marf;
 use vm::database::marf::MarfedKV;
 use vm::database::SqliteConnection;
 use vm::clarity::ClarityInstance;
@@ -722,7 +721,7 @@ impl StacksChainState {
 
         let headers_state_index = StacksChainState::open_index(&header_index_root, None)?;
 
-        let vm_state = sqlite_marf(&clarity_state_index_root, Some(&StacksBlockHeader::make_index_block_hash(&MINER_BLOCK_BURN_HEADER_HASH, &MINER_BLOCK_HEADER_HASH)))
+        let vm_state = MarfedKV::open(&clarity_state_index_root, Some(&StacksBlockHeader::make_index_block_hash(&MINER_BLOCK_BURN_HEADER_HASH, &MINER_BLOCK_HEADER_HASH)))
             .map_err(|e| Error::ClarityError(e.into()))?;
 
         let clarity_state = ClarityInstance::new(vm_state);

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -432,8 +432,9 @@ impl StacksChainState {
 
                 // execution -- if this fails due to a runtime error, then the transaction is still
                 // accepted, but the contract does not materialize (but the sender is out their fee).
-                let asset_map = match clarity_tx.connection().initialize_smart_contract(&contract_id, &contract_ast,
-                                                                                       |asset_map, _| { !StacksChainState::check_transaction_postconditions(&tx.post_conditions, &tx.post_condition_mode, origin_account, asset_map) }) {
+                let asset_map = match clarity_tx.connection().initialize_smart_contract(
+                    &contract_id, &contract_ast, &contract_code_str,
+                    |asset_map, _| { !StacksChainState::check_transaction_postconditions(&tx.post_conditions, &tx.post_condition_mode, origin_account, asset_map) }) {
                     Ok(asset_map) => {
                         Ok(asset_map)
                     },

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -506,6 +506,10 @@ impl MARF {
             .map(|opt_result| opt_result.map(|(leaf, _)| leaf))
     }
 
+    pub fn get_bhh_at_height(&mut self, block_hash: &BlockHeaderHash, height: u32) -> Result<Option<BlockHeaderHash>, Error> {
+        MARF::get_block_at_height(&mut self.storage, height, block_hash)
+    }
+
     /// Resolve a key from the MARF to a MARFValue with respect to the given block height, returning the block header in which it was found
     pub fn get_with_bhh(&mut self, block_hash: &BlockHeaderHash, key: &str) -> Result<Option<(MARFValue, BlockHeaderHash)>, Error> {
         MARF::get_by_key(&mut self.storage, block_hash, key)
@@ -788,6 +792,12 @@ impl MARF {
     pub fn get_open_chain_tip(&self) -> Option<&BlockHeaderHash> {
         self.open_chain_tip.as_ref()
             .map(|x| &x.block_hash)
+    }
+
+    /// Get open chain tip
+    pub fn get_open_chain_tip_height(&self) -> Option<u32> {
+        self.open_chain_tip.as_ref()
+            .map(|x| x.height)
     }
 
     /// Get all known chain tips

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -276,12 +276,13 @@ impl StacksBlockBuilder {
 
         // clear out the block trie we just created, so the block validator logic doesn't step all
         // over it.
+        let moved_filename = format!("{}.mined", index_block_hash.to_hex());
         let block_pathbuf = tx.get_block_path(&new_burn_hash, &new_block_hash);
         let mut mined_block_pathbuf = block_pathbuf.clone();
-        mined_block_pathbuf.set_file_name(format!("{}.mined", index_block_hash.to_hex()));
+        mined_block_pathbuf.set_file_name(&moved_filename);
 
         // write out the trie...
-        tx.commit_block();
+        tx.commit_block_will_move(&moved_filename);
 
         // ...and move it (possibly overwriting)
         // TODO: this is atomic but _not_ crash-consistent!

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -289,6 +289,8 @@ impl StacksBlockBuilder {
         fs::rename(&block_pathbuf, &mined_block_pathbuf)
             .expect(&format!("FATAL: failed to rename {:?} to {:?}", &block_pathbuf, &mined_block_pathbuf));
 
+        debug!("Moved {:?} -> {:?}", &block_pathbuf, &mined_block_pathbuf);
+
         test_debug!("\n\nMiner {}: Finished mining child of {}/{}. Trie is in {:?}\n", self.miner_id, self.chain_tip.burn_header_hash.to_hex(), self.chain_tip.anchored_header.block_hash().to_hex(), &mined_block_pathbuf);
     }
 }

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -21,7 +21,7 @@ use util::db::FromRow;
 
 use vm::ast::parse;
 use vm::contexts::OwnedEnvironment;
-use vm::database::{ClarityDatabase, SqliteConnection, KeyValueStorage,
+use vm::database::{ClarityDatabase, SqliteConnection,
                    MarfedKV, in_memory_marf, sqlite_marf};
 use vm::errors::{InterpreterResult};
 use vm::{SymbolicExpression, SymbolicExpressionType, Value};
@@ -547,6 +547,9 @@ mod test {
         
         eprintln!("initialize");
         invoke_command("test", &["initialize".to_string(), db_name.clone()]);
+
+        eprintln!("check tokens");
+        invoke_command("test", &["check".to_string(), "sample-programs/tokens.clar".to_string()]);
         
         eprintln!("check tokens");
         invoke_command("test", &["check".to_string(), "sample-programs/tokens.clar".to_string(), db_name.clone()]);

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -160,7 +160,7 @@ where F: FnOnce(MarfedKV) -> (MarfedKV, R) {
     let (from, to) = advance_cli_chain_tip(&cli_db_path);
     marf_kv.begin(&from, &to);
     let (mut marf_return, result) = f(marf_kv);
-    marf_return.commit();
+    marf_return.commit_to(&to);
     result
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 
 #![allow(unused_imports)]
 #![allow(unused_assignments)]
+#![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@
 
 #![allow(unused_imports)]
 #![allow(unused_assignments)]
+#![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -63,7 +63,7 @@ impl <'a> AnalysisDatabase <'a> {
     //    even if the contract isn't published.
     #[cfg(test)]
     pub fn test_insert_contract_hash(&mut self, contract_identifier: &QualifiedContractIdentifier) {
-        self.store.prepare_for_contract_metadata(contract_identifier, "");
+        self.store.prepare_for_contract_metadata(contract_identifier, [0; 32]);
     }
 
     fn load_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> Option<ContractAnalysis> {

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use vm::types::{TypeSignature, FunctionType, QualifiedContractIdentifier};
 use vm::database::{ClaritySerializable, ClarityDeserializable,
-                   RollbackWrapper, MarfedKV, in_memory_marf};
+                   RollbackWrapper, MarfedKV, ClarityBackingStore};
 use vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use vm::analysis::type_checker::{ContractAnalysis};
 
@@ -25,7 +25,7 @@ impl ClarityDeserializable<ContractAnalysis> for ContractAnalysis {
 }
 
 impl <'a> AnalysisDatabase <'a> {
-    pub fn new(store: &'a mut MarfedKV) -> AnalysisDatabase<'a> {
+    pub fn new(store: &'a mut dyn ClarityBackingStore) -> AnalysisDatabase<'a> {
         AnalysisDatabase {
             store: RollbackWrapper::new(store)
         }

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -63,7 +63,8 @@ impl <'a> AnalysisDatabase <'a> {
     //    even if the contract isn't published.
     #[cfg(test)]
     pub fn test_insert_contract_hash(&mut self, contract_identifier: &QualifiedContractIdentifier) {
-        self.store.prepare_for_contract_metadata(contract_identifier, [0; 32]);
+        use util::hash::Sha512Trunc256Sum;
+        self.store.prepare_for_contract_metadata(contract_identifier, Sha512Trunc256Sum([0; 32]));
     }
 
     fn load_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> Option<ContractAnalysis> {

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use vm::types::{TypeSignature, FunctionType, QualifiedContractIdentifier};
-use vm::database::{KeyValueStorage, ClaritySerializable, ClarityDeserializable,
+use vm::database::{ClaritySerializable, ClarityDeserializable,
                    RollbackWrapper, MarfedKV, in_memory_marf};
 use vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use vm::analysis::type_checker::{ContractAnalysis};

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use vm::types::{TypeSignature, FunctionType, QualifiedContractIdentifier};
-use vm::database::{KeyValueStorage, ClaritySerializable, ClarityDeserializable, RollbackWrapper};
+use vm::database::{KeyValueStorage, ClaritySerializable, ClarityDeserializable,
+                   RollbackWrapper, MarfedKV, in_memory_marf};
 use vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use vm::analysis::type_checker::{ContractAnalysis};
 
@@ -24,15 +25,10 @@ impl ClarityDeserializable<ContractAnalysis> for ContractAnalysis {
 }
 
 impl <'a> AnalysisDatabase <'a> {
-    pub fn new(store: Box<dyn KeyValueStorage + 'a>) -> AnalysisDatabase<'a> {
+    pub fn new(store: &'a mut MarfedKV) -> AnalysisDatabase<'a> {
         AnalysisDatabase {
             store: RollbackWrapper::new(store)
         }
-    }
-
-    pub fn memory() -> AnalysisDatabase<'a> {
-        let store: HashMap<String, String> = HashMap::new();
-        Self::new(Box::new(store))
     }
 
     pub fn execute <F, T, E> (&mut self, f: F) -> Result<T,E> where F: FnOnce(&mut Self) -> Result<T,E>, {

--- a/src/vm/analysis/definition_sorter/mod.rs
+++ b/src/vm/analysis/definition_sorter/mod.rs
@@ -224,7 +224,7 @@ impl Graph {
         Self { adjacency_list: Vec::new() }
     }
 
-    fn add_node(&mut self, expr_index: usize) {
+    fn add_node(&mut self, _expr_index: usize) {
         self.adjacency_list.push(vec![]);
     }
 

--- a/src/vm/analysis/definition_sorter/tests.rs
+++ b/src/vm/analysis/definition_sorter/tests.rs
@@ -4,9 +4,12 @@ use vm::types::QualifiedContractIdentifier;
 use vm::analysis::{CheckResult, AnalysisDatabase};
 use vm::analysis::types::{ContractAnalysis, AnalysisPass};
 use vm::analysis::definition_sorter::DefinitionSorter;
+use vm::database::in_memory_marf;
 
 fn run_scoped_analysis_helper(contract: &str) -> CheckResult<ContractAnalysis> {
-    let mut db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut db = marf.as_analysis_db();
+
     let contract_identifier = QualifiedContractIdentifier::transient();
 
     let expressions = parse(&contract_identifier, contract).unwrap();

--- a/src/vm/analysis/definition_sorter/tests.rs
+++ b/src/vm/analysis/definition_sorter/tests.rs
@@ -4,10 +4,10 @@ use vm::types::QualifiedContractIdentifier;
 use vm::analysis::{CheckResult, AnalysisDatabase};
 use vm::analysis::types::{ContractAnalysis, AnalysisPass};
 use vm::analysis::definition_sorter::DefinitionSorter;
-use vm::database::in_memory_marf;
+use vm::database::MemoryBackingStore;
 
 fn run_scoped_analysis_helper(contract: &str) -> CheckResult<ContractAnalysis> {
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
 
     let contract_identifier = QualifiedContractIdentifier::transient();

--- a/src/vm/analysis/mod.rs
+++ b/src/vm/analysis/mod.rs
@@ -9,6 +9,7 @@ pub mod contract_interface_builder;
 pub use self::types::{ContractAnalysis, AnalysisPass};
 use vm::representations::{SymbolicExpression};
 use vm::types::{TypeSignature, QualifiedContractIdentifier};
+use vm::database::in_memory_marf;
 
 pub use self::errors::{CheckResult, CheckError, CheckErrors};
 pub use self::analysis_db::{AnalysisDatabase};
@@ -22,7 +23,8 @@ pub fn mem_type_check(snippet: &str) -> CheckResult<(Option<TypeSignature>, Cont
     use vm::ast::parse;
     let contract_identifier = QualifiedContractIdentifier::transient();
     let mut contract = parse(&contract_identifier, snippet).unwrap();
-    let mut analysis_db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut analysis_db = marf.as_analysis_db();
     type_check(&QualifiedContractIdentifier::transient(), &mut contract, &mut analysis_db, false)
         .map(|x| {
              // return the first type result of the type checker

--- a/src/vm/analysis/mod.rs
+++ b/src/vm/analysis/mod.rs
@@ -9,7 +9,6 @@ pub mod contract_interface_builder;
 pub use self::types::{ContractAnalysis, AnalysisPass};
 use vm::representations::{SymbolicExpression};
 use vm::types::{TypeSignature, QualifiedContractIdentifier};
-use vm::database::in_memory_marf;
 
 pub use self::errors::{CheckResult, CheckError, CheckErrors};
 pub use self::analysis_db::{AnalysisDatabase};
@@ -20,10 +19,11 @@ use self::type_checker::TypeChecker;
 
 #[cfg(test)]
 pub fn mem_type_check(snippet: &str) -> CheckResult<(Option<TypeSignature>, ContractAnalysis)> {
+    use vm::database::MemoryBackingStore;
     use vm::ast::parse;
     let contract_identifier = QualifiedContractIdentifier::transient();
     let mut contract = parse(&contract_identifier, snippet).unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut analysis_db = marf.as_analysis_db();
     type_check(&QualifiedContractIdentifier::transient(), &mut contract, &mut analysis_db, false)
         .map(|x| {

--- a/src/vm/analysis/read_only_checker/tests.rs
+++ b/src/vm/analysis/read_only_checker/tests.rs
@@ -1,5 +1,5 @@
 use vm::ast::parse;
-use vm::database::{in_memory_marf};
+use vm::database::{MemoryBackingStore};
 use vm::analysis::{type_check, mem_type_check, CheckError, CheckErrors, AnalysisDatabase};
 use vm::types::QualifiedContractIdentifier;
 
@@ -140,7 +140,7 @@ fn test_contract_call_read_only_violations() {
     let mut bad_caller = parse(&contract_bad_caller_id, bad_caller).unwrap();
     let mut ok_caller = parse(&contract_ok_caller_id, ok_caller).unwrap();
 
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
 
     let mut db = marf.as_analysis_db();
     db.execute(|db| {

--- a/src/vm/analysis/read_only_checker/tests.rs
+++ b/src/vm/analysis/read_only_checker/tests.rs
@@ -141,12 +141,16 @@ fn test_contract_call_read_only_violations() {
     let mut ok_caller = parse(&contract_ok_caller_id, ok_caller).unwrap();
 
     let mut marf = in_memory_marf();
+
     let mut db = marf.as_analysis_db();
-    db.execute(|db| type_check(&contract_1_id, &mut contract1, db, true)).unwrap();
+    db.execute(|db| {
+        db.test_insert_contract_hash(&contract_1_id);
+        type_check(&contract_1_id, &mut contract1, db, true)
+    }).unwrap();
 
     let err = db.execute(|db| type_check(&contract_bad_caller_id, &mut bad_caller, db, true)).unwrap_err();
     assert_eq!(err.err, CheckErrors::WriteAttemptedInReadOnly);
 
-    db.execute(|db| type_check(&contract_ok_caller_id, &mut ok_caller, db, true)).unwrap();
+    db.execute(|db| type_check(&contract_ok_caller_id, &mut ok_caller, db, false)).unwrap();
 
 }

--- a/src/vm/analysis/read_only_checker/tests.rs
+++ b/src/vm/analysis/read_only_checker/tests.rs
@@ -1,4 +1,5 @@
 use vm::ast::parse;
+use vm::database::{in_memory_marf};
 use vm::analysis::{type_check, mem_type_check, CheckError, CheckErrors, AnalysisDatabase};
 use vm::types::QualifiedContractIdentifier;
 
@@ -139,7 +140,8 @@ fn test_contract_call_read_only_violations() {
     let mut bad_caller = parse(&contract_bad_caller_id, bad_caller).unwrap();
     let mut ok_caller = parse(&contract_ok_caller_id, ok_caller).unwrap();
 
-    let mut db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut db = marf.as_analysis_db();
     db.execute(|db| type_check(&contract_1_id, &mut contract1, db, true)).unwrap();
 
     let err = db.execute(|db| type_check(&contract_bad_caller_id, &mut bad_caller, db, true)).unwrap_err();

--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -381,7 +381,7 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
 
     fn type_check_define_persisted_variable(&mut self, var_name: &ClarityName, var_type: &SymbolicExpression, initial: &SymbolicExpression, context: &mut TypingContext) -> CheckResult<(ClarityName, TypeSignature)> {
         let expected_type = TypeSignature::parse_type_repr(var_type)
-            .map_err(|e| CheckErrors::DefineVariableBadSignature)?;
+            .map_err(|_e| CheckErrors::DefineVariableBadSignature)?;
 
         self.type_check_expects(initial, context, &expected_type)?;
 
@@ -396,7 +396,7 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
         Ok(token_name.clone())
     }
 
-    fn type_check_define_nft(&mut self, asset_name: &ClarityName, nft_type: &SymbolicExpression, context: &mut TypingContext) -> CheckResult<(ClarityName, TypeSignature)> {
+    fn type_check_define_nft(&mut self, asset_name: &ClarityName, nft_type: &SymbolicExpression, _context: &mut TypingContext) -> CheckResult<(ClarityName, TypeSignature)> {
         let asset_type = TypeSignature::parse_type_repr(&nft_type)
             .or_else(|_| Err(CheckErrors::DefineNFTBadSignature))?;
 

--- a/src/vm/analysis/type_checker/natives/mod.rs
+++ b/src/vm/analysis/type_checker/natives/mod.rs
@@ -129,7 +129,7 @@ fn check_special_let(checker: &mut TypeChecker, args: &[SymbolicExpression], con
     Ok(last_return)
 }
 
-fn check_special_fetch_var(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
+fn check_special_fetch_var(checker: &mut TypeChecker, args: &[SymbolicExpression], _context: &TypingContext) -> TypeResult {
     check_argument_count(1, args)?;
     
     let var_name = args[0].match_atom()

--- a/src/vm/analysis/type_checker/tests/assets.rs
+++ b/src/vm/analysis/type_checker/tests/assets.rs
@@ -1,3 +1,4 @@
+use vm::database::in_memory_marf;
 use vm::types::{TypeSignature, QualifiedContractIdentifier};
 use vm::ast::parse;
 use vm::analysis::errors::CheckErrors;
@@ -83,7 +84,8 @@ fn test_names_tokens_contracts() {
 
     let mut tokens_contract = parse(&tokens_contract_id, FIRST_CLASS_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, ASSET_NAMES).unwrap();
-    let mut db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut db = marf.as_analysis_db();
 
     db.execute(|db| {
         type_check(&tokens_contract_id, &mut tokens_contract, db, true)?;

--- a/src/vm/analysis/type_checker/tests/assets.rs
+++ b/src/vm/analysis/type_checker/tests/assets.rs
@@ -1,4 +1,4 @@
-use vm::database::in_memory_marf;
+use vm::database::MemoryBackingStore;
 use vm::types::{TypeSignature, QualifiedContractIdentifier};
 use vm::ast::parse;
 use vm::analysis::errors::CheckErrors;
@@ -84,7 +84,7 @@ fn test_names_tokens_contracts() {
 
     let mut tokens_contract = parse(&tokens_contract_id, FIRST_CLASS_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, ASSET_NAMES).unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
 
     db.execute(|db| {

--- a/src/vm/analysis/type_checker/tests/contracts.rs
+++ b/src/vm/analysis/type_checker/tests/contracts.rs
@@ -396,7 +396,10 @@ fn test_names_tokens_contracts_bad() {
     let mut marf = in_memory_marf();
     let mut db = marf.as_analysis_db();
 
-    db.execute(|db| type_check(&tokens_contract_id, &mut tokens_contract, db, true)).unwrap();
+    db.execute(|db| {
+        db.test_insert_contract_hash(&tokens_contract_id);
+        type_check(&tokens_contract_id, &mut tokens_contract, db, true)
+    }).unwrap();
 
     let err = db.execute(|db| type_check(&names_contract_id, &mut names_contract, db, true)).unwrap_err();
     assert!(match &err.err {
@@ -429,7 +432,10 @@ fn test_names_tokens_contracts_bad_fetch_contract_entry() {
     let mut marf = in_memory_marf();
     let mut db = marf.as_analysis_db();
 
-    db.execute(|db| type_check(&tokens_contract_id, &mut tokens_contract, db, true)).unwrap();
+    db.execute(|db| {
+        db.test_insert_contract_hash(&tokens_contract_id);
+        type_check(&tokens_contract_id, &mut tokens_contract, db, true)
+    }).unwrap();
 
     let err = db.execute(|db| type_check(&names_contract_id, &mut names_contract, db, true)).unwrap_err();
     assert!(match &err.err {

--- a/src/vm/analysis/type_checker/tests/contracts.rs
+++ b/src/vm/analysis/type_checker/tests/contracts.rs
@@ -4,7 +4,7 @@ use serde_json;
 use vm::ast::parse;
 use vm::analysis::errors::CheckErrors;
 use vm::analysis::{AnalysisDatabase, contract_interface_builder::build_contract_interface};
-use vm::database::in_memory_marf;
+use vm::database::MemoryBackingStore;
 use vm::analysis::mem_type_check;
 use vm::analysis::type_check;
 use vm::types::QualifiedContractIdentifier;
@@ -363,7 +363,7 @@ fn test_names_tokens_contracts() {
 
     let mut tokens_contract = parse(&tokens_contract_id, SIMPLE_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, SIMPLE_NAMES).unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
 
     db.execute(|db| {
@@ -393,7 +393,7 @@ fn test_names_tokens_contracts_bad() {
 
     let mut tokens_contract = parse(&tokens_contract_id, SIMPLE_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, &names_contract).unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
 
     db.execute(|db| {
@@ -429,7 +429,7 @@ fn test_names_tokens_contracts_bad_fetch_contract_entry() {
 
     let mut tokens_contract = parse(&tokens_contract_id, SIMPLE_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, &names_contract).unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
 
     db.execute(|db| {

--- a/src/vm/analysis/type_checker/tests/contracts.rs
+++ b/src/vm/analysis/type_checker/tests/contracts.rs
@@ -4,6 +4,7 @@ use serde_json;
 use vm::ast::parse;
 use vm::analysis::errors::CheckErrors;
 use vm::analysis::{AnalysisDatabase, contract_interface_builder::build_contract_interface};
+use vm::database::in_memory_marf;
 use vm::analysis::mem_type_check;
 use vm::analysis::type_check;
 use vm::types::QualifiedContractIdentifier;
@@ -362,7 +363,8 @@ fn test_names_tokens_contracts() {
 
     let mut tokens_contract = parse(&tokens_contract_id, SIMPLE_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, SIMPLE_NAMES).unwrap();
-    let mut db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut db = marf.as_analysis_db();
 
     db.execute(|db| {
         type_check(&tokens_contract_id, &mut tokens_contract, db, true)?;
@@ -391,7 +393,9 @@ fn test_names_tokens_contracts_bad() {
 
     let mut tokens_contract = parse(&tokens_contract_id, SIMPLE_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, &names_contract).unwrap();
-    let mut db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut db = marf.as_analysis_db();
+
     db.execute(|db| type_check(&tokens_contract_id, &mut tokens_contract, db, true)).unwrap();
 
     let err = db.execute(|db| type_check(&names_contract_id, &mut names_contract, db, true)).unwrap_err();
@@ -422,7 +426,9 @@ fn test_names_tokens_contracts_bad_fetch_contract_entry() {
 
     let mut tokens_contract = parse(&tokens_contract_id, SIMPLE_TOKENS).unwrap();
     let mut names_contract = parse(&names_contract_id, &names_contract).unwrap();
-    let mut db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut db = marf.as_analysis_db();
+
     db.execute(|db| type_check(&tokens_contract_id, &mut tokens_contract, db, true)).unwrap();
 
     let err = db.execute(|db| type_check(&names_contract_id, &mut names_contract, db, true)).unwrap_err();

--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -1533,6 +1533,7 @@ fn test_fetch_contract_entry_matching_type_signatures() {
 
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();
     analysis_db.execute(|db| {
+        db.test_insert_contract_hash(&contract_id);
         type_check(&contract_id, &mut kv_store_contract, db, true)
     }).unwrap();
 
@@ -1570,6 +1571,7 @@ fn test_fetch_contract_entry_mismatching_type_signatures() {
 
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();
     analysis_db.execute(|db| {
+        db.test_insert_contract_hash(&contract_id);
         type_check(&contract_id, &mut kv_store_contract, db, true)
     }).unwrap();
     
@@ -1614,6 +1616,7 @@ fn test_fetch_contract_entry_unbound_variables() {
 
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();
     analysis_db.execute(|db| {
+        db.test_insert_contract_hash(&contract_id);
         type_check(&contract_id, &mut kv_store_contract, db, true)
     }).unwrap();
     

--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -10,7 +10,7 @@ use vm::contexts::{OwnedEnvironment};
 use vm::types::{Value, PrincipalData, TypeSignature, FunctionType, FixedFunction, BUFF_32, BUFF_64,
                 QualifiedContractIdentifier};
 
-use vm::database::in_memory_marf;
+use vm::database::MemoryBackingStore;
 use vm::types::TypeSignature::{IntType, BoolType, BufferType, UIntType};
 use std::convert::TryInto;
 
@@ -1526,7 +1526,7 @@ fn test_fetch_contract_entry_matching_type_signatures() {
             (unwrap! (get value (map-get? kv-store ((key key)))) 0))
         (begin (map-insert kv-store ((key 42)) ((value 42))))"#;
 
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut analysis_db = marf.as_analysis_db();
 
     let contract_id = QualifiedContractIdentifier::local("kv-store-contract").unwrap();
@@ -1566,7 +1566,7 @@ fn test_fetch_contract_entry_mismatching_type_signatures() {
         (begin (map-insert kv-store ((key 42)) ((value 42))))"#;
 
     let contract_id = QualifiedContractIdentifier::local("kv-store-contract").unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut analysis_db = marf.as_analysis_db();
 
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();
@@ -1611,7 +1611,7 @@ fn test_fetch_contract_entry_unbound_variables() {
         (begin (map-insert kv-store ((key 42)) ((value 42))))"#;
 
     let contract_id = QualifiedContractIdentifier::local("kv-store-contract").unwrap();
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut analysis_db = marf.as_analysis_db();
 
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();

--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -10,6 +10,7 @@ use vm::contexts::{OwnedEnvironment};
 use vm::types::{Value, PrincipalData, TypeSignature, FunctionType, FixedFunction, BUFF_32, BUFF_64,
                 QualifiedContractIdentifier};
 
+use vm::database::in_memory_marf;
 use vm::types::TypeSignature::{IntType, BoolType, BufferType, UIntType};
 use std::convert::TryInto;
 
@@ -1525,7 +1526,8 @@ fn test_fetch_contract_entry_matching_type_signatures() {
             (unwrap! (get value (map-get? kv-store ((key key)))) 0))
         (begin (map-insert kv-store ((key 42)) ((value 42))))"#;
 
-    let mut analysis_db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut analysis_db = marf.as_analysis_db();
 
     let contract_id = QualifiedContractIdentifier::local("kv-store-contract").unwrap();
 
@@ -1563,7 +1565,9 @@ fn test_fetch_contract_entry_mismatching_type_signatures() {
         (begin (map-insert kv-store ((key 42)) ((value 42))))"#;
 
     let contract_id = QualifiedContractIdentifier::local("kv-store-contract").unwrap();
-    let mut analysis_db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut analysis_db = marf.as_analysis_db();
+
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();
     analysis_db.execute(|db| {
         type_check(&contract_id, &mut kv_store_contract, db, true)
@@ -1605,7 +1609,9 @@ fn test_fetch_contract_entry_unbound_variables() {
         (begin (map-insert kv-store ((key 42)) ((value 42))))"#;
 
     let contract_id = QualifiedContractIdentifier::local("kv-store-contract").unwrap();
-    let mut analysis_db = AnalysisDatabase::memory();
+    let mut marf = in_memory_marf();
+    let mut analysis_db = marf.as_analysis_db();
+
     let mut kv_store_contract = parse(&contract_id, &kv_store_contract_src).unwrap();
     analysis_db.execute(|db| {
         type_check(&contract_id, &mut kv_store_contract, db, true)

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -319,13 +319,13 @@ mod tests {
     use super::*;
     use vm::analysis::errors::CheckErrors;
     use vm::types::{Value, StandardPrincipalData};
-    use vm::database::{marf, ClarityBackingStore};
+    use vm::database::marf::{ClarityBackingStore, MarfedKV};
     use chainstate::stacks::index::storage::{TrieFileStorage};
     use rusqlite::NO_PARAMS;
 
     #[test]
     pub fn simple_test() {
-        let marf = marf::temporary_marf();
+        let marf = MarfedKV::temporary();
         let mut clarity_instance = ClarityInstance::new(marf);
 
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     pub fn test_block_roll_back() {
-        let marf = marf::temporary_marf();
+        let marf = MarfedKV::temporary();
         let mut clarity_instance = ClarityInstance::new(marf);
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     pub fn test_tx_roll_backs() {
-        let marf = marf::temporary_marf();
+        let marf = MarfedKV::temporary();
         let mut clarity_instance = ClarityInstance::new(marf);
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
         let sender = StandardPrincipalData::transient().into();

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -144,7 +144,7 @@ impl <'a> ClarityBlockConnection <'a> {
     #[cfg(test)]
     pub fn commit_block(mut self) {
         debug!("Commit Clarity datastore");
-        self.datastore.commit();
+        self.datastore.test_commit();
 
         self.parent.datastore.replace(self.datastore);
     }

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -319,7 +319,7 @@ mod tests {
     use super::*;
     use vm::analysis::errors::CheckErrors;
     use vm::types::{Value, StandardPrincipalData};
-    use vm::database::marf;
+    use vm::database::{marf, ClarityBackingStore};
     use chainstate::stacks::index::storage::{TrieFileStorage};
     use rusqlite::NO_PARAMS;
 

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -307,7 +307,6 @@ mod tests {
     use vm::types::{Value, StandardPrincipalData};
     use vm::database::marf;
     use chainstate::stacks::index::storage::{TrieFileStorage};
-    use vm::database::KeyValueStorage;
     use rusqlite::NO_PARAMS;
 
     #[test]
@@ -336,7 +335,7 @@ mod tests {
             conn.commit_block();
         }
         let mut marf = clarity_instance.destroy();
-        assert!((&mut marf).has_entry(&ClarityDatabase::make_contract_key(&contract_identifier)));
+//        assert!((&mut marf).has_entry(&ClarityDatabase::make_contract_key(&contract_identifier)));
     }
 
     #[test]
@@ -361,7 +360,7 @@ mod tests {
 
         let mut marf = clarity_instance.destroy();
         // should not be in the marf.
-        assert!(! (&mut marf).has_entry(&ClarityDatabase::make_contract_key(&contract_identifier)));
+//        assert!(! (&mut marf).has_entry(&ClarityDatabase::make_contract_key(&contract_identifier)));
         let sql = marf.get_side_store();
         // sqlite should not have any entries
         assert_eq!(0,

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -141,6 +141,7 @@ impl <'a> ClarityBlockConnection <'a> {
     /// Commits all changes in the current block by
     /// (1) committing the current MARF tip to storage,
     /// (2) committing side-storage.
+    #[cfg(test)]
     pub fn commit_block(mut self) {
         debug!("Commit Clarity datastore");
         self.datastore.commit();

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     pub fn simple_test() {
-        let marf = marf::in_memory_marf();
+        let marf = marf::temporary_marf();
         let mut clarity_instance = ClarityInstance::new(marf);
 
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     pub fn test_block_roll_back() {
-        let marf = marf::in_memory_marf();
+        let marf = marf::temporary_marf();
         let mut clarity_instance = ClarityInstance::new(marf);
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     pub fn test_tx_roll_backs() {
-        let marf = marf::in_memory_marf();
+        let marf = marf::temporary_marf();
         let mut clarity_instance = ClarityInstance::new(marf);
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
         let sender = StandardPrincipalData::transient().into();

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -317,6 +317,7 @@ impl <'a> ClarityBlockConnection <'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vm::analysis::errors::CheckErrors;
     use vm::types::{Value, StandardPrincipalData};
     use vm::database::marf;
     use chainstate::stacks::index::storage::{TrieFileStorage};
@@ -348,7 +349,7 @@ mod tests {
             conn.commit_block();
         }
         let mut marf = clarity_instance.destroy();
-//        assert!((&mut marf).has_entry(&ClarityDatabase::make_contract_key(&contract_identifier)));
+        assert!(marf.get_contract_hash(&contract_identifier).is_ok());
     }
 
     #[test]
@@ -373,7 +374,8 @@ mod tests {
 
         let mut marf = clarity_instance.destroy();
         // should not be in the marf.
-//        assert!(! (&mut marf).has_entry(&ClarityDatabase::make_contract_key(&contract_identifier)));
+        assert_eq!(marf.get_contract_hash(&contract_identifier).unwrap_err(),
+                   CheckErrors::NoSuchContract(contract_identifier.to_string()).into());
         let sql = marf.get_side_store();
         // sqlite should not have any entries
         assert_eq!(0,

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -292,10 +292,11 @@ impl <'a> ClarityBlockConnection <'a> {
     /// abort_call_back is called with an AssetMap and a ClarityDatabase reference,
     ///   if abort_call_back returns false, all modifications from this transaction will be rolled back.
     ///      otherwise, they will be committed (though they may later be rolled back if the block itself is rolled back).
-    pub fn initialize_smart_contract <F> (&mut self, identifier: &QualifiedContractIdentifier, contract_ast: &ContractAST, abort_call_back: F) -> Result<AssetMap, Error>
+    pub fn initialize_smart_contract <F> (&mut self, identifier: &QualifiedContractIdentifier, contract_ast: &ContractAST,
+                                          contract_str: &str, abort_call_back: F) -> Result<AssetMap, Error>
     where F: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool {
         let (_, asset_map) = self.with_abort_callback(
-            |vm_env| { vm_env.initialize_contract_from_ast(identifier.clone(), contract_ast)
+            |vm_env| { vm_env.initialize_contract_from_ast(identifier.clone(), contract_ast, contract_str)
                        .map_err(Error::from) },
             abort_call_back)?;
         Ok(asset_map)
@@ -335,7 +336,7 @@ mod tests {
             
             let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
             conn.initialize_smart_contract(
-                &contract_identifier, &ct_ast, |_,_| false).unwrap();
+                &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap();
             conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
             
             assert_eq!(
@@ -363,7 +364,7 @@ mod tests {
 
             let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
             conn.initialize_smart_contract(
-                &contract_identifier, &ct_ast, |_,_| false).unwrap();
+                &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap();
             conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
             
             conn.rollback_block();
@@ -398,7 +399,7 @@ mod tests {
 
             let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
             conn.initialize_smart_contract(
-                &contract_identifier, &ct_ast, |_,_| false).unwrap();
+                &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap();
             conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
 
             assert_eq!(

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use vm::errors::{InterpreterError, CheckErrors, RuntimeErrorType, InterpreterResult as Result};
 use vm::types::{Value, AssetIdentifier, PrincipalData, QualifiedContractIdentifier, TypeSignature};
 use vm::callables::{DefinedFunction, FunctionIdentifier};
-use vm::database::{ClarityDatabase, memory_db};
+use vm::database::{ClarityDatabase};
 use vm::representations::{SymbolicExpression, ClarityName, ContractName};
 use vm::contracts::Contract;
 use vm::ast::ContractAST;
@@ -369,10 +369,6 @@ impl <'a> OwnedEnvironment <'a> {
             default_contract: ContractContext::new(QualifiedContractIdentifier::transient()),
             call_stack: CallStack::new()
         }
-    }
-
-    pub fn memory<'c>() -> OwnedEnvironment<'c> {
-        OwnedEnvironment::new(memory_db())
     }
 
     pub fn get_exec_environment <'b> (&'b mut self, sender: Option<Value>) -> Environment<'b,'a> {

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -594,6 +594,13 @@ impl <'a,'b> Environment <'a,'b> {
 
     pub fn initialize_contract_from_ast(&mut self, contract_identifier: QualifiedContractIdentifier, contract_content: &ContractAST) -> Result<()> {
         self.global_context.begin();
+
+        // first, store the contract _content hash_ in the data store.
+        //    this is necessary before creating and accessing metadata fields in the data store,
+        //      --or-- storing any analysis metadata in the data store.
+        // TODO: pass the actual string data in.
+        self.global_context.database.insert_contract_hash(&contract_identifier, &format!("{:?}", contract_content))?;
+
         let result = Contract::initialize_from_ast(contract_identifier.clone(), 
                                                    contract_content,
                                                    &mut self.global_context);

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -15,9 +15,7 @@ use vm::database::structures::{
     DataMapMetadata, DataVariableMetadata, ClaritySerializable, SimmedBlock,
     ClarityDeserializable,
 };
-use vm::database::{
-    KeyValueStorage, RollbackWrapper
-};
+use vm::database::RollbackWrapper;
 
 
 const SIMMED_BLOCK_TIME: u64 = 10 * 60; // 10 min

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -9,6 +9,7 @@ use chainstate::burn::{VRFSeed, BlockHeaderHash};
 use burnchains::BurnchainHeaderHash;
 
 use util::hash::Sha256Sum;
+use vm::database::MarfedKV;
 use vm::database::structures::{
     FungibleTokenMetadata, NonFungibleTokenMetadata, ContractMetadata,
     DataMapMetadata, DataVariableMetadata, ClaritySerializable, SimmedBlock,
@@ -44,7 +45,7 @@ pub struct ClarityDatabase<'a> {
 }
 
 impl <'a> ClarityDatabase <'a> {
-    pub fn new(store: Box<dyn KeyValueStorage + 'a>) -> ClarityDatabase<'a> {
+    pub fn new(store: &'a mut MarfedKV) -> ClarityDatabase<'a> {
         ClarityDatabase {
             store: RollbackWrapper::new(store)
         }

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -110,7 +110,7 @@ impl <'a> ClarityDatabase <'a> {
     }
 
     pub fn insert_contract_hash(&mut self, contract_identifier: &QualifiedContractIdentifier, contract_content: &str) -> Result<()> {
-        let hash = Sha512Trunc256Sum::from_data(contract_content.as_bytes()).0;
+        let hash = Sha512Trunc256Sum::from_data(contract_content.as_bytes());
         self.store.prepare_for_contract_metadata(contract_identifier, hash);
         Ok(())
     }

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -131,7 +131,7 @@ impl <'a> ClarityDatabase <'a> {
 
     pub fn insert_contract(&mut self, contract_identifier: &QualifiedContractIdentifier, contract: Contract) {
         let key = ClarityDatabase::make_metadata_key(StoreType::Contract, "contract");
-        self.insert_metadata(contract_identifier, &key, &contract);
+       self.insert_metadata(contract_identifier, &key, &contract);
     }
 
     pub fn get_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> Result<Contract> {

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -9,11 +9,11 @@ use chainstate::burn::{VRFSeed, BlockHeaderHash};
 use burnchains::BurnchainHeaderHash;
 
 use util::hash::{Sha256Sum, Sha512Trunc256Sum};
-use vm::database::MarfedKV;
+use vm::database::{MarfedKV, ClarityBackingStore};
 use vm::database::structures::{
     FungibleTokenMetadata, NonFungibleTokenMetadata, ContractMetadata,
     DataMapMetadata, DataVariableMetadata, ClaritySerializable, SimmedBlock,
-    ClarityDeserializable,
+    ClarityDeserializable
 };
 use vm::database::RollbackWrapper;
 
@@ -43,7 +43,7 @@ pub struct ClarityDatabase<'a> {
 }
 
 impl <'a> ClarityDatabase <'a> {
-    pub fn new(store: &'a mut MarfedKV) -> ClarityDatabase<'a> {
+    pub fn new(store: &'a mut dyn ClarityBackingStore) -> ClarityDatabase<'a> {
         ClarityDatabase {
             store: RollbackWrapper::new(store)
         }

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -8,7 +8,7 @@ use vm::types::{Value, OptionalData, TypeSignature, TupleTypeSignature, Principa
 use chainstate::burn::{VRFSeed, BlockHeaderHash};
 use burnchains::BurnchainHeaderHash;
 
-use util::hash::Sha256Sum;
+use util::hash::{Sha256Sum, Sha512Trunc256Sum};
 use vm::database::MarfedKV;
 use vm::database::structures::{
     FungibleTokenMetadata, NonFungibleTokenMetadata, ContractMetadata,
@@ -101,27 +101,45 @@ impl <'a> ClarityDatabase <'a> {
         format!("vm::{}::{}::{}", contract_identifier, data as u8, var_name)
     }
 
+    pub fn make_metadata_key(data: StoreType, var_name: &str) -> String {
+        format!("vm-metadata::{}::{}", data as u8, var_name)
+    }
+
     pub fn make_key_for_quad(contract_identifier: &QualifiedContractIdentifier, data: StoreType, var_name: &str, key_value: String) -> String {
         format!("vm::{}::{}::{}::{}", contract_identifier, data as u8, var_name, key_value)
     }
 
-    pub fn make_contract_key(contract_identifier: &QualifiedContractIdentifier) -> String {
-        format!("vm::{}::{}", contract_identifier, StoreType::Contract as u8)
+    pub fn insert_contract_hash(&mut self, contract_identifier: &QualifiedContractIdentifier, contract_content: &str) -> Result<()> {
+        let hash = Sha512Trunc256Sum::from_data(contract_content.as_bytes()).to_hex();
+        self.store.prepare_for_contract_metadata(contract_identifier, &hash);
+        Ok(())
     }
 
-    pub fn insert_contract(&mut self, contract_identifier: &QualifiedContractIdentifier, contract: Contract) {
-        let key = ClarityDatabase::make_contract_key(contract_identifier);
-        if self.store.has_entry(&key) {
-            panic!("Contract already exists {}", contract_identifier);
+    fn insert_metadata <T: ClaritySerializable> (&mut self, contract_identifier: &QualifiedContractIdentifier, key: &str, data: &T) {
+        if self.store.has_metadata_entry(contract_identifier, key) {
+            panic!("Metadata entry '{}' already exists for contract: {}", key, contract_identifier);
         } else {
-            self.put(&key, &contract);
+            self.store.insert_metadata(contract_identifier, key, &data.serialize());
         }
     }
 
+    fn fetch_metadata <T> (&mut self, contract_identifier: &QualifiedContractIdentifier, key: &str) -> Result<Option<T>>
+    where T: ClarityDeserializable<T> {
+        Ok(self.store.get_metadata(contract_identifier, key)
+           .map(|x| T::deserialize(&x)))
+    }
+
+    pub fn insert_contract(&mut self, contract_identifier: &QualifiedContractIdentifier, contract: Contract) {
+        let key = ClarityDatabase::make_metadata_key(StoreType::Contract, "contract");
+        self.insert_metadata(contract_identifier, &key, &contract);
+    }
+
     pub fn get_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> Result<Contract> {
-        let key = ClarityDatabase::make_contract_key(contract_identifier);
-        self.get(&key)
-            .ok_or_else(|| { CheckErrors::NoSuchContract(contract_identifier.to_string()).into() })
+        let key = ClarityDatabase::make_metadata_key(StoreType::Contract, "contract");
+        let data = self.fetch_metadata(contract_identifier, &key)?
+            .expect("Failed to read non-consensus contract metadata, even though contract exists in MARF.");
+        Ok(data)
+
     }
 }
 
@@ -200,7 +218,7 @@ impl <'a> ClarityDatabase <'a> {
     }
 
     pub fn sim_mine_blocks(&mut self, count: u32) {
-        for i in 0..count {
+        for _i in 0..count {
             self.sim_mine_block();
         }
     }
@@ -210,21 +228,16 @@ impl <'a> ClarityDatabase <'a> {
 impl <'a> ClarityDatabase <'a> {
     pub fn create_variable(&mut self, contract_identifier: &QualifiedContractIdentifier, variable_name: &str, value_type: TypeSignature) {
         let variable_data = DataVariableMetadata { value_type };
+        let key = ClarityDatabase::make_metadata_key(StoreType::VariableMeta, variable_name);
 
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::VariableMeta, variable_name);
-
-        assert!(!self.store.has_entry(&key), format!("Clarity VM attempted to initialize existing variable '{}'", variable_name));
-
-        self.put(&key, &variable_data);
+        self.insert_metadata(contract_identifier, &key, &variable_data)
     }
 
     fn load_variable(&mut self, contract_identifier: &QualifiedContractIdentifier, variable_name: &str) -> Result<DataVariableMetadata> {
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::VariableMeta, variable_name);
+        let key = ClarityDatabase::make_metadata_key(StoreType::VariableMeta, variable_name);
 
-        let data = self.get(&key)
-            .ok_or(CheckErrors::NoSuchDataVariable(variable_name.to_string()))?;
-
-        Ok(data)
+        self.fetch_metadata(contract_identifier, &key)?
+            .ok_or(CheckErrors::NoSuchDataVariable(variable_name.to_string()).into())
     }
 
     pub fn set_variable(&mut self, contract_identifier: &QualifiedContractIdentifier, variable_name: &str, value: Value) -> Result<Value> {
@@ -262,20 +275,15 @@ impl <'a> ClarityDatabase <'a> {
 
         let data = DataMapMetadata { key_type, value_type };
 
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::DataMapMeta, map_name);
-
-        assert!(!self.store.has_entry(&key), "Clarity VM attempted to initialize existing data map");
-
-        self.store.put(&key, &data.serialize());
+        let key = ClarityDatabase::make_metadata_key(StoreType::DataMapMeta, map_name);
+        self.insert_metadata(contract_identifier, &key, &data)
     }
 
     fn load_map(&mut self, contract_identifier: &QualifiedContractIdentifier, map_name: &str) -> Result<DataMapMetadata> {
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::DataMapMeta, map_name);
+        let key = ClarityDatabase::make_metadata_key(StoreType::DataMapMeta, map_name);
 
-        let data = self.get(&key)
-            .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
-
-        Ok(data)
+        self.fetch_metadata(contract_identifier, &key)?
+            .ok_or(CheckErrors::NoSuchMap(map_name.to_string()).into())
     }
 
     pub fn fetch_entry(&mut self, contract_identifier: &QualifiedContractIdentifier, map_name: &str, key_value: &Value) -> Result<Value> {
@@ -354,31 +362,29 @@ impl <'a> ClarityDatabase <'a> {
 
 impl <'a> ClarityDatabase <'a> {
     pub fn create_fungible_token(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str, total_supply: &Option<u128>) {
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::FungibleTokenMeta, token_name);
         let data = FungibleTokenMetadata { total_supply: total_supply.clone() };
 
-        assert!(!self.store.has_entry(&key), "Clarity VM attempted to initialize existing token");
+        let key = ClarityDatabase::make_metadata_key(StoreType::FungibleTokenMeta, token_name);
+        self.insert_metadata(contract_identifier, &key, &data);
 
+        // total supply _is_ included in the consensus hash
         if total_supply.is_some() {
             let supply_key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::CirculatingSupply, token_name);
             self.put(&supply_key, &(0 as u128));
         }
-
-        self.put(&key, &data);
     }
 
     fn load_ft(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str) -> Result<FungibleTokenMetadata> {
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::FungibleTokenMeta, token_name);
+        let key = ClarityDatabase::make_metadata_key(StoreType::FungibleTokenMeta, token_name);
 
-        let data = self.get(&key)
-            .ok_or(CheckErrors::NoSuchFT(token_name.to_string()))?;
-
-        Ok(data)
+        self.fetch_metadata(contract_identifier, &key)?
+            .ok_or(CheckErrors::NoSuchFT(token_name.to_string()).into())
     }
 
     pub fn create_non_fungible_token(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str, key_type: &TypeSignature) {
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::NonFungibleTokenMeta, token_name);
         let data = NonFungibleTokenMetadata { key_type: key_type.clone() };
+        let key = ClarityDatabase::make_metadata_key(StoreType::NonFungibleTokenMeta, token_name);
+        self.insert_metadata(contract_identifier, &key, &data);
 
         assert!(!self.store.has_entry(&key), "Clarity VM attempted to initialize existing token");
 
@@ -386,12 +392,10 @@ impl <'a> ClarityDatabase <'a> {
     }
 
     fn load_nft(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str) -> Result<NonFungibleTokenMetadata> {
-        let key = ClarityDatabase::make_key_for_trip(contract_identifier, StoreType::NonFungibleTokenMeta, token_name);
+        let key = ClarityDatabase::make_metadata_key(StoreType::NonFungibleTokenMeta, token_name);
 
-        let data = self.get(&key)
-            .ok_or(CheckErrors::NoSuchNFT(token_name.to_string()))?;
-
-        Ok(data)
+        self.fetch_metadata(contract_identifier, &key)?
+            .ok_or(CheckErrors::NoSuchNFT(token_name.to_string()).into())
     }
 
     pub fn checked_increase_token_supply(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str, amount: u128) -> Result<()> {

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -224,6 +224,15 @@ impl <'a> ClarityDatabase <'a> {
     }
 }
 
+// this is used so that things like load_map, load_var, load_nft, etc.
+//   will throw NoSuchFoo errors instead of NoSuchContract errors.
+fn map_no_contract_as_none <T> (res: Result<Option<T>>) -> Result<Option<T>> {
+    res.or_else(|e| match e {
+        Error::Unchecked(CheckErrors::NoSuchContract(_)) => Ok(None),
+        x => Err(x)
+    })
+}
+
 // Variable Functions...
 impl <'a> ClarityDatabase <'a> {
     pub fn create_variable(&mut self, contract_identifier: &QualifiedContractIdentifier, variable_name: &str, value_type: TypeSignature) {
@@ -236,7 +245,8 @@ impl <'a> ClarityDatabase <'a> {
     fn load_variable(&mut self, contract_identifier: &QualifiedContractIdentifier, variable_name: &str) -> Result<DataVariableMetadata> {
         let key = ClarityDatabase::make_metadata_key(StoreType::VariableMeta, variable_name);
 
-        self.fetch_metadata(contract_identifier, &key)?
+        map_no_contract_as_none(
+            self.fetch_metadata(contract_identifier, &key))?
             .ok_or(CheckErrors::NoSuchDataVariable(variable_name.to_string()).into())
     }
 
@@ -282,7 +292,8 @@ impl <'a> ClarityDatabase <'a> {
     fn load_map(&mut self, contract_identifier: &QualifiedContractIdentifier, map_name: &str) -> Result<DataMapMetadata> {
         let key = ClarityDatabase::make_metadata_key(StoreType::DataMapMeta, map_name);
 
-        self.fetch_metadata(contract_identifier, &key)?
+        map_no_contract_as_none(
+            self.fetch_metadata(contract_identifier, &key))?
             .ok_or(CheckErrors::NoSuchMap(map_name.to_string()).into())
     }
 
@@ -377,7 +388,8 @@ impl <'a> ClarityDatabase <'a> {
     fn load_ft(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str) -> Result<FungibleTokenMetadata> {
         let key = ClarityDatabase::make_metadata_key(StoreType::FungibleTokenMeta, token_name);
 
-        self.fetch_metadata(contract_identifier, &key)?
+        map_no_contract_as_none(
+            self.fetch_metadata(contract_identifier, &key))?
             .ok_or(CheckErrors::NoSuchFT(token_name.to_string()).into())
     }
 
@@ -394,7 +406,8 @@ impl <'a> ClarityDatabase <'a> {
     fn load_nft(&mut self, contract_identifier: &QualifiedContractIdentifier, token_name: &str) -> Result<NonFungibleTokenMetadata> {
         let key = ClarityDatabase::make_metadata_key(StoreType::NonFungibleTokenMeta, token_name);
 
-        self.fetch_metadata(contract_identifier, &key)?
+        map_no_contract_as_none(
+            self.fetch_metadata(contract_identifier, &key))?
             .ok_or(CheckErrors::NoSuchNFT(token_name.to_string()).into())
     }
 

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -110,8 +110,8 @@ impl <'a> ClarityDatabase <'a> {
     }
 
     pub fn insert_contract_hash(&mut self, contract_identifier: &QualifiedContractIdentifier, contract_content: &str) -> Result<()> {
-        let hash = Sha512Trunc256Sum::from_data(contract_content.as_bytes()).to_hex();
-        self.store.prepare_for_contract_metadata(contract_identifier, &hash);
+        let hash = Sha512Trunc256Sum::from_data(contract_content.as_bytes()).0;
+        self.store.prepare_for_contract_metadata(contract_identifier, hash);
         Ok(())
     }
 

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -125,8 +125,8 @@ impl <'a> ClarityDatabase <'a> {
 
     fn fetch_metadata <T> (&mut self, contract_identifier: &QualifiedContractIdentifier, key: &str) -> Result<Option<T>>
     where T: ClarityDeserializable<T> {
-        Ok(self.store.get_metadata(contract_identifier, key)
-           .map(|x| T::deserialize(&x)))
+        self.store.get_metadata(contract_identifier, key)
+            .map(|x_opt| x_opt.map(|x| T::deserialize(&x)))
     }
 
     pub fn insert_contract(&mut self, contract_identifier: &QualifiedContractIdentifier, contract: Contract) {

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -154,9 +154,10 @@ impl <'a> RollbackWrapper <'a> {
             .or_else(|| self.store.get(key))
     }
 
-    pub fn prepare_for_contract_metadata(&mut self, contract: &QualifiedContractIdentifier, content_hash: &str) {
+    pub fn prepare_for_contract_metadata(&mut self, contract: &QualifiedContractIdentifier, content_hash: [u8; 32]) {
         let key = MarfedKV::make_contract_hash_key(contract);
-        self.put(&key, content_hash)
+        let value = self.store.make_contract_commitment(content_hash);
+        self.put(&key, &value)
     }
 
     pub fn insert_metadata(&mut self, contract: &QualifiedContractIdentifier, key: &str, value: &str) {

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -1,4 +1,4 @@
-use super::MarfedKV;
+use super::{MarfedKV, ClarityBackingStore};
 use vm::errors::{ InterpreterResult as Result };
 use chainstate::burn::BlockHeaderHash;
 use std::collections::{HashMap};
@@ -12,7 +12,7 @@ pub struct RollbackContext {
 
 pub struct RollbackWrapper <'a> {
     // the underlying key-value storage.
-    store: &'a mut MarfedKV,
+    store: &'a mut dyn ClarityBackingStore,
     // lookup_map is a history of edits for a given key.
     //   in order of least-recent to most-recent at the tail.
     //   this allows ~ O(1) lookups, and ~ O(1) commits, roll-backs (amortized by # of PUTs).
@@ -43,7 +43,7 @@ where T: Eq + Hash + Clone {
 }
 
 impl <'a> RollbackWrapper <'a> {
-    pub fn new(store: &'a mut MarfedKV) -> RollbackWrapper {
+    pub fn new(store: &'a mut dyn ClarityBackingStore) -> RollbackWrapper {
         RollbackWrapper {
             store: store,
             lookup_map: HashMap::new(),

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -2,6 +2,7 @@ use super::{MarfedKV, ClarityBackingStore};
 use vm::errors::{ InterpreterResult as Result };
 use chainstate::burn::BlockHeaderHash;
 use std::collections::{HashMap};
+use util::hash::{Sha512Trunc256Sum};
 use vm::types::QualifiedContractIdentifier;
 use std::{cmp::Eq, hash::Hash, clone::Clone};
 
@@ -154,7 +155,7 @@ impl <'a> RollbackWrapper <'a> {
             .or_else(|| self.store.get(key))
     }
 
-    pub fn prepare_for_contract_metadata(&mut self, contract: &QualifiedContractIdentifier, content_hash: [u8; 32]) {
+    pub fn prepare_for_contract_metadata(&mut self, contract: &QualifiedContractIdentifier, content_hash: Sha512Trunc256Sum) {
         let key = MarfedKV::make_contract_hash_key(contract);
         let value = self.store.make_contract_commitment(content_hash);
         self.put(&key, &value)

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -157,6 +157,14 @@ impl <S> KeyValueStorage for &mut MarfedKV <S> where S: KeyValueStorage {
             .expect("ERROR: Unexpected MARF Failure")
     }
 
+    fn put_non_consensus(&mut self, key: &str, value: &str) {
+        panic!("Not implemented");
+    }
+
+    fn get_non_consensus(&mut self, key: &str) -> Option<String> {
+        panic!("Not implemented");
+    }
+
     fn get(&mut self, key: &str) -> Option<String> {
         self.marf.get(&self.chain_tip, key)
             .or_else(|e| {

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -227,9 +227,9 @@ impl MarfedKV {
             .ok_or_else(|| { CheckErrors::NoSuchContract(contract.to_string()).into() })
     }
 
-    pub fn get_metadata(&mut self, contract: &QualifiedContractIdentifier, key: &str) -> Option<String> {
-        let (bhh, _) = self.get_contract_hash(contract).ok()?;
-        self.side_store.get_metadata(&bhh, &contract.to_string(), key)
+    pub fn get_metadata(&mut self, contract: &QualifiedContractIdentifier, key: &str) -> Result<Option<String>> {
+        let (bhh, _) = self.get_contract_hash(contract)?;
+        Ok(self.side_store.get_metadata(&bhh, &contract.to_string(), key))
     }
 
     pub fn insert_metadata(&mut self, contract: &QualifiedContractIdentifier, key: &str, value: &str) -> bool {

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -63,14 +63,14 @@ pub trait ClarityBackingStore {
     /// This function is used to obtain a committed contract hash, and the block header hash of the block
     ///   in which the contract was initialized. This data is used to store contract metadata in the side
     ///   store.
-    fn get_contract_hash(&mut self, contract: &QualifiedContractIdentifier) -> Result<(BlockHeaderHash, String)> {
+    fn get_contract_hash(&mut self, contract: &QualifiedContractIdentifier) -> Result<(BlockHeaderHash, Sha512Trunc256Sum)> {
         let key = MarfedKV::make_contract_hash_key(contract);
         let contract_commitment = self.get(&key).map(|x| ContractCommitment::deserialize(&x))
             .ok_or_else(|| { CheckErrors::NoSuchContract(contract.to_string()) })?;
         let ContractCommitment { block_height, hash: contract_hash } = contract_commitment;
         let bhh = self.get_block_at_height(block_height)
             .expect("Should always be able to map from height to block hash when looking up contract information.");
-        Ok((bhh, contract_hash.to_hex()))
+        Ok((bhh, contract_hash))
     }
 
     fn insert_metadata(&mut self, contract: &QualifiedContractIdentifier, key: &str, value: &str) {

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -187,13 +187,10 @@ impl MarfedKV {
         self.side_store.rollback(&self.chain_tip);
         self.chain_tip = TrieFileStorage::block_sentinel();
     }
-    pub fn commit(&mut self) {
-        debug!("_metadata_ COMMIT()"); 
-        // AARON: I'm not sure this path should be considered 'legal' anymore,
-        //     and may want to delete or panic.
-        self.side_store.commit(&self.chain_tip);
-        self.marf.commit()
-            .expect("ERROR: Failed to commit MARF block");
+    #[cfg(test)]
+    pub fn test_commit(&mut self) {
+        let bhh = self.chain_tip.clone();
+        self.commit_to(&bhh);
     }
     // This is used by miners, before renaming their committed blocks.
     //   so that the block validation and processing logic doesn't

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -10,4 +10,4 @@ pub use self::key_value_wrapper::{RollbackWrapper};
 pub use self::clarity_db::{ClarityDatabase};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};
-pub use self::marf::{sqlite_marf, in_memory_marf, MarfedKV};
+pub use self::marf::{sqlite_marf, in_memory_marf, MarfedKV, ClarityBackingStore};

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -20,6 +20,15 @@ impl KeyValueStorage for HashMap<String, String> {
     fn get(&mut self, key: &str) -> Option<String> {
         (&*self).get(key).cloned()
     }
+
+    fn put_non_consensus(&mut self, key: &str, value: &str) {
+        self.insert(format!("nc::{}", key), value.to_string());
+    }
+    fn get_non_consensus(&mut self, key: &str) -> Option<String> {
+        let key = format!("nc::{}", key);
+        (&*self).get(&key).cloned()
+    }
+
     fn has_entry(&mut self, key: &str) -> bool {
         self.contains_key(key)
     }

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -10,4 +10,4 @@ pub use self::key_value_wrapper::{RollbackWrapper};
 pub use self::clarity_db::{ClarityDatabase};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};
-pub use self::marf::{sqlite_marf, in_memory_marf, MarfedKV, ClarityBackingStore};
+pub use self::marf::{MemoryBackingStore, MarfedKV, ClarityBackingStore};

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -6,9 +6,8 @@ mod key_value_wrapper;
 
 use std::collections::HashMap;
 
-pub use self::key_value_wrapper::{
-    KeyValueStorage, RollbackWrapper };
+pub use self::key_value_wrapper::{RollbackWrapper};
 pub use self::clarity_db::{ClarityDatabase};
-pub use self::structures::{ClaritySerializable, ClarityDeserializable };
+pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};
 pub use self::marf::{sqlite_marf, in_memory_marf, MarfedKV};

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -11,32 +11,4 @@ pub use self::key_value_wrapper::{
 pub use self::clarity_db::{ClarityDatabase};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable };
 pub use self::sqlite::{SqliteConnection};
-pub use self::marf::{sqlite_marf, MarfedKV};
-
-impl KeyValueStorage for HashMap<String, String> {
-    fn put(&mut self, key: &str, value: &str) {
-        self.insert(key.to_string(), value.to_string());
-    }
-    fn get(&mut self, key: &str) -> Option<String> {
-        (&*self).get(key).cloned()
-    }
-
-    fn put_non_consensus(&mut self, key: &str, value: &str) {
-        self.insert(format!("nc::{}", key), value.to_string());
-    }
-    fn get_non_consensus(&mut self, key: &str) -> Option<String> {
-        let key = format!("nc::{}", key);
-        (&*self).get(&key).cloned()
-    }
-
-    fn has_entry(&mut self, key: &str) -> bool {
-        self.contains_key(key)
-    }
-}
-
-pub fn memory_db<'a>() -> ClarityDatabase<'a> {
-    let store: HashMap<String, String> = HashMap::new();
-    let mut db = ClarityDatabase::new(Box::new(store));
-    db.initialize();
-    db
-}
+pub use self::marf::{sqlite_marf, in_memory_marf, MarfedKV};

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -2,7 +2,6 @@ use rusqlite::{Connection, OptionalExtension, NO_PARAMS, Row, Savepoint};
 use rusqlite::types::{ToSql, FromSql};
 
 use chainstate::burn::BlockHeaderHash;
-use vm::database::{KeyValueStorage};
 
 use vm::contracts::Contract;
 use vm::errors::{Error, InterpreterError, RuntimeErrorType, InterpreterResult as Result, IncomparableError};
@@ -32,40 +31,40 @@ fn sqlite_has_entry(conn: &Connection, key: &str) -> bool {
     sqlite_get(conn, key).is_some()
 }
 
-impl KeyValueStorage for SqliteConnection {
-    fn put(&mut self, key: &str, value: &str) {
+impl SqliteConnection {
+    pub fn put(&mut self, key: &str, value: &str) {
         sqlite_put(&self.conn, key, value)
     }
 
-    fn get(&mut self, key: &str) -> Option<String> {
+    pub fn get(&mut self, key: &str) -> Option<String> {
         sqlite_get(&self.conn, key)
     }
 
-    fn put_non_consensus(&mut self, key: &str, value: &str) {
+    pub fn put_non_consensus(&mut self, key: &str, value: &str) {
         let key = format!("nc::{}", key);
         sqlite_put(&self.conn, &key, value)
     }
 
-    fn get_non_consensus(&mut self, key: &str) -> Option<String> {
+    pub fn get_non_consensus(&mut self, key: &str) -> Option<String> {
         let key = format!("nc::{}", key);
         sqlite_get(&self.conn, &key)
     }
 
-    fn has_entry(&mut self, key: &str) -> bool {
+    pub fn has_entry(&mut self, key: &str) -> bool {
         sqlite_has_entry(&self.conn, key)
     }
 
-    fn begin(&mut self, key: &BlockHeaderHash) {
+    pub fn begin(&mut self, key: &BlockHeaderHash) {
         self.conn.execute(&format!("SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
             .expect(SQL_FAIL_MESSAGE);
     }
 
-    fn rollback(&mut self, key: &BlockHeaderHash) {
+    pub fn rollback(&mut self, key: &BlockHeaderHash) {
         self.conn.execute(&format!("ROLLBACK TO SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
             .expect(SQL_FAIL_MESSAGE);
     }
 
-    fn commit(&mut self, key: &BlockHeaderHash) {
+    pub fn commit(&mut self, key: &BlockHeaderHash) {
         self.conn.execute(&format!("RELEASE SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
             .expect(SQL_FAIL_MESSAGE);
     }

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, OptionalExtension, NO_PARAMS, Row, Savepoint};
+use rusqlite::{ErrorCode as SqliteErrorCode, Error as SqliteError, Connection, OptionalExtension, NO_PARAMS, Row, Savepoint};
 use rusqlite::types::{ToSql, FromSql};
 
 use chainstate::burn::BlockHeaderHash;
@@ -13,11 +13,12 @@ pub struct SqliteConnection {
 }
 
 fn sqlite_put(conn: &Connection, key: &str, value: &str) {
-    let params: [&dyn ToSql; 2] = [&key, &value.to_string()];
+    let params: [&dyn ToSql; 2] = [&key, &value];
     conn.execute("REPLACE INTO data_table (key, value) VALUES (?, ?)",
                       &params)
         .expect(SQL_FAIL_MESSAGE);
 }
+
 fn sqlite_get(conn: &Connection, key: &str) -> Option<String> {
     let params: [&dyn ToSql; 1] = [&key];
     conn.query_row(
@@ -40,19 +41,58 @@ impl SqliteConnection {
         sqlite_get(&self.conn, key)
     }
 
-    pub fn put_non_consensus(&mut self, key: &str, value: &str) {
-        let key = format!("nc::{}", key);
-        sqlite_put(&self.conn, &key, value)
+    pub fn insert_metadata(&mut self, contract_hash: &str, key: &str, value: &str) -> bool {
+        let blockhash: Option<String> = None;
+        let key = format!("clr-meta::{}::{}", contract_hash, key);
+        let params: [&dyn ToSql; 3] = [&blockhash, &key, &value.to_string()];
+
+        match self.conn.execute("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)", &params) {
+            Ok(_) => true,
+            Err(SqliteError::SqliteFailure(e, _)) => {
+                if e.code == SqliteErrorCode::ConstraintViolation {
+                    false
+                } else {
+                    panic!(SQL_FAIL_MESSAGE)
+                }
+            },
+            _ => panic!(SQL_FAIL_MESSAGE)
+        }
     }
 
-    pub fn get_non_consensus(&mut self, key: &str) -> Option<String> {
-        let key = format!("nc::{}", key);
-        sqlite_get(&self.conn, &key)
+    pub fn commit_metadata_to(&mut self, bhh: &BlockHeaderHash) {
+        let bhh = Some(bhh.to_hex());
+        let params = [&bhh];
+        let rows_updated = self.conn.execute(
+            "UPDATE metadata_table SET blockhash = ? WHERE blockhash IS NULL",
+            &params)
+            .expect(SQL_FAIL_MESSAGE);
+        debug!("{} metadata rows committed to blockhash: {}", rows_updated, bhh.unwrap());
+    }
+
+    pub fn get_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str) -> Option<String> {
+        let bhh = Some(bhh.to_hex());
+        let key = format!("clr-meta::{}::{}", contract_hash, key);
+        let params: [&dyn ToSql; 2] = [&bhh, &key];
+        self.conn.query_row(
+            "SELECT value FROM metadata_table WHERE blockhash = ? AND key = ?",
+            &params,
+            |row| row.get(0))
+            .optional()
+            .expect(SQL_FAIL_MESSAGE)
     }
 
     pub fn has_entry(&mut self, key: &str) -> bool {
         sqlite_has_entry(&self.conn, key)
     }
+
+    /// begin, commit, rollback a save point identified by key
+    ///    this is used to clean up any data from aborted blocks
+    ///     (NOT aborted transactions that is handled by the clarity vm directly).
+    /// The block header hash is used for identifying savepoints.
+    ///     this _cannot_ be used to rollback to arbitrary prior block hash, because that
+    ///     blockhash would already have committed and no longer exist in the save point stack.
+    /// this is a "lower-level" rollback than the roll backs performed in
+    ///   ClarityDatabase or AnalysisDatabase -- this is done at the backing store level.
 
     pub fn begin(&mut self, key: &BlockHeaderHash) {
         self.conn.execute(&format!("SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
@@ -77,6 +117,12 @@ impl SqliteConnection {
         contract_db.conn.execute("CREATE TABLE IF NOT EXISTS data_table
                       (key TEXT PRIMARY KEY, value TEXT)", NO_PARAMS)
             .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
+
+        contract_db.conn.execute("CREATE TABLE IF NOT EXISTS metadata_table
+                      (key TEXT NOT NULL, blockhash TEXT, value TEXT)
+                      UNIQUE (key, blockhash)", NO_PARAMS)
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
+
         contract_db.check_schema()?;
 
         Ok(contract_db)
@@ -93,6 +139,9 @@ impl SqliteConnection {
     pub fn check_schema(&self) -> Result<()> {
         let sql = "SELECT sql FROM sqlite_master WHERE name=?";
         let _: String = self.conn.query_row(sql, &["data_table"],
+                                            |row| row.get(0))
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
+        let _: String = self.conn.query_row(sql, &["metadata_table"],
                                             |row| row.get(0))
             .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
         Ok(())

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -42,7 +42,7 @@ impl SqliteConnection {
     }
 
     pub fn insert_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str, value: &str) -> bool {
-        println!("insert_metadata: {}, {}", contract_hash, key);
+        debug!("insert_metadata: {}, {}, {}", bhh, contract_hash, key);
 
         let blockhash = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);
@@ -67,11 +67,20 @@ impl SqliteConnection {
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
             &params)
             .expect(SQL_FAIL_MESSAGE);
-        debug!("{} metadata rows committed to blockhash: {} => {}", rows_updated, from, to);
+        debug!("commit_metadata {} rows committed to blockhash: {} => {}", rows_updated, from, to);
+    }
+
+    pub fn move_metadata_to(&mut self, from: &BlockHeaderHash, to: &str) {
+        let params = [to.to_string(), from.to_hex()];
+        let rows_updated = self.conn.execute(
+            "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
+            &params)
+            .expect(SQL_FAIL_MESSAGE);
+        debug!("move_metadata {} rows moved to: {} => {}", rows_updated, from, to);
     }
 
     pub fn get_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str) -> Option<String> {
-        println!("get_metadata: {}, {}, {}", bhh, contract_hash, key);
+        debug!("get_metadata: {}, {}, {}", bhh, contract_hash, key);
 
         let bhh = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -41,24 +41,15 @@ impl SqliteConnection {
         sqlite_get(&self.conn, key)
     }
 
-    pub fn insert_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str, value: &str) -> bool {
+    pub fn insert_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str, value: &str) {
         debug!("insert_metadata: {}, {}, {}", bhh, contract_hash, key);
 
         let blockhash = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);
         let params: [&dyn ToSql; 3] = [&blockhash, &key, &value.to_string()];
 
-        match self.conn.execute("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)", &params) {
-            Ok(_) => true,
-            Err(SqliteError::SqliteFailure(e, _)) => {
-                if e.code == SqliteErrorCode::ConstraintViolation {
-                    false
-                } else {
-                    panic!(SQL_FAIL_MESSAGE)
-                }
-            },
-            _ => panic!(SQL_FAIL_MESSAGE)
-        }
+        self.conn.execute("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)", &params)
+            .expect(SQL_FAIL_MESSAGE);
     }
 
     pub fn commit_metadata_to(&mut self, from: &BlockHeaderHash, to: &BlockHeaderHash) {

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -41,6 +41,16 @@ impl KeyValueStorage for SqliteConnection {
         sqlite_get(&self.conn, key)
     }
 
+    fn put_non_consensus(&mut self, key: &str, value: &str) {
+        let key = format!("nc::{}", key);
+        sqlite_put(&self.conn, &key, value)
+    }
+
+    fn get_non_consensus(&mut self, key: &str) -> Option<String> {
+        let key = format!("nc::{}", key);
+        sqlite_get(&self.conn, &key)
+    }
+
     fn has_entry(&mut self, key: &str) -> bool {
         sqlite_has_entry(&self.conn, key)
     }

--- a/src/vm/database/structures.rs
+++ b/src/vm/database/structures.rs
@@ -28,7 +28,6 @@ macro_rules! clarity_serializable {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FungibleTokenMetadata {
     pub total_supply: Option<u128>

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -28,7 +28,7 @@ use vm::contexts::{ContractContext, LocalContext, Environment, CallStack};
 use vm::contexts::{GlobalContext};
 use vm::functions::define::DefineResult;
 use vm::errors::{Error, InterpreterError, RuntimeErrorType, CheckErrors, InterpreterResult as Result};
-use vm::database::{memory_db};
+use vm::database::{in_memory_marf};
 use vm::types::QualifiedContractIdentifier;
 
 pub use vm::representations::{SymbolicExpression, SymbolicExpressionType, ClarityName, ContractName};
@@ -203,7 +203,8 @@ fn eval_all (expressions: &[SymbolicExpression],
 pub fn execute(program: &str) -> Result<Option<Value>> {
     let contract_id = QualifiedContractIdentifier::transient();
     let mut contract_context = ContractContext::new(contract_id.clone());
-    let conn = memory_db();
+    let mut marf = in_memory_marf();
+    let conn = marf.as_clarity_db();
     let mut global_context = GlobalContext::new(conn);
     global_context.execute(|g| {
         let parsed = ast::parse(&contract_id, program)?;
@@ -214,7 +215,7 @@ pub fn execute(program: &str) -> Result<Option<Value>> {
 
 #[cfg(test)]
 mod test {
-    use vm::database::memory_db;
+    use vm::database::in_memory_marf;
     use vm::{Value, LocalContext, GlobalContext, ContractContext, Environment, SymbolicExpression, CallStack};
     use vm::types::{TypeSignature, QualifiedContractIdentifier};
     use vm::callables::{DefinedFunction, DefineType};
@@ -243,7 +244,9 @@ mod test {
 
         let context = LocalContext::new();
         let mut contract_context = ContractContext::new(QualifiedContractIdentifier::transient());
-        let mut global_context = GlobalContext::new(memory_db());
+
+        let mut marf = in_memory_marf();
+        let mut global_context = GlobalContext::new(marf.as_clarity_db());
 
         contract_context.variables.insert("a".into(), Value::Int(59));
         contract_context.functions.insert("do_work".into(), user_function);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -28,7 +28,7 @@ use vm::contexts::{ContractContext, LocalContext, Environment, CallStack};
 use vm::contexts::{GlobalContext};
 use vm::functions::define::DefineResult;
 use vm::errors::{Error, InterpreterError, RuntimeErrorType, CheckErrors, InterpreterResult as Result};
-use vm::database::{in_memory_marf};
+use vm::database::MemoryBackingStore;
 use vm::types::QualifiedContractIdentifier;
 
 pub use vm::representations::{SymbolicExpression, SymbolicExpressionType, ClarityName, ContractName};
@@ -203,7 +203,7 @@ fn eval_all (expressions: &[SymbolicExpression],
 pub fn execute(program: &str) -> Result<Option<Value>> {
     let contract_id = QualifiedContractIdentifier::transient();
     let mut contract_context = ContractContext::new(contract_id.clone());
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let conn = marf.as_clarity_db();
     let mut global_context = GlobalContext::new(conn);
     global_context.execute(|g| {
@@ -215,7 +215,7 @@ pub fn execute(program: &str) -> Result<Option<Value>> {
 
 #[cfg(test)]
 mod test {
-    use vm::database::in_memory_marf;
+    use vm::database::{MemoryBackingStore};
     use vm::{Value, LocalContext, GlobalContext, ContractContext, Environment, SymbolicExpression, CallStack};
     use vm::types::{TypeSignature, QualifiedContractIdentifier};
     use vm::callables::{DefinedFunction, DefineType};
@@ -245,7 +245,7 @@ mod test {
         let context = LocalContext::new();
         let mut contract_context = ContractContext::new(QualifiedContractIdentifier::transient());
 
-        let mut marf = in_memory_marf();
+        let mut marf = MemoryBackingStore::new();
         let mut global_context = GlobalContext::new(marf.as_clarity_db());
 
         contract_context.variables.insert("a".into(), Value::Int(59));

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -7,7 +7,7 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::temporary_marf;
+use vm::database::marf::in_memory_marf;
 use vm::database::ClarityDatabase;
 
 use vm::tests::{with_memory_environment, with_marfed_environment, execute, symbols_from_values};
@@ -96,7 +96,8 @@ fn test_get_block_info_eval() {
     ];
 
     for i in 0..contracts.len() {
-        let mut owned_env = OwnedEnvironment::memory();
+        let mut marf = in_memory_marf();
+        let mut owned_env = OwnedEnvironment::new(marf.as_clarity_db());
         let contract_identifier = QualifiedContractIdentifier::local("test-contract").unwrap();
         owned_env.initialize_contract(contract_identifier.clone(), contracts[i]).unwrap();
 

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -7,7 +7,7 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::in_memory_marf;
+use vm::database::marf::MemoryBackingStore;
 use vm::database::ClarityDatabase;
 
 use vm::tests::{with_memory_environment, with_marfed_environment, execute, symbols_from_values};
@@ -96,7 +96,7 @@ fn test_get_block_info_eval() {
     ];
 
     for i in 0..contracts.len() {
-        let mut marf = in_memory_marf();
+        let mut marf = MemoryBackingStore::new();
         let mut owned_env = OwnedEnvironment::new(marf.as_clarity_db());
         let contract_identifier = QualifiedContractIdentifier::local("test-contract").unwrap();
         owned_env.initialize_contract(contract_identifier.clone(), contracts[i]).unwrap();

--- a/src/vm/tests/datamaps.rs
+++ b/src/vm/tests/datamaps.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use vm::errors::{Error, CheckErrors, RuntimeErrorType, ShortReturnType};
 use vm::types::{Value, TupleData, TypeSignature, QualifiedContractIdentifier, StandardPrincipalData, ListData, TupleTypeSignature};
 use vm::contexts::{OwnedEnvironment};
-use vm::database::in_memory_marf;
+use vm::database::MemoryBackingStore;
 use vm::execute;
 
 fn assert_executes(expected: Result<Value, Error>, input: &str) {
@@ -195,7 +195,7 @@ fn test_fetch_contract_entry() {
             (let ((t (tuple (key 42))))
             (unwrap! (get value (contract-map-get? .kv-store-contract kv-store t)) 0)))"#;
 
-    let mut marf = in_memory_marf();
+    let mut marf = MemoryBackingStore::new();
     let mut owned_env = OwnedEnvironment::new(marf.as_clarity_db());
 
     let sender = StandardPrincipalData::transient().into();

--- a/src/vm/tests/datamaps.rs
+++ b/src/vm/tests/datamaps.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use vm::errors::{Error, CheckErrors, RuntimeErrorType, ShortReturnType};
 use vm::types::{Value, TupleData, TypeSignature, QualifiedContractIdentifier, StandardPrincipalData, ListData, TupleTypeSignature};
 use vm::contexts::{OwnedEnvironment};
+use vm::database::in_memory_marf;
 use vm::execute;
 
 fn assert_executes(expected: Result<Value, Error>, input: &str) {
@@ -194,7 +195,8 @@ fn test_fetch_contract_entry() {
             (let ((t (tuple (key 42))))
             (unwrap! (get value (contract-map-get? .kv-store-contract kv-store t)) 0)))"#;
 
-    let mut owned_env = OwnedEnvironment::memory();
+    let mut marf = in_memory_marf();
+    let mut owned_env = OwnedEnvironment::new(marf.as_clarity_db());
 
     let sender = StandardPrincipalData::transient().into();
     let mut env = owned_env.get_exec_environment(Some(sender));

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -3,7 +3,7 @@ use vm::analysis::errors::{CheckErrors};
 use vm::types::{Value};
 use vm::contexts::{OwnedEnvironment};
 use vm::representations::SymbolicExpression;
-use vm::database::marf::temporary_marf;
+use vm::database::marf::MarfedKV;
 use vm::database::ClarityDatabase;
 use vm::types::{QualifiedContractIdentifier, PrincipalData};
 
@@ -167,7 +167,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
       F2: FnOnce(&mut OwnedEnvironment),
       F3: FnOnce(&mut OwnedEnvironment)
 {
-    let mut marf_kv = temporary_marf();
+    let mut marf_kv = MarfedKV::temporary();
     marf_kv.begin(&TrieFileStorage::block_sentinel(),
                   &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
 

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -172,8 +172,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
 
     {
-        let mut clarity_db = ClarityDatabase::new(Box::new(&mut marf_kv));
-        clarity_db.initialize();
+        marf_kv.as_clarity_db().initialize();
     }
 
     marf_kv.commit();
@@ -181,8 +180,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap());
 
     {
-        let clarity_db = ClarityDatabase::new(Box::new(&mut marf_kv));
-        let mut owned_env = OwnedEnvironment::new(clarity_db);
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
         f(&mut owned_env)
     }
 
@@ -194,8 +192,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[2 as u8; 32]).unwrap());
 
     {
-        let clarity_db = ClarityDatabase::new(Box::new(&mut marf_kv));
-        let mut owned_env = OwnedEnvironment::new(clarity_db);
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
         a(&mut owned_env)
     }
 
@@ -205,8 +202,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[3 as u8; 32]).unwrap());
 
     {
-        let clarity_db = ClarityDatabase::new(Box::new(&mut marf_kv));
-        let mut owned_env = OwnedEnvironment::new(clarity_db);
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
         b(&mut owned_env)
     }
 
@@ -217,8 +213,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[4 as u8; 32]).unwrap());
 
     {
-        let clarity_db = ClarityDatabase::new(Box::new(&mut marf_kv));
-        let mut owned_env = OwnedEnvironment::new(clarity_db);
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
         z(&mut owned_env)
     }
 

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -148,7 +148,7 @@ fn test_at_block_missing_defines() {
         |_| {},
         |env| {
             let err = initialize_3(env);
-            assert_eq!(err, CheckErrors::NoSuchContract("'S1G2081040G2081040G2081040G208105NK8PE5.contract-a".into()).into());
+            assert_eq!(err, CheckErrors::NoSuchMap("datum".into()).into());
         });
 
 }

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -175,7 +175,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
         marf_kv.as_clarity_db().initialize();
     }
 
-    marf_kv.commit();
+    marf_kv.test_commit();
     marf_kv.begin(&BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
                   &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap());
 
@@ -184,7 +184,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
         f(&mut owned_env)
     }
 
-    marf_kv.commit();
+    marf_kv.test_commit();
 
     // Now, we can do our forking.
 
@@ -196,7 +196,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
         a(&mut owned_env)
     }
 
-    marf_kv.commit();
+    marf_kv.test_commit();
 
     marf_kv.begin(&BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap(),
                   &BlockHeaderHash::from_bytes(&[3 as u8; 32]).unwrap());
@@ -206,7 +206,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
         b(&mut owned_env)
     }
 
-    marf_kv.commit();
+    marf_kv.test_commit();
 
 
     marf_kv.begin(&BlockHeaderHash::from_bytes(&[2 as u8; 32]).unwrap(),
@@ -217,7 +217,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
         z(&mut owned_env)
     }
 
-    marf_kv.commit();
+    marf_kv.test_commit();
     
 }
 

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -148,7 +148,7 @@ fn test_at_block_missing_defines() {
         |_| {},
         |env| {
             let err = initialize_3(env);
-            assert_eq!(err, CheckErrors::NoSuchMap("datum".into()).into());
+            assert_eq!(err, CheckErrors::NoSuchContract("'S1G2081040G2081040G2081040G208105NK8PE5.contract-a".into()).into());
         });
 
 }

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -22,7 +22,7 @@ mod contracts;
 pub fn with_memory_environment<F>(f: F, top_level: bool)
 where F: FnOnce(&mut OwnedEnvironment) -> ()
 {
-    let mut marf_kv = in_memory_marf();
+/*    let mut marf_kv = in_memory_marf();
 
     let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
     // start an initial transaction.
@@ -30,7 +30,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
         owned_env.begin();
     }
 
-    f(&mut owned_env)
+    f(&mut owned_env)*/
 }
 
 pub fn with_marfed_environment<F>(f: F, top_level: bool)

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -44,7 +44,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
         marf_kv.as_clarity_db().initialize();
     }
 
-    marf_kv.commit();
+    marf_kv.test_commit();
     marf_kv.begin(&BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
                   &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap());
 

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -5,7 +5,7 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::in_memory_marf;
+use vm::database::marf::{ in_memory_marf, temporary_marf };
 use vm::database::ClarityDatabase;
 
 use chainstate::stacks::index::storage::{TrieFileStorage};
@@ -23,6 +23,7 @@ pub fn with_memory_environment<F>(f: F, top_level: bool)
 where F: FnOnce(&mut OwnedEnvironment) -> ()
 {
     let mut marf_kv = in_memory_marf();
+
     let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
     // start an initial transaction.
     if !top_level {
@@ -35,7 +36,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
 pub fn with_marfed_environment<F>(f: F, top_level: bool)
 where F: FnOnce(&mut OwnedEnvironment) -> ()
 {
-    let mut marf_kv = in_memory_marf();
+    let mut marf_kv = temporary_marf();
     marf_kv.begin(&TrieFileStorage::block_sentinel(),
                   &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
 

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -5,7 +5,7 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::{ in_memory_marf, temporary_marf };
+use vm::database::marf::{ MarfedKV, MemoryBackingStore };
 use vm::database::ClarityDatabase;
 
 use chainstate::stacks::index::storage::{TrieFileStorage};
@@ -22,7 +22,7 @@ mod contracts;
 pub fn with_memory_environment<F>(f: F, top_level: bool)
 where F: FnOnce(&mut OwnedEnvironment) -> ()
 {
-    let mut marf_kv = in_memory_marf();
+    let mut marf_kv = MemoryBackingStore::new();
 
     let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
     // start an initial transaction.
@@ -36,7 +36,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
 pub fn with_marfed_environment<F>(f: F, top_level: bool)
 where F: FnOnce(&mut OwnedEnvironment) -> ()
 {
-    let mut marf_kv = temporary_marf();
+    let mut marf_kv = MarfedKV::temporary();
     marf_kv.begin(&TrieFileStorage::block_sentinel(),
                   &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
 

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -22,7 +22,7 @@ mod contracts;
 pub fn with_memory_environment<F>(f: F, top_level: bool)
 where F: FnOnce(&mut OwnedEnvironment) -> ()
 {
-/*    let mut marf_kv = in_memory_marf();
+    let mut marf_kv = in_memory_marf();
 
     let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
     // start an initial transaction.
@@ -30,7 +30,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
         owned_env.begin();
     }
 
-    f(&mut owned_env)*/
+    f(&mut owned_env)
 }
 
 pub fn with_marfed_environment<F>(f: F, top_level: bool)

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -1,5 +1,5 @@
 use vm::{eval, execute as vm_execute};
-use vm::database::memory_db;
+use vm::database::in_memory_marf;
 use vm::errors::{CheckErrors, ShortReturnType, RuntimeErrorType, Error};
 use vm::{Value, LocalContext, ContractContext, GlobalContext, Environment, CallStack};
 use vm::contexts::{OwnedEnvironment};
@@ -29,7 +29,8 @@ fn test_simple_let() {
     let contract_id = QualifiedContractIdentifier::transient();
     if let Ok(parsed_program) = parse(&contract_id, &program) {
         let context = LocalContext::new();
-        let mut env = OwnedEnvironment::memory();
+        let mut marf = in_memory_marf();
+        let mut env = OwnedEnvironment::new(marf.as_clarity_db());
 
         assert_eq!(Ok(Value::Int(7)), eval(&parsed_program[0], &mut env.get_exec_environment(None), &context));
     } else {
@@ -198,7 +199,8 @@ fn test_simple_if_functions() {
 
         let context = LocalContext::new();
         let mut contract_context = ContractContext::new(QualifiedContractIdentifier::transient());
-        let mut global_context = GlobalContext::new(memory_db());
+        let mut marf = in_memory_marf();
+        let mut global_context = GlobalContext::new(marf.as_clarity_db());
 
         contract_context.functions.insert("with_else".into(), user_function1);
         contract_context.functions.insert("without_else".into(), user_function2);

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -1,5 +1,5 @@
 use vm::{eval, execute as vm_execute};
-use vm::database::in_memory_marf;
+use vm::database::MemoryBackingStore;
 use vm::errors::{CheckErrors, ShortReturnType, RuntimeErrorType, Error};
 use vm::{Value, LocalContext, ContractContext, GlobalContext, Environment, CallStack};
 use vm::contexts::{OwnedEnvironment};
@@ -29,7 +29,7 @@ fn test_simple_let() {
     let contract_id = QualifiedContractIdentifier::transient();
     if let Ok(parsed_program) = parse(&contract_id, &program) {
         let context = LocalContext::new();
-        let mut marf = in_memory_marf();
+        let mut marf = MemoryBackingStore::new();
         let mut env = OwnedEnvironment::new(marf.as_clarity_db());
 
         assert_eq!(Ok(Value::Int(7)), eval(&parsed_program[0], &mut env.get_exec_environment(None), &context));
@@ -199,7 +199,7 @@ fn test_simple_if_functions() {
 
         let context = LocalContext::new();
         let mut contract_context = ContractContext::new(QualifiedContractIdentifier::transient());
-        let mut marf = in_memory_marf();
+        let mut marf = MemoryBackingStore::new();
         let mut global_context = GlobalContext::new(marf.as_clarity_db());
 
         contract_context.functions.insert("with_else".into(), user_function1);


### PR DESCRIPTION
This PR does a couple of things, with the goal of removing non-consensus critical information from the MARF commitments (see #1208 and #1206).

### 1. Remove storage generics from Clarity VM, analysis codebases

The generics weren't doing much, and were growing increasingly cumbersome as more and more behavior started to depend on a connection to the MARF. Should we need to re-genericize for a future project like a WASM build, IDE-connection, etc., we'll likely want to implement a higher-level trait that provides the `vm::database::MarfedKV` interface rather than the simple key-value interface we used to use.

### 2. Store metadata in the sidestore, but not the MARF

This is achieved by storing a contract commitment to the MARF when the contract is initialized. This is a hash of the contract string (this required altering the interface of `vm::clarity::ClarityBlockConnection` such that the contract string is passed at initialization, rather than just the AST). The contract commitment is the contract hash _and_ the current block height. Metadata associated with the contract is keyed by the blockhash and the contract identifier.

Looking up metadata requires figuring out the blockhash that the contract was initialized during -- this is a MARF lookup for the contract commitment, which returns the block height, which can then be used to determine the block hash.

### 3. Update metadata keying on blockhash saves, or renames

Keying metadata by blockhash is all well and good, but it requires having the correct blockhash. This keying is updated when the block is committed (using the `vm::clarity::ClarityBlockConnection::commit_to_block` function). For the _miner_ block assembly, the metadata in the ".mined" block also needs to be rekeyed, otherwise it gets in the way when the miner reprocesses their block.

### 4. panic! on simming methods in CLI

The updates above affected the block simulation codepaths. I did not update them, because #1207 will be coming shortly, and it seemed like a waste to try and patch functions which will be changed much more radically soon enough. These CLI methods now panic.
