### PR TITLE
Unsim Block Info Functions

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -549,7 +549,7 @@ pub mod test {
         }
 
         pub fn make_proof(&self, vrf_pubkey: &VRFPublicKey, last_sortition_hash: &SortitionHash) -> Option<VRFProof> {
-            test_debug!("Make proof from {} over {}", vrf_pubkey.to_hex(), last_sortition_hash.to_hex());
+            test_debug!("Make proof from {} over {}", vrf_pubkey.to_hex(), last_sortition_hash);
             match self.vrf_key_map.get(vrf_pubkey) {
                 Some(ref prover_key) => {
                     let proof = VRF::prove(prover_key, &last_sortition_hash.as_bytes().to_vec());
@@ -767,7 +767,7 @@ pub mod test {
             
             // this is basically lifted verbatum from Burnchain::process_block_ops()
 
-            test_debug!("Process block {} {}", block.block_height(), &block.block_hash().to_hex());
+            test_debug!("Process block {} {}", block.block_height(), &block.block_hash());
 
             let (header, parent_snapshot) = Burnchain::get_burnchain_block_attachment_info(tx, &block).expect("FATAL: failed to get burnchain linkage info");
             let mut blockstack_txs = self.txs.clone();
@@ -803,7 +803,7 @@ pub mod test {
         }
 
         pub fn get_tip<'a>(&mut self, tx: &mut BurnDBTx<'a>) -> BlockSnapshot {
-            test_debug!("Get tip snapshot at {}", &self.tip_header_hash.to_hex());
+            test_debug!("Get tip snapshot at {}", &self.tip_header_hash);
             BurnDB::get_block_snapshot(tx, &self.tip_header_hash).unwrap().unwrap()
         }
 

--- a/src/chainstate/burn/db/burndb.rs
+++ b/src/chainstate/burn/db/burndb.rs
@@ -574,8 +574,8 @@ impl BurnDB {
         assert!(snapshot.block_height < BLOCK_HEIGHT_MAX);
         assert!(snapshot.num_sortitions < BLOCK_HEIGHT_MAX);
 
-        test_debug!("Insert block snapshot state {} for block {} ({},{}) {}", snapshot.index_root.to_hex(), snapshot.block_height,
-                    snapshot.burn_header_hash.to_hex(), snapshot.parent_burn_header_hash.to_hex(), snapshot.num_sortitions);
+        test_debug!("Insert block snapshot state {} for block {} ({},{}) {}", snapshot.index_root, snapshot.block_height,
+                    snapshot.burn_header_hash, snapshot.parent_burn_header_hash, snapshot.num_sortitions);
 
         let total_burn_str = format!("{}", snapshot.total_burn);
 
@@ -594,17 +594,17 @@ impl BurnDB {
     fn store_burnchain_transaction<'a>(tx: &mut BurnDBTx<'a>, blockstack_op: &BlockstackOperationType) -> Result<(), db_error> {
         match blockstack_op {
             BlockstackOperationType::LeaderKeyRegister(ref op) => {
-                info!("ACCEPTED({}) leader key register {} at {},{}", op.block_height, &op.txid.to_hex(), op.block_height, op.vtxindex);
+                info!("ACCEPTED({}) leader key register {} at {},{}", op.block_height, &op.txid, op.block_height, op.vtxindex);
                 BurnDB::insert_leader_key(tx, op)
                     .expect("FATAL: failed to store leader key to Sqlite");
             },
             BlockstackOperationType::LeaderBlockCommit(ref op) => {
-                info!("ACCEPTED({}) leader block commit {} at {},{}", op.block_height, &op.txid.to_hex(), op.block_height, op.vtxindex);
+                info!("ACCEPTED({}) leader block commit {} at {},{}", op.block_height, &op.txid, op.block_height, op.vtxindex);
                 BurnDB::insert_block_commit(tx, op)
                     .expect("FATAL: failed to store leader block commit to Sqlite");
             },
             BlockstackOperationType::UserBurnSupport(ref op) => {
-                info!("ACCEPTED({}) user burn support {} at {},{}", op.block_height, &op.txid.to_hex(), op.block_height, op.vtxindex);
+                info!("ACCEPTED({}) user burn support {} at {},{}", op.block_height, &op.txid, op.block_height, op.vtxindex);
                 BurnDB::insert_user_burn(tx, op)
                     .expect("FATAL: failed to store user burn support to Sqlite");
             }
@@ -712,7 +712,7 @@ impl BurnDB {
             keys.push("burndb::last_sortition".to_string());
             values.push(snapshot.burn_header_hash.to_hex());
 
-            keys.push(format!("burndb::sortition_block_hash::{}", snapshot.winning_stacks_block_hash.to_hex()));
+            keys.push(format!("burndb::sortition_block_hash::{}", snapshot.winning_stacks_block_hash));
             values.push(snapshot.burn_header_hash.to_hex());
         }
 
@@ -782,7 +782,7 @@ impl BurnDB {
                 BurnchainHeaderHash::from(bhh)
             },
             None => {
-                test_debug!("No ancestor block {} from {} in index", ancestor_block_height, tip_block_hash.to_hex());
+                test_debug!("No ancestor block {} from {} in index", ancestor_block_height, tip_block_hash);
                 return Ok(None);
             }
         };
@@ -862,8 +862,8 @@ impl BurnDB {
 
         tx.execute("INSERT INTO user_burn_support (txid, vtxindex, block_height, burn_header_hash, address, consensus_hash, public_key, key_block_ptr, key_vtxindex, block_header_hash_160, burn_fee) \
                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-                   &[&user_burn.txid, &user_burn.vtxindex as &dyn ToSql, &(user_burn.block_height as i64) as &dyn ToSql, &user_burn.burn_header_hash, 
-                   &user_burn.address.to_string(), &user_burn.consensus_hash, &user_burn.public_key.to_hex(), &user_burn.key_block_ptr as &dyn ToSql, &user_burn.key_vtxindex as &dyn ToSql,
+                   &[&user_burn.txid, &user_burn.vtxindex as &dyn ToSql, &(user_burn.block_height as i64), &user_burn.burn_header_hash, 
+                   &user_burn.address.to_string(), &user_burn.consensus_hash, &user_burn.public_key.to_hex(), &user_burn.key_block_ptr, &user_burn.key_vtxindex,
                    &user_burn.block_header_hash_160, &burn_fee_str])
             .map_err(db_error::SqliteError)?;
 
@@ -894,13 +894,13 @@ impl BurnDB {
         let rows = query_rows::<BlockSnapshot, _>(conn, &qry.to_string(), &args)?;
         match rows.len() {
             0 => {
-                test_debug!("No snapshot with burn hash {}", burn_hash.to_hex());
+                test_debug!("No snapshot with burn hash {}", burn_hash);
                 Ok(None)
             },
             1 => Ok(Some(rows[0].clone())),
             _ => {
                 // should never happen 
-                panic!("FATAL: multiple block snapshots for the same block {}", burn_hash.to_hex());
+                panic!("FATAL: multiple block snapshots for the same block {}", burn_hash);
             }
         }
     }
@@ -915,7 +915,7 @@ impl BurnDB {
             1 => Ok(Some(rows[0].clone())),
             _ => {
                 // should never happen 
-                panic!("FATAL: multiple block snapshots for the same block {}", index_root.to_hex());
+                panic!("FATAL: multiple block snapshots for the same block {}", index_root);
             }
         }
     }
@@ -956,7 +956,7 @@ impl BurnDB {
                 sn
             },
             None => {
-                test_debug!("No ancestor snapshot for height {} back from {}", key_block_height, tip_block_hash.to_hex());
+                test_debug!("No ancestor snapshot for height {} back from {}", key_block_height, tip_block_hash);
                 return Ok(None);
             }
         };
@@ -966,14 +966,14 @@ impl BurnDB {
         let rows = query_rows::<LeaderKeyRegisterOp, _>(tx, &qry, &args)?;
         match rows.len() {
             0 => {
-                test_debug!("No leader keys at {},{} in {}", key_block_height, key_vtxindex, &ancestor_snapshot.burn_header_hash.to_hex());
+                test_debug!("No leader keys at {},{} in {}", key_block_height, key_vtxindex, &ancestor_snapshot.burn_header_hash);
                 return Ok(None);
             },
             1 => {
                 return Ok(Some(rows[0].clone()));
             },
             _ => {
-                panic!("Multiple keys at {},{} in {}", key_block_height, key_vtxindex, tip_block_hash.to_hex());
+                panic!("Multiple keys at {},{} in {}", key_block_height, key_vtxindex, tip_block_hash);
             }
         }
     }
@@ -988,7 +988,7 @@ impl BurnDB {
             let leader_key_block_height = block_candidates[i].key_block_ptr as u64;
             let leader_key_vtxindex = block_candidates[i].key_vtxindex as u32;
             let leader_key = BurnDB::get_leader_key_at(tx, leader_key_block_height, leader_key_vtxindex, parent_tip_block_hash)?
-                .expect(&format!("FATAL: no leader key for accepted block commit {} (at {},{})", &block_candidates[i].txid.to_hex(), leader_key_block_height, leader_key_vtxindex));
+                .expect(&format!("FATAL: no leader key for accepted block commit {} (at {},{})", &block_candidates[i].txid, leader_key_block_height, leader_key_vtxindex));
                     
             leader_keys.push(leader_key);
         }
@@ -1005,7 +1005,7 @@ impl BurnDB {
                 sn
             },
             None => {
-                error!("No ancestor snapshot at {} from {}", block_height, tip_block_hash.to_hex());
+                error!("No ancestor snapshot at {} from {}", block_height, tip_block_hash);
                 return Err(db_error::NotFoundError);
             }
         };
@@ -1025,7 +1025,7 @@ impl BurnDB {
                 sn
             },
             None => {
-                error!("No ancestor snapshot at {} from {}", block_height, tip_block_hash.to_hex());
+                error!("No ancestor snapshot at {} from {}", block_height, tip_block_hash);
                 return Err(db_error::NotFoundError);
             }
         };
@@ -1045,7 +1045,7 @@ impl BurnDB {
                 sn
             },
             None => {
-                error!("No ancestor snapshot at {} from {}", block_height, tip_block_hash.to_hex());
+                error!("No ancestor snapshot at {} from {}", block_height, tip_block_hash);
                 return Err(db_error::NotFoundError);
             }
         };
@@ -1122,7 +1122,7 @@ impl BurnDB {
                 return Ok(Some(rows[0].clone()));
             },
             _ => {
-                panic!("Multiple parent blocks at {},{} in {}", block_height, vtxindex, tip_block_hash.to_hex());
+                panic!("Multiple parent blocks at {},{} in {}", block_height, vtxindex, tip_block_hash);
             }
         }
     }
@@ -1140,7 +1140,7 @@ impl BurnDB {
             1 => Ok(Some(rows[0].clone())),
             _ => {
                 // should never happen 
-                panic!("FATAL: multiple block commits for {},{}", &txid.to_hex(), &burn_header_hash.to_hex());
+                panic!("FATAL: multiple block commits for {},{}", &txid, &burn_header_hash);
             }
         }
     }
@@ -1156,14 +1156,14 @@ impl BurnDB {
             1 => Ok(Some(rows[0].clone())),
             _ => {
                 // should never happen 
-                panic!("FATAL: multiple block commits for {}", &block_hash.to_hex());
+                panic!("FATAL: multiple block commits for {}", &block_hash);
             }
         }
     }
 
     /// Get a block snapshot for a winning block hash in a given burn chain fork.
     pub fn get_block_snapshot_for_winning_stacks_block<'a>(tx: &mut BurnDBTx<'a>, tip_burn_header_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash) -> Result<Option<BlockSnapshot>, db_error> {
-        match BurnDB::index_value_get(tx, tip_burn_header_hash, &format!("burndb::sortition_block_hash::{}", block_hash.to_hex()))? {
+        match BurnDB::index_value_get(tx, tip_burn_header_hash, &format!("burndb::sortition_block_hash::{}", block_hash))? {
             Some(burn_header_hash_str) => {
                 let bhh = BurnchainHeaderHash::from_hex(&burn_header_hash_str).expect(&format!("FATAL: corrupt database: failed to parse {} as a hex string", &burn_header_hash_str));
                 BurnDB::get_block_snapshot(tx, &bhh)
@@ -1178,7 +1178,7 @@ impl BurnDB {
     pub fn has_VRF_public_key<'a>(tx: &mut BurnDBTx<'a>, key: &VRFPublicKey, tip_block_hash: &BurnchainHeaderHash) -> Result<bool, db_error> {
         let tip_snapshot = match BurnDB::get_block_snapshot(tx, tip_block_hash)? {
             None => {
-                error!("No tip with index root {}", tip_block_hash.to_hex());
+                error!("No tip with index root {}", tip_block_hash);
                 return Err(db_error::NotFoundError);
             }
             Some(sn) => {
@@ -1243,7 +1243,7 @@ impl BurnDB {
                     sn
                 },
                 None => {
-                    panic!("Discontiguous index: missing block {}", block_hash.to_hex());
+                    panic!("Discontiguous index: missing block {}", block_hash);
                 }
             };
 
@@ -1295,7 +1295,7 @@ impl BurnDB {
                     sn
                 },
                 None => {
-                    panic!("Discontiguous index: missing block {}", block_hash.to_hex());
+                    panic!("Discontiguous index: missing block {}", block_hash);
                 }
             };
 
@@ -1316,7 +1316,7 @@ impl BurnDB {
         
         let tip_snapshot = match BurnDB::get_block_snapshot(tx, tip_block_hash)? { 
             None => {
-                error!("No tip with index root {}", tip_block_hash.to_hex());
+                error!("No tip with index root {}", tip_block_hash);
                 return Err(db_error::NotFoundError);
             }
             Some(sn) => {
@@ -1352,10 +1352,10 @@ impl BurnDB {
     /// Will always return a snapshot -- even if it's the initial sentinel snapshot.
     pub fn get_last_snapshot_with_sortition<'a>(tx: &mut BurnDBTx<'a>, burn_block_height: u64, tip_block_hash: &BurnchainHeaderHash) -> Result<BlockSnapshot, db_error> {
         assert!(burn_block_height < BLOCK_HEIGHT_MAX);
-        test_debug!("Get snapshot at burn block {}, expect height {}", tip_block_hash.to_hex(), burn_block_height);
+        test_debug!("Get snapshot at burn block {}, expect height {}", tip_block_hash, burn_block_height);
         let tip_snapshot = match BurnDB::get_block_snapshot(tx, tip_block_hash)? {
             None => {
-                error!("No tip at burn block {}", tip_block_hash.to_hex());
+                error!("No tip at burn block {}", tip_block_hash);
                 return Err(db_error::NotFoundError);
             }
             Some(sn) => {
@@ -1377,7 +1377,7 @@ impl BurnDB {
 
         match BurnDB::get_block_snapshot(tx, &ancestor_hash) {
             Ok(snapshot_opt) => {
-                Ok(snapshot_opt.expect(&format!("FATAL: corrupt index: no snapshot {}", ancestor_hash.to_hex())))
+                Ok(snapshot_opt.expect(&format!("FATAL: corrupt index: no snapshot {}", ancestor_hash)))
             },
             Err(e) => {
                 Err(e)
@@ -1415,7 +1415,7 @@ impl BurnDB {
             },
             None => {
                 // shouldn't be possible, but don't panic since this is network-callable code
-                error!("Failed to load snapshot for block {} from fork {}", stable_block_height, &chain_tip.burn_header_hash.to_hex());
+                error!("Failed to load snapshot for block {} from fork {}", stable_block_height, &chain_tip.burn_header_hash);
                 return Err(db_error::Corruption);
             }
         };
@@ -1436,7 +1436,7 @@ impl BurnDB {
             last_consensus_hashes.insert(height, ch);
         }
 
-        test_debug!("Chain view: {},{}-{},{}", chain_tip.block_height, chain_tip.consensus_hash.to_hex(), stable_block_height, stable_snapshot.consensus_hash.to_hex());
+        test_debug!("Chain view: {},{}-{},{}", chain_tip.block_height, chain_tip.consensus_hash, stable_block_height, stable_snapshot.consensus_hash);
         Ok(BurnchainView {
             burn_block_height: chain_tip.block_height, 
             burn_consensus_hash: chain_tip.consensus_hash,
@@ -1459,7 +1459,7 @@ impl BurnDB {
     /// Do we expect a stacks block in this particular fork?
     /// i.e. is this block hash part of the fork history identified by tip_block_hash?
     pub fn expects_stacks_block_in_fork<'a>(tx: &mut BurnDBTx<'a>, block_hash: &BlockHeaderHash, tip_block_hash: &BurnchainHeaderHash) -> Result<bool, db_error> {
-        match BurnDB::index_value_get(tx, tip_block_hash, &format!("burndb::sortition_block_hash::{}", block_hash.to_hex()))? {
+        match BurnDB::index_value_get(tx, tip_block_hash, &format!("burndb::sortition_block_hash::{}", block_hash))? {
             Some(block_hash) => {
                 Ok(true)
             },
@@ -2277,8 +2277,8 @@ mod tests {
         let initial = BurnDB::get_first_block_snapshot(db.conn()).unwrap();
        
         test_debug!("Verify from {},hash={},parent={} back to {},hash={},parent={}",
-                    child.block_height, child.burn_header_hash.to_hex(), child.parent_burn_header_hash.to_hex(),
-                    initial.block_height, initial.burn_header_hash.to_hex(), initial.parent_burn_header_hash.to_hex());
+                    child.block_height, child.burn_header_hash, child.parent_burn_header_hash,
+                    initial.block_height, initial.burn_header_hash, initial.parent_burn_header_hash);
 
         while child.block_height > initial.block_height {
             let parent = {
@@ -2288,7 +2288,7 @@ mod tests {
 
             test_debug!("Verify {} == {} - 1 and hash={},parent_hash={} == parent={}",
                         parent.block_height, child.block_height,
-                        child.burn_header_hash.to_hex(), parent.burn_header_hash.to_hex(), child.parent_burn_header_hash.to_hex());
+                        child.burn_header_hash, parent.burn_header_hash, child.parent_burn_header_hash);
 
             assert_eq!(parent.block_height, child.block_height - 1);
             assert_eq!(parent.burn_header_hash, child.parent_burn_header_hash);
@@ -2356,7 +2356,7 @@ mod tests {
                 };
             
             let parent_block = BurnchainHeaderHash(parent_block_hash);
-            test_debug!("----- build fork off of parent {} (i = {}) -----", &parent_block.to_hex(), i);
+            test_debug!("----- build fork off of parent {} (i = {}) -----", &parent_block, i);
 
             let mut last_snapshot = BurnDB::get_block_snapshot(db.conn(), &parent_block).unwrap().unwrap();
 
@@ -2384,7 +2384,7 @@ mod tests {
                 last_snapshot = next_snapshot.clone();
             }
         
-            test_debug!("----- made fork {} (i = {}) -----", &next_snapshot.burn_header_hash.to_hex(), i);
+            test_debug!("----- made fork {} (i = {}) -----", &next_snapshot.burn_header_hash, i);
         }
 
         test_debug!("----- grow forks -----");
@@ -2397,7 +2397,7 @@ mod tests {
             last_block_hash[i] = (9 - i) as u8;
             let last_block = BurnchainHeaderHash(last_block_hash);
             
-            test_debug!("----- grow fork {} (i = {}) -----", &last_block.to_hex(), i);
+            test_debug!("----- grow fork {} (i = {}) -----", &last_block, i);
 
             let mut last_snapshot = BurnDB::get_block_snapshot(db.conn(), &last_block).unwrap().unwrap();
            

--- a/src/chainstate/burn/db/burndb.rs
+++ b/src/chainstate/burn/db/burndb.rs
@@ -425,8 +425,8 @@ impl BurnDB {
         burndbtx.tx.execute("INSERT INTO snapshots \
                    (block_height, burn_header_hash, parent_burn_header_hash, consensus_hash, ops_hash, total_burn, sortition, sortition_hash, winning_block_txid, winning_stacks_block_hash, index_root, num_sortitions) \
                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-                   &[&(first_snapshot.block_height as i64) as &dyn ToSql, &first_snapshot.burn_header_hash.to_hex(), &first_snapshot.parent_burn_header_hash.to_hex(), &first_snapshot.consensus_hash.to_hex(), &first_snapshot.ops_hash.to_hex(), &"0".to_string(),
-                     &first_snapshot.sortition as &dyn ToSql, &first_snapshot.sortition_hash.to_hex(), &first_snapshot.winning_block_txid.to_hex(), &first_snapshot.winning_stacks_block_hash.to_hex(), &first_snapshot.index_root.to_hex(), 
+                   &[&(first_snapshot.block_height as i64) as &dyn ToSql, &first_snapshot.burn_header_hash, &first_snapshot.parent_burn_header_hash, &first_snapshot.consensus_hash, &first_snapshot.ops_hash, &"0".to_string(),
+                     &first_snapshot.sortition as &dyn ToSql, &first_snapshot.sortition_hash, &first_snapshot.winning_block_txid, &first_snapshot.winning_stacks_block_hash, &first_snapshot.index_root, 
                      &(first_snapshot.num_sortitions as i64) as &dyn ToSql])
             .map_err(db_error::SqliteError)?;
        
@@ -582,8 +582,8 @@ impl BurnDB {
         tx.execute("INSERT INTO snapshots \
                    (block_height, burn_header_hash, parent_burn_header_hash, consensus_hash, ops_hash, total_burn, sortition, sortition_hash, winning_block_txid, winning_stacks_block_hash, index_root, num_sortitions) \
                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-                   &[&(snapshot.block_height as i64) as &dyn ToSql, &snapshot.burn_header_hash.to_hex(), &snapshot.parent_burn_header_hash.to_hex(), &snapshot.consensus_hash.to_hex(), &snapshot.ops_hash.to_hex(), &total_burn_str,
-                     &snapshot.sortition as &dyn ToSql, &snapshot.sortition_hash.to_hex(), &snapshot.winning_block_txid.to_hex(), &snapshot.winning_stacks_block_hash.to_hex(), &snapshot.index_root.to_hex(),
+                   &[&(snapshot.block_height as i64) as &dyn ToSql, &snapshot.burn_header_hash, &snapshot.parent_burn_header_hash, &snapshot.consensus_hash, &snapshot.ops_hash, &total_burn_str,
+                     &snapshot.sortition as &dyn ToSql, &snapshot.sortition_hash, &snapshot.winning_block_txid, &snapshot.winning_stacks_block_hash, &snapshot.index_root,
                      &(snapshot.num_sortitions as i64) as &dyn ToSql])
             .map_err(db_error::SqliteError)?;
 
@@ -616,7 +616,7 @@ impl BurnDB {
     pub fn get_burnchain_transaction(conn: &Connection, txid: &Txid) -> Result<Option<BlockstackOperationType>, db_error> {
         // leader key?
         let leader_key_sql = "SELECT * FROM leader_keys WHERE txid = ?1 LIMIT 1".to_string();
-        let args = [&txid.to_hex() as &dyn ToSql];
+        let args = [&txid];
 
         let leader_key_rows = query_rows::<LeaderKeyRegisterOp, _>(conn, &leader_key_sql, &args)?;
         match leader_key_rows.len() {
@@ -818,8 +818,8 @@ impl BurnDB {
         assert!(leader_key.block_height < BLOCK_HEIGHT_MAX);
 
         tx.execute("INSERT INTO leader_keys (txid, vtxindex, block_height, burn_header_hash, consensus_hash, public_key, memo, address) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                   &[&leader_key.txid.to_hex(), &leader_key.vtxindex as &dyn ToSql, &(leader_key.block_height as i64) as &dyn ToSql, &leader_key.burn_header_hash.to_hex(),
-                   &leader_key.consensus_hash.to_hex(), &leader_key.public_key.to_hex(), &to_hex(&leader_key.memo), &leader_key.address.to_string()])
+                   &[&leader_key.txid, &leader_key.vtxindex as &dyn ToSql, &(leader_key.block_height as i64) as &dyn ToSql, &leader_key.burn_header_hash,
+                   &leader_key.consensus_hash, &leader_key.public_key.to_hex(), &to_hex(&leader_key.memo), &leader_key.address.to_string()])
             .map_err(db_error::SqliteError)?;
 
         Ok(())
@@ -841,8 +841,8 @@ impl BurnDB {
 
         tx.execute("INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, key_block_ptr, key_vtxindex, memo, burn_fee, input) \
                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                    &[&block_commit.txid.to_hex(), &block_commit.vtxindex as &dyn ToSql, &(block_commit.block_height as i64) as &dyn ToSql, &block_commit.burn_header_hash.to_hex(), 
-                    &block_commit.block_header_hash.to_hex(), &block_commit.new_seed.to_hex(), &block_commit.parent_block_ptr as &dyn ToSql, &block_commit.parent_vtxindex as &dyn ToSql,
+                    &[&block_commit.txid, &block_commit.vtxindex as &dyn ToSql, &(block_commit.block_height as i64) as &dyn ToSql, &block_commit.burn_header_hash, 
+                    &block_commit.block_header_hash, &block_commit.new_seed, &block_commit.parent_block_ptr as &dyn ToSql, &block_commit.parent_vtxindex as &dyn ToSql,
                     &block_commit.key_block_ptr as &dyn ToSql, &block_commit.key_vtxindex as &dyn ToSql, &to_hex(&block_commit.memo[..]), &burn_fee_str as &dyn ToSql, &tx_input_str])
             .map_err(db_error::SqliteError)?;
 
@@ -862,9 +862,9 @@ impl BurnDB {
 
         tx.execute("INSERT INTO user_burn_support (txid, vtxindex, block_height, burn_header_hash, address, consensus_hash, public_key, key_block_ptr, key_vtxindex, block_header_hash_160, burn_fee) \
                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-                   &[&user_burn.txid.to_hex(), &user_burn.vtxindex as &dyn ToSql, &(user_burn.block_height as i64) as &dyn ToSql, &user_burn.burn_header_hash.to_hex(), 
-                   &user_burn.address.to_string(), &user_burn.consensus_hash.to_hex(), &user_burn.public_key.to_hex(), &user_burn.key_block_ptr as &dyn ToSql, &user_burn.key_vtxindex as &dyn ToSql,
-                   &user_burn.block_header_hash_160.to_hex(), &burn_fee_str])
+                   &[&user_burn.txid, &user_burn.vtxindex as &dyn ToSql, &(user_burn.block_height as i64) as &dyn ToSql, &user_burn.burn_header_hash, 
+                   &user_burn.address.to_string(), &user_burn.consensus_hash, &user_burn.public_key.to_hex(), &user_burn.key_block_ptr as &dyn ToSql, &user_burn.key_vtxindex as &dyn ToSql,
+                   &user_burn.block_header_hash_160, &burn_fee_str])
             .map_err(db_error::SqliteError)?;
 
         Ok(())
@@ -873,7 +873,7 @@ impl BurnDB {
     /// Get the first snapshot 
     pub fn get_first_block_snapshot(conn: &Connection) -> Result<BlockSnapshot, db_error> {
         let qry = "SELECT * FROM snapshots WHERE consensus_hash = ?1".to_string();
-        let rows = query_rows::<BlockSnapshot, _>(conn, &qry.to_string(), &[&ConsensusHash::empty().to_hex()])?;
+        let rows = query_rows::<BlockSnapshot, _>(conn, &qry.to_string(), &[&ConsensusHash::empty()])?;
         match rows.len() {
             0 => {
                 // should never happen
@@ -890,7 +890,7 @@ impl BurnDB {
     /// Get a snapshot for an existing block.
     pub fn get_block_snapshot(conn: &Connection, burn_hash: &BurnchainHeaderHash) -> Result<Option<BlockSnapshot>, db_error> {
         let qry = "SELECT * FROM snapshots WHERE burn_header_hash = ?1".to_string();
-        let args = [&burn_hash.to_hex()];
+        let args = [&burn_hash];
         let rows = query_rows::<BlockSnapshot, _>(conn, &qry.to_string(), &args)?;
         match rows.len() {
             0 => {
@@ -908,7 +908,7 @@ impl BurnDB {
     /// Get a snapshot for an existing block given its state index
     pub fn get_block_snapshot_at(conn: &Connection, index_root: &TrieHash) -> Result<Option<BlockSnapshot>, db_error> {
         let qry = "SELECT * FROM snapshots WHERE index_root = ?1".to_string();
-        let args = [&index_root.to_hex()];
+        let args = [&index_root];
         let rows = query_rows::<BlockSnapshot, _>(conn, &qry.to_string(), &args)?;
         match rows.len() {
             0 => Ok(None),
@@ -933,7 +933,7 @@ impl BurnDB {
         };
 
         let qry = "SELECT * FROM snapshots WHERE burn_header_hash = ?1 AND block_height = ?2".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex() as &dyn ToSql, &(block_height as i64) as &dyn ToSql];
+        let args = [&ancestor_snapshot.burn_header_hash, &(block_height as i64) as &dyn ToSql];
         let rows = query_rows::<BlockSnapshot, _>(tx, &qry.to_string(), &args)?;
         match rows.len() {
             0 => Ok(None),
@@ -962,7 +962,7 @@ impl BurnDB {
         };
 
         let qry = "SELECT * FROM leader_keys WHERE burn_header_hash = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex(), &(key_block_height as i64) as &dyn ToSql, &key_vtxindex as &dyn ToSql];
+        let args = [&ancestor_snapshot.burn_header_hash, &(key_block_height as i64) as &dyn ToSql, &key_vtxindex];
         let rows = query_rows::<LeaderKeyRegisterOp, _>(tx, &qry, &args)?;
         match rows.len() {
             0 => {
@@ -1011,7 +1011,7 @@ impl BurnDB {
         };
 
         let qry = "SELECT * FROM leader_keys WHERE burn_header_hash = ?1 AND block_height = ?2 ORDER BY vtxindex ASC".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex() as &dyn ToSql, &(block_height as i64) as &dyn ToSql];
+        let args = [&ancestor_snapshot.burn_header_hash, &(block_height as i64) as &dyn ToSql];
 
         query_rows::<LeaderKeyRegisterOp, _>(tx, &qry.to_string(), &args)
     }
@@ -1031,7 +1031,7 @@ impl BurnDB {
         };
 
         let qry = "SELECT * FROM block_commits WHERE burn_header_hash = ?1 AND block_height = ?2 ORDER BY vtxindex ASC".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex() as &dyn ToSql, &(block_height as i64) as &dyn ToSql];
+        let args: [&dyn ToSql; 2] = [&ancestor_snapshot.burn_header_hash, &(block_height as i64)];
 
         query_rows::<LeaderBlockCommitOp, _>(tx, &qry.to_string(), &args)
     }
@@ -1051,7 +1051,7 @@ impl BurnDB {
         };
 
         let qry = "SELECT * FROM user_burn_support WHERE burn_header_hash = ?1 AND block_height = ?2 ORDER BY vtxindex ASC".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex() as &dyn ToSql, &(block_height as i64) as &dyn ToSql];
+        let args: [&dyn ToSql; 2] = [&ancestor_snapshot.burn_header_hash, &(block_height as i64)];
 
         query_rows::<UserBurnSupportOp, _>(tx, &qry.to_string(), &args)
     }
@@ -1075,7 +1075,7 @@ impl BurnDB {
         let winning_block_hash160 = Hash160::from_sha256(ancestor_snapshot.winning_stacks_block_hash.as_bytes());
 
         let qry = "SELECT * FROM user_burn_support WHERE burn_header_hash = ?1 AND block_header_hash_160 = ?2 ORDER BY vtxindex ASC".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex() as &dyn ToSql, &winning_block_hash160.to_hex() as &dyn ToSql];
+        let args: [&dyn ToSql; 2] = [&ancestor_snapshot.burn_header_hash, &winning_block_hash160];
 
         query_rows::<UserBurnSupportOp, _>(conn, &qry.to_string(), &args)
     }
@@ -1111,7 +1111,7 @@ impl BurnDB {
         };
 
         let qry = "SELECT * FROM block_commits WHERE burn_header_hash = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2".to_string();
-        let args = [&ancestor_snapshot.burn_header_hash.to_hex(), &(block_height as i64) as &dyn ToSql, &vtxindex as &dyn ToSql];
+        let args: [&dyn ToSql; 3] = [&ancestor_snapshot.burn_header_hash, &(block_height as i64), &vtxindex];
         let rows = query_rows::<LeaderBlockCommitOp, _>(tx, &qry, &args)?;
 
         match rows.len() {
@@ -1132,7 +1132,7 @@ impl BurnDB {
     /// construction.
     pub fn get_block_commit(conn: &Connection, txid: &Txid, burn_header_hash: &BurnchainHeaderHash) -> Result<Option<LeaderBlockCommitOp>, db_error> {
         let qry = "SELECT * FROM block_commits WHERE txid = ?1 AND burn_header_hash = ?2".to_string();
-        let args = [&txid.to_hex(), &burn_header_hash.to_hex()];
+        let args: [&dyn ToSql; 2] = [&txid, &burn_header_hash];
         let rows = query_rows::<LeaderBlockCommitOp, _>(conn, &qry.to_string(), &args)?;
 
         match rows.len() {
@@ -1148,7 +1148,7 @@ impl BurnDB {
     /// Get a block commit by its committed block
     pub fn get_block_commit_for_stacks_block(conn: &Connection, burn_header_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash) -> Result<Option<LeaderBlockCommitOp>, db_error> {
         let qry = "SELECT * FROM block_commits WHERE burn_header_hash = ?1 AND block_header_hash = ?2".to_string();
-        let args = [&burn_header_hash.to_hex(), &block_hash.to_hex()];
+        let args: [&dyn ToSql; 2] = [&burn_header_hash, &block_hash];
         let rows = query_rows::<LeaderBlockCommitOp, _>(conn, &qry.to_string(), &args)?;
 
         match rows.len() {
@@ -1449,7 +1449,7 @@ impl BurnDB {
     /// Do we expect a stacks block on some fork?  i.e. is there at least one winning block commit for it?
     pub fn expects_stacks_block(conn: &Connection, block_hash: &BlockHeaderHash) -> Result<bool, db_error> {
         let sql = "SELECT winning_stacks_block_hash FROM snapshots WHERE winning_stacks_block_hash = ?1".to_string();
-        let rows = query_row_columns::<BlockHeaderHash, _>(conn, &sql, &[&block_hash.to_hex()], "winning_stacks_block_hash")?;
+        let rows = query_row_columns::<BlockHeaderHash, _>(conn, &sql, &[&block_hash], "winning_stacks_block_hash")?;
         match rows.len() {
             0 => Ok(false),
             _ => Ok(true)

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -93,7 +93,7 @@ impl BurnSamplePoint {
             match key_index.get(&(bc.key_block_ptr as u64, bc.key_vtxindex as u32)) {
                 None => {
                     panic!("No leader key for block commitment {} at ({},{}) -- points to ({},{})",
-                            &bc.txid.to_hex(), bc.block_height, bc.vtxindex, bc.key_block_ptr, bc.key_vtxindex);
+                            &bc.txid, bc.block_height, bc.vtxindex, bc.key_block_ptr, bc.key_vtxindex);
                 },
                 Some(_) => {}
             }
@@ -108,7 +108,7 @@ impl BurnSamplePoint {
             match key_index.get(&(bc.key_block_ptr as u64, bc.key_vtxindex as u32)) {
                 None => {
                     // leader key already consumed; drop this commit
-                    warn!("VRF public key at {},{} already consumed; ignoring block commit {},{} ({})", bc.key_block_ptr, bc.key_vtxindex, bc.block_height, bc.vtxindex, bc.txid.to_hex());
+                    warn!("VRF public key at {},{} already consumed; ignoring block commit {},{} ({})", bc.key_block_ptr, bc.key_vtxindex, bc.block_height, bc.vtxindex, bc.txid);
                     continue;
                 },
                 Some(i) => {
@@ -143,7 +143,7 @@ impl BurnSamplePoint {
             let block_height = block_candidates[0].block_height;
             for i in 1..block_candidates.len() {
                 if block_candidates[i].block_height != block_height {
-                    panic!("FATAL ERROR: block commit {} is at ({},{}) not {}", &block_candidates[i].txid.to_hex(), block_candidates[i].block_height, block_candidates[i].vtxindex, block_height);
+                    panic!("FATAL ERROR: block commit {} is at ({},{}) not {}", &block_candidates[i].txid, block_candidates[i].block_height, block_candidates[i].vtxindex, block_height);
                 }
             }
 
@@ -158,7 +158,7 @@ impl BurnSamplePoint {
             let block_height = user_burns[0].block_height;
             for i in 0..user_burns.len() {
                 if user_burns[i].block_height != block_height {
-                    panic!("FATAL ERROR: user burn {} is at ({},{}) not {}", &user_burns[i].txid.to_hex(), user_burns[i].block_height, user_burns[i].vtxindex, block_height);
+                    panic!("FATAL ERROR: user burn {} is at ({},{}) not {}", &user_burns[i].txid, user_burns[i].block_height, user_burns[i].vtxindex, block_height);
                 }
             }
             
@@ -198,8 +198,8 @@ impl BurnSamplePoint {
                 },
                 None => {
                     info!("User burn {} ({},{}) of {} for key={}, block={} has no matching block commit",
-                          &user_burn.txid.to_hex(), user_burn.block_height, user_burn.vtxindex, user_burn.burn_fee,
-                          user_burn.public_key.to_hex(), &user_burn.block_header_hash_160.to_hex());
+                          &user_burn.txid, user_burn.block_height, user_burn.vtxindex, user_burn.burn_fee,
+                          user_burn.public_key.to_hex(), &user_burn.block_header_hash_160);
                     continue;
                 }
             };
@@ -242,7 +242,7 @@ impl BurnSamplePoint {
         }
 
         for i in 0..burn_sample.len() {
-            test_debug!("Range for block {}: {} / {}: {} - {}", burn_sample[i].candidate.block_header_hash.to_hex(), burn_sample[i].burns, total_burns_u128, burn_sample[i].range_start, burn_sample[i].range_end);
+            test_debug!("Range for block {}: {} / {}: {} - {}", burn_sample[i].candidate.block_header_hash, burn_sample[i].burns, total_burns_u128, burn_sample[i].range_start, burn_sample[i].range_end);
         }
     }
 

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -262,9 +262,9 @@ impl ConsensusHash {
         while i < 64 && block_height - (((1 as u64) << i) - 1) >= first_block_height {
             let prev_block : u64 = block_height - (((1 as u64) << i) - 1);
             let prev_ch = BurnDB::get_consensus_at(tx, prev_block, tip_block_hash)
-                .expect(&format!("FATAL: failed to get consensus hash at {} in fork {}", prev_block, tip_block_hash.to_hex()));
+                .expect(&format!("FATAL: failed to get consensus hash at {} in fork {}", prev_block, tip_block_hash));
 
-            debug!("Consensus at {}: {}", prev_block, &prev_ch.to_hex());
+            debug!("Consensus at {}: {}", prev_block, &prev_ch);
             prev_chs.push(prev_ch.clone());
             i += 1;
 

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -139,12 +139,6 @@ impl BlockHeaderHash {
     }
 }
 
-impl fmt::Display for BlockHeaderHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", to_hex(&self.0))
-    }
-}
-
 impl SortitionHash {
     /// Calculate a new sortition hash from the given burn header hash
     pub fn initial() -> SortitionHash {

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -284,7 +284,7 @@ impl BlockstackOperation for LeaderBlockCommitOp {
             .expect("FATAL: failed to query DB for prior instances of this block");
 
         if is_already_committed {
-            warn!("Invalid block commit: already committed to {}", self.block_header_hash.to_hex());
+            warn!("Invalid block commit: already committed to {}", self.block_header_hash);
             return Err(op_error::BlockCommitAlreadyExists);
         }
         
@@ -303,7 +303,7 @@ impl BlockstackOperation for LeaderBlockCommitOp {
                 key
             },
             None => {
-                warn!("Invalid block commit: no corresponding leader key at {},{} in fork {}", leader_key_block_height, self.key_vtxindex, chain_tip.burn_header_hash.to_hex());
+                warn!("Invalid block commit: no corresponding leader key at {},{} in fork {}", leader_key_block_height, self.key_vtxindex, chain_tip.burn_header_hash);
                 return Err(op_error::BlockCommitNoLeaderKey);
             }
         };
@@ -312,7 +312,7 @@ impl BlockstackOperation for LeaderBlockCommitOp {
             .expect("Sqlite failure while verifying that a leader VRF key is not consumed");
 
         if is_key_consumed {
-            warn!("Invalid block commit: leader key at ({},{}) is already used as of {} in fork {}", register_key.block_height, register_key.vtxindex, chain_tip.block_height, chain_tip.burn_header_hash.to_hex());
+            warn!("Invalid block commit: leader key at ({},{}) is already used as of {} in fork {}", register_key.block_height, register_key.vtxindex, chain_tip.block_height, chain_tip.burn_header_hash);
             return Err(op_error::BlockCommitLeaderKeyAlreadyUsed);
         }
 

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -211,7 +211,7 @@ impl BlockstackOperation for LeaderKeyRegisterOp {
             .expect("Sqlite failure while checking consensus hash freshness");
 
         if !consensus_hash_recent {
-            warn!("Invalid leader key registration: invalid consensus hash {}", &self.consensus_hash.to_hex());
+            warn!("Invalid leader key registration: invalid consensus hash {}", &self.consensus_hash);
             return Err(op_error::LeaderKeyBadConsensusHash);
         }
 

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -200,7 +200,7 @@ impl BlockstackOperation for UserBurnSupportOp {
         }
 
         if !is_fresh {
-            warn!("Invalid user burn: invalid consensus hash {}", &self.consensus_hash.to_hex());
+            warn!("Invalid user burn: invalid consensus hash {}", &self.consensus_hash);
             return Err(op_error::UserBurnSupportBadConsensusHash);
         }
 

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -105,7 +105,7 @@ impl BlockSnapshot {
         let index = sortition_hash.mix_VRF_seed(VRF_seed).to_uint256();
         for i in 0..dist.len() {
             if (dist[i].range_start <= index) && (index < dist[i].range_end) {
-                debug!("Sampled {}: sortition index = {}", dist[i].candidate.block_header_hash.to_hex(), &index);
+                debug!("Sampled {}: sortition index = {}", dist[i].candidate.block_header_hash, &index);
                 return Some(i);
             }
         }

--- a/src/chainstate/stacks/auth.rs
+++ b/src/chainstate/stacks/auth.rs
@@ -271,7 +271,7 @@ impl MultisigSpendingCondition {
         };
 
         if addr_bytes != self.signer {
-            return Err(net_error::VerifyingError(format!("Signer hash does not equal hash of public key(s): {} != {}", addr_bytes.to_hex(), self.signer.to_hex())));
+            return Err(net_error::VerifyingError(format!("Signer hash does not equal hash of public key(s): {} != {}", addr_bytes, self.signer)));
         }
 
         Ok(cur_sighash)
@@ -380,7 +380,7 @@ impl SinglesigSpendingCondition {
         };
         
         if addr_bytes != self.signer {
-            return Err(net_error::VerifyingError(format!("Signer hash does not equal hash of public key(s): {} != {}", &addr_bytes.to_hex(), &self.signer.to_hex())));
+            return Err(net_error::VerifyingError(format!("Signer hash does not equal hash of public key(s): {} != {}", &addr_bytes, &self.signer)));
         }
 
         Ok(next_sighash)

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -253,28 +253,28 @@ impl StacksBlockHeader {
         
         // this header must match the header that won sortition on the burn chain
         if self.block_hash() != burn_chain_tip.winning_stacks_block_hash {
-            let msg = format!("Invalid Stacks block header {}: invalid commit: {} != {}", self.block_hash().to_hex(), self.block_hash().to_hex(), burn_chain_tip.winning_stacks_block_hash.to_hex());
+            let msg = format!("Invalid Stacks block header {}: invalid commit: {} != {}", self.block_hash(), self.block_hash(), burn_chain_tip.winning_stacks_block_hash);
             debug!("{}", msg);
             return Err(Error::InvalidStacksBlock(msg));
         }
 
         // this header must match the parent header as recorded on the burn chain
         if self.parent_block != stacks_chain_tip.winning_stacks_block_hash {
-            let msg = format!("Invalid Stacks block header {}: invalid parent hash: {} != {}", self.block_hash().to_hex(), self.parent_block.to_hex(), stacks_chain_tip.winning_stacks_block_hash.to_hex());
+            let msg = format!("Invalid Stacks block header {}: invalid parent hash: {} != {}", self.block_hash(), self.parent_block, stacks_chain_tip.winning_stacks_block_hash);
             debug!("{}", msg);
             return Err(Error::InvalidStacksBlock(msg));
         }
         
         // this header's proof must hash to the burn chain tip's VRF seed
         if !block_commit.new_seed.is_from_proof(&self.proof) {
-            let msg = format!("Invalid Stacks block header {}: invalid VRF proof: hash({}) != {} (but {})", self.block_hash().to_hex(), self.proof.to_hex(), block_commit.new_seed.to_hex(), VRFSeed::from_proof(&self.proof).to_hex());
+            let msg = format!("Invalid Stacks block header {}: invalid VRF proof: hash({}) != {} (but {})", self.block_hash(), self.proof.to_hex(), block_commit.new_seed, VRFSeed::from_proof(&self.proof));
             debug!("{}", msg);
             return Err(Error::InvalidStacksBlock(msg));
         }
 
         // this header must commit to all of the work seen so far in this stacks blockchain fork.
         if self.total_work.burn != stacks_chain_tip.total_burn {
-            let msg = format!("Invalid Stacks block header {}: invalid total burns: {} != {}", self.block_hash().to_hex(), self.total_work.burn, stacks_chain_tip.total_burn);
+            let msg = format!("Invalid Stacks block header {}: invalid total burns: {} != {}", self.block_hash(), self.total_work.burn, stacks_chain_tip.total_burn);
             debug!("{}", msg);
             return Err(Error::InvalidStacksBlock(msg));
         }
@@ -291,7 +291,7 @@ impl StacksBlockHeader {
         };
 
         if !valid {
-            let msg = format!("Invalid Stacks block header {}: leader VRF key {} did not produce a valid proof over {}", self.block_hash().to_hex(), leader_key.public_key.to_hex(), burn_chain_tip.sortition_hash.to_hex());
+            let msg = format!("Invalid Stacks block header {}: leader VRF key {} did not produce a valid proof over {}", self.block_hash(), leader_key.public_key.to_hex(), burn_chain_tip.sortition_hash);
             debug!("{}", msg);
             return Err(Error::InvalidStacksBlock(msg));
         }
@@ -444,7 +444,7 @@ impl StacksBlock {
         for (i, tx) in txs.iter().enumerate() {
             let txid = tx.txid();
             if txids.get(&txid).is_some() {
-                warn!("Duplicate tx {}: at index {} and {}", txid.to_hex(), txids.get(&txid).unwrap(), i);
+                warn!("Duplicate tx {}: at index {} and {}", txid, txids.get(&txid).unwrap(), i);
                 test_debug!("{:?}", &tx);
                 return false;
             }
@@ -457,11 +457,11 @@ impl StacksBlock {
     pub fn validate_transactions_network(txs: &Vec<StacksTransaction>, mainnet: bool) -> bool {
         for tx in txs {
             if mainnet && !tx.is_mainnet() {
-                warn!("Tx {} is not mainnet", tx.txid().to_hex());
+                warn!("Tx {} is not mainnet", tx.txid());
                 return false;
             }
             else if !mainnet && tx.is_mainnet() {
-                warn!("Tx {} is not testnet", tx.txid().to_hex());
+                warn!("Tx {} is not testnet", tx.txid());
                 return false;
             }
         }
@@ -472,7 +472,7 @@ impl StacksBlock {
     pub fn validate_transactions_chain_id(txs: &Vec<StacksTransaction>, chain_id: u32) -> bool {
         for tx in txs {
             if tx.chain_id != chain_id {
-                warn!("Tx {} has chain ID {:08x}; expected {:08x}", tx.txid().to_hex(), tx.chain_id, chain_id);
+                warn!("Tx {} has chain ID {:08x}; expected {:08x}", tx.txid(), tx.chain_id, chain_id);
                 return false;
             }
         }
@@ -484,11 +484,11 @@ impl StacksBlock {
         for tx in txs {
             match (anchored, tx.anchor_mode) {
                 (true, TransactionAnchorMode::OffChainOnly) => {
-                    warn!("Tx {} is off-chain-only; expected on-chain-only or any", tx.txid().to_hex());
+                    warn!("Tx {} is off-chain-only; expected on-chain-only or any", tx.txid());
                     return false;
                 }
                 (false, TransactionAnchorMode::OnChainOnly) => {
-                    warn!("Tx {} is on-chain-only; expected off-chain-only or any", tx.txid().to_hex());
+                    warn!("Tx {} is on-chain-only; expected off-chain-only or any", tx.txid());
                     return false;
                 }
                 (_, _) => {}
@@ -505,17 +505,17 @@ impl StacksBlock {
             match tx.payload {
                 TransactionPayload::Coinbase(_) => {
                     if !check_present {
-                        warn!("Found unexpected coinbase tx {}", tx.txid().to_hex());
+                        warn!("Found unexpected coinbase tx {}", tx.txid());
                         return false;
                     }
 
                     if found_coinbase {
-                        warn!("Found duplicate coinbase tx {}", tx.txid().to_hex());
+                        warn!("Found duplicate coinbase tx {}", tx.txid());
                         return false;
                     }
 
                     if tx.anchor_mode != TransactionAnchorMode::OnChainOnly {
-                        warn!("Invalid coinbase tx {}: not on-chain only", tx.txid().to_hex());
+                        warn!("Invalid coinbase tx {}: not on-chain only", tx.txid());
                         return false;
                     }
                     found_coinbase = true;

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -744,7 +744,7 @@ impl StacksChainState {
     /// Load up a preprocessed but still unprocessed microblock.
     pub fn load_staging_microblock(blocks_conn: &DBConn, burn_header_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash, microblock_hash: &BlockHeaderHash) -> Result<Option<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE burn_header_hash = ?1 AND anchored_block_hash = ?2 AND microblock_hash = ?3 AND orphaned = 0".to_string();
-        let args: &[&dyn ToSql] = &[&block_hash, &burn_header_hash, &microblock_hash];
+        let args: &[&dyn ToSql] = &[&burn_header_hash, &block_hash, &microblock_hash];
         let mut rows = query_rows::<StagingMicroblock, _>(blocks_conn, &sql, args).map_err(Error::DBError)?;
         let len = rows.len();
         match len {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -326,7 +326,7 @@ impl StacksChainState {
 
         block_path.push(to_hex(&block_hash_bytes[0..2]));
         block_path.push(to_hex(&block_hash_bytes[2..4]));
-        block_path.push(format!("{}-{}", to_hex(block_hash_bytes), burn_header_hash.to_hex()));
+        block_path.push(format!("{}-{}", to_hex(block_hash_bytes), burn_header_hash));
 
         let blocks_path_str = block_path.to_str().ok_or_else(|| Error::DBError(db_error::ParseError))?.to_string();
         Ok(blocks_path_str)
@@ -342,7 +342,7 @@ impl StacksChainState {
 
         let _ = StacksChainState::mkdirs(&block_path)?;
 
-        block_path.push(format!("{}-{}", to_hex(block_hash_bytes), burn_header_hash.to_hex()));
+        block_path.push(format!("{}-{}", to_hex(block_hash_bytes), burn_header_hash));
         let blocks_path_str = block_path.to_str().ok_or_else(|| Error::DBError(db_error::ParseError))?.to_string();
         Ok(blocks_path_str)
     }
@@ -510,14 +510,14 @@ impl StacksChainState {
         let block_path = StacksChainState::get_block_path(blocks_dir, burn_header_hash, block_hash)?;
         let block_bytes = StacksChainState::file_load(&block_path)?;
         if block_bytes.len() == 0 {
-            debug!("Zero-sized block {}", block_hash.to_hex());
+            debug!("Zero-sized block {}", block_hash);
             return Ok(None);
         }
 
         let mut index = 0;
         let block = StacksBlock::deserialize(&block_bytes, &mut index, block_bytes.len() as u32).map_err(Error::NetError)?;
         if index != (block_bytes.len() as u32) {
-            error!("Corrupt block {}: read {} out of {} bytes", block_hash.to_hex(), index, block_bytes.len());
+            error!("Corrupt block {}: read {} out of {} bytes", block_hash, index, block_bytes.len());
             return Err(Error::DBError(db_error::Corruption));
         }
 
@@ -532,7 +532,7 @@ impl StacksChainState {
         let block_path = StacksChainState::get_block_path(blocks_dir, burn_header_hash, block_hash)?;
         let block_bytes = StacksChainState::file_load(&block_path)?;
         if block_bytes.len() == 0 {
-            debug!("Zero-sized block {}", block_hash.to_hex());
+            debug!("Zero-sized block {}", block_hash);
             return Ok(None);
         }
 
@@ -578,7 +578,7 @@ impl StacksChainState {
         let block_bytes = StacksChainState::file_load(&block_path)?;
         if block_bytes.len() == 0 {
             // known-invalid
-            debug!("Zero-sized microblock stream {}", microblock_head_hash.to_hex());
+            debug!("Zero-sized microblock stream {}", microblock_head_hash);
             return Ok(None);
         }
 
@@ -590,7 +590,7 @@ impl StacksChainState {
         }
 
         if (index as usize) != block_bytes.len() {
-            error!("Corrupt microblock stream {}: read {} out of {} bytes", microblock_head_hash.to_hex(), index, block_bytes.len());
+            error!("Corrupt microblock stream {}: read {} out of {} bytes", microblock_head_hash, index, block_bytes.len());
             return Err(Error::DBError(db_error::Corruption));
         }
 
@@ -780,7 +780,7 @@ impl StacksChainState {
             // corrupt!
             if !staging_microblocks[i].processed {
                 if staging_microblocks[i].block_data.len() == 0 {
-                    return Err(Error::NetError(net_error::DeserializeError(format!("Microblock {} does not have block data", staging_microblocks[i].microblock_hash.to_hex()))));
+                    return Err(Error::NetError(net_error::DeserializeError(format!("Microblock {} does not have block data", staging_microblocks[i].microblock_hash))));
                 }
 
                 let mut index = 0;
@@ -797,7 +797,7 @@ impl StacksChainState {
             for i in cnt..num_staging_microblocks {
                 if !staging_microblocks[i].processed {
                     if staging_microblocks[i].block_data.len() == 0 {
-                        return Err(Error::NetError(net_error::DeserializeError(format!("Microblock {} does not have block data", staging_microblocks[i].microblock_hash.to_hex()))));
+                        return Err(Error::NetError(net_error::DeserializeError(format!("Microblock {} does not have block data", staging_microblocks[i].microblock_hash))));
                     }
 
                     let mut index = 0;
@@ -839,7 +839,7 @@ impl StacksChainState {
 
         if staging_microblocks.len() == 0 {
             // haven't seen any microblocks that descend from this block yet
-            test_debug!("No microblocks built on {}/{} up to {}", &burn_header_hash.to_hex(), &anchored_block_hash.to_hex(), last_seq);
+            test_debug!("No microblocks built on {}/{} up to {}", &burn_header_hash, &anchored_block_hash, last_seq);
             return Ok(None);
         }
 
@@ -1139,7 +1139,7 @@ impl StacksChainState {
                     return Ok(());
                 }
                 else {
-                    test_debug!("No such block at {}/{}", burn_hash.to_hex(), anchored_block_hash.to_hex());
+                    test_debug!("No such block at {}/{}", burn_hash, anchored_block_hash);
                     return Err(Error::DBError(db_error::NotFoundError));
                 }
             },
@@ -1155,19 +1155,19 @@ impl StacksChainState {
         if !block.processed {
             if !has_stored_block {
                 if accept {
-                    debug!("Accept block {}/{}", burn_hash.to_hex(), anchored_block_hash.to_hex());
+                    debug!("Accept block {}/{}", burn_hash, anchored_block_hash);
                     StacksChainState::move_staging_block_data_to_file(tx, anchored_block_hash, &block_path)?;
                 }
                 else {
-                    debug!("Reject block {}/{}", burn_hash.to_hex(), anchored_block_hash.to_hex());
+                    debug!("Reject block {}/{}", burn_hash, anchored_block_hash);
                 }
             }
             else {
-                debug!("Already stored block {}/{}", burn_hash.to_hex(), anchored_block_hash.to_hex());
+                debug!("Already stored block {}/{}", burn_hash, anchored_block_hash);
             }
         }
         else {
-            debug!("Already processed block {}/{}", burn_hash.to_hex(), anchored_block_hash.to_hex());
+            debug!("Already processed block {}/{}", burn_hash, anchored_block_hash);
         }
 
         let update_sql = "UPDATE staging_blocks SET processed = 1 WHERE burn_header_hash = ?1 AND anchored_block_hash = ?2".to_string();
@@ -1213,7 +1213,7 @@ impl StacksChainState {
             }
         };
 
-        test_debug!("Drop staging microblocks {}/{} up to {} ({})", burn_hash.to_hex(), anchored_block_hash.to_hex(), invalid_block_hash.to_hex(), seq);
+        test_debug!("Drop staging microblocks {}/{} up to {} ({})", burn_hash, anchored_block_hash, invalid_block_hash, seq);
 
         // drop staging children at and beyond the invalid block
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE anchored_block_hash = ?1 AND sequence >= ?2".to_string();
@@ -1274,7 +1274,7 @@ impl StacksChainState {
     
         let microblocks = StacksChainState::merge_microblock_streams(staging_microblocks, stored_microblocks)?;
 
-        debug!("Accept microblock stream rooted at {}/{}-{} (up to {})", burn_hash.to_hex(), anchored_block_hash.to_hex(), microblocks[0].block_hash().to_hex(), last_seq);
+        debug!("Accept microblock stream rooted at {}/{}-{} (up to {})", burn_hash, anchored_block_hash, microblocks[0].block_hash(), last_seq);
         StacksChainState::store_microblock_stream(tx.get_blocks_path(), burn_hash, &microblocks)?;
 
         // clear out of staging
@@ -1308,7 +1308,7 @@ impl StacksChainState {
                 return Some((0, None));
             }
             else {
-                warn!("Block {} has no ancestor, and should have no microblock parents", anchored_block_header.block_hash().to_hex());
+                warn!("Block {} has no ancestor, and should have no microblock parents", anchored_block_header.block_hash());
                 return None;
             }
         }
@@ -1319,7 +1319,7 @@ impl StacksChainState {
                 for microblock in microblocks.iter() {
                     let mut dup = microblock.clone();
                     if dup.verify(&parent_anchored_block_header.microblock_pubkey_hash).is_err() {
-                        warn!("Microblock {} not signed by {}", microblock.block_hash().to_hex(), parent_anchored_block_header.microblock_pubkey_hash.to_hex());
+                        warn!("Microblock {} not signed by {}", microblock.block_hash(), parent_anchored_block_header.microblock_pubkey_hash);
                         continue;
                     }
                     signed_microblocks.push(microblock.clone());
@@ -1333,12 +1333,12 @@ impl StacksChainState {
         if signed_microblocks.len() == 0 {
             if anchored_block_header.parent_microblock == EMPTY_MICROBLOCK_PARENT_HASH && anchored_block_header.parent_microblock_sequence == 0 {
                 // expected empty
-                warn!("No microblocks between {} and {}", parent_anchored_block_header.block_hash().to_hex(), anchored_block_header.block_hash().to_hex());
+                warn!("No microblocks between {} and {}", parent_anchored_block_header.block_hash(), anchored_block_header.block_hash());
                 return Some((0, None));
             }
             else {
                 // did not expect empty
-                warn!("Missing microblocks between {} and {}", parent_anchored_block_header.block_hash().to_hex(), anchored_block_header.block_hash().to_hex());
+                warn!("Missing microblocks between {} and {}", parent_anchored_block_header.block_hash(), anchored_block_header.block_hash());
                 return None;
             }
         }
@@ -1374,7 +1374,7 @@ impl StacksChainState {
         for i in 0..signed_microblocks.len() {
             let signed_microblock = &signed_microblocks[i];
             if parent_hashes.contains_key(&signed_microblock.header.prev_block) {
-                debug!("Deliberate microblock fork: duplicate parent {}", signed_microblock.header.prev_block.to_hex());
+                debug!("Deliberate microblock fork: duplicate parent {}", signed_microblock.header.prev_block);
                 let conflicting_microblock_header = parent_hashes.get(&signed_microblock.header.prev_block).unwrap();
 
                 return Some((i - 1, Some(TransactionPayload::PoisonMicroblock(signed_microblock.header.clone(), conflicting_microblock_header.clone()))));
@@ -1400,7 +1400,7 @@ impl StacksChainState {
         
         if anchored_block_header.parent_microblock == EMPTY_MICROBLOCK_PARENT_HASH && anchored_block_header.parent_microblock_sequence == 0 {
             // expected empty
-            debug!("Empty microblock stream between {} and {}", parent_anchored_block_header.block_hash().to_hex(), anchored_block_header.block_hash().to_hex());
+            debug!("Empty microblock stream between {} and {}", parent_anchored_block_header.block_hash(), anchored_block_header.block_hash());
             return Some((0, None));
         }
 
@@ -1416,7 +1416,7 @@ impl StacksChainState {
 
         if !connects {
             // discontiguous
-            debug!("Discontiguous stream: block {} does not connect to tail", anchored_block_header.block_hash().to_hex());
+            debug!("Discontiguous stream: block {} does not connect to tail", anchored_block_header.block_hash());
             return None;
         }
 
@@ -1508,7 +1508,7 @@ impl StacksChainState {
     pub fn preprocess_anchored_block<'a>(&mut self, burn_tx: &mut BurnDBTx<'a>, burn_header_hash: &BurnchainHeaderHash, block: &StacksBlock, parent_burn_header_hash: &BurnchainHeaderHash) -> Result<bool, Error> {
         // already in queue or already processed?
         if StacksChainState::has_stored_block(&self.blocks_path, burn_header_hash, &block.block_hash())? || StacksChainState::has_staging_block(&self.blocks_db, burn_header_hash, &block.block_hash())? {
-            test_debug!("Block already stored and/or processed: {}/{}", burn_header_hash.to_hex(), &block.block_hash());
+            test_debug!("Block already stored and/or processed: {}/{}", burn_header_hash, &block.block_hash());
             return Ok(false);
         }
         
@@ -1555,7 +1555,7 @@ impl StacksChainState {
     pub fn preprocess_streamed_microblock(&mut self, burn_header_hash: &BurnchainHeaderHash, anchored_block_hash: &BlockHeaderHash, microblock: &StacksMicroblock) -> Result<bool, Error> {
         // already queued or already processed?
         if StacksChainState::has_staging_microblock(&self.blocks_db, burn_header_hash, anchored_block_hash, &microblock.block_hash())? {
-            test_debug!("Microblock already stored and/or processed: {}/{} {} {}", burn_header_hash.to_hex(), &anchored_block_hash.to_hex(), microblock.block_hash().to_hex(), microblock.header.sequence);
+            test_debug!("Microblock already stored and/or processed: {}/{} {} {}", burn_header_hash, &anchored_block_hash, microblock.block_hash(), microblock.header.sequence);
             return Ok(true);
         }
 
@@ -1581,14 +1581,14 @@ impl StacksChainState {
 
         let mut dup = microblock.clone();
         if dup.verify(&pubkey_hash).is_err() {
-            warn!("Invalid microblock {}: failed to verify signature with {}", microblock.block_hash().to_hex(), pubkey_hash.to_hex());
+            warn!("Invalid microblock {}: failed to verify signature with {}", microblock.block_hash(), pubkey_hash);
             return Ok(false);
         }
 
         // static checks on transactions all pass
         let valid = microblock.validate_transactions_static(mainnet, chain_id);
         if !valid {
-            warn!("Invalid microblock {}: one or more transactions failed static tests", microblock.block_hash().to_hex());
+            warn!("Invalid microblock {}: one or more transactions failed static tests", microblock.block_hash());
             return Ok(false);
         }
 
@@ -1692,7 +1692,7 @@ impl StacksChainState {
             }
             None => {
                 // parent microblocks haven't arrived yet, or there are none
-                debug!("No parent microblock stream for {}: expected {},{}", staging_block.anchored_block_hash.to_hex(), staging_block.parent_microblock_hash.to_hex(), staging_block.parent_microblock_seq);
+                debug!("No parent microblock stream for {}: expected {},{}", staging_block.anchored_block_hash, staging_block.parent_microblock_hash, staging_block.parent_microblock_seq);
                 return Ok(None);
             }
         }
@@ -1716,7 +1716,7 @@ impl StacksChainState {
 
         let orphan_block = rows.pop().unwrap();
 
-        test_debug!("Delete orphaned block {}/{} and its microblocks, and orphan its children", &orphan_block.burn_header_hash.to_hex(), &orphan_block.anchored_block_hash.to_hex());
+        test_debug!("Delete orphaned block {}/{} and its microblocks, and orphan its children", &orphan_block.burn_header_hash, &orphan_block.anchored_block_hash);
 
         StacksChainState::delete_orphaned_epoch_data(blocks_tx, &orphan_block.burn_header_hash, &orphan_block.anchored_block_hash)?;
         Ok(true)
@@ -1745,8 +1745,8 @@ impl StacksChainState {
                     let candidate = StagingBlock::from_row(&row).map_err(Error::DBError)?;
                     
                     test_debug!("Consider block {}/{} whose parent is {}/{}", 
-                                &candidate.burn_header_hash.to_hex(), &candidate.anchored_block_hash.to_hex(),
-                                &candidate.parent_burn_header_hash.to_hex(), &candidate.parent_anchored_block_hash.to_hex());
+                                &candidate.burn_header_hash, &candidate.anchored_block_hash,
+                                &candidate.parent_burn_header_hash, &candidate.parent_anchored_block_hash);
         
                     let can_attach = {
                         if candidate.parent_anchored_block_hash == FIRST_STACKS_BLOCK_HASH {
@@ -1773,7 +1773,7 @@ impl StacksChainState {
                                 },
                                 _ => {
                                     // should be impossible -- stored the same block twice
-                                    unreachable!("Stored the same block twice: {}/{}", &candidate.parent_anchored_block_hash.to_hex(), &candidate.parent_burn_header_hash.to_hex());
+                                    unreachable!("Stored the same block twice: {}/{}", &candidate.parent_anchored_block_hash, &candidate.parent_burn_header_hash);
                                 }
                             }
                         }
@@ -1785,7 +1785,7 @@ impl StacksChainState {
                             Some(staging_block) => {
                                 // must be unprocessed -- must have a block
                                 if staging_block.block_data.len() == 0 {
-                                    return Err(Error::NetError(net_error::DeserializeError(format!("No block data for staging block {}", candidate.anchored_block_hash.to_hex()))));
+                                    return Err(Error::NetError(net_error::DeserializeError(format!("No block data for staging block {}", candidate.anchored_block_hash))));
                                 }
 
                                 // find its microblock parent stream
@@ -1968,7 +1968,7 @@ impl StacksChainState {
                     let last_microblock_hash = microblocks[num_mblocks-1].block_hash();
                     let last_microblock_seq = microblocks[num_mblocks-1].header.sequence;
 
-                    test_debug!("\n\nAppend {} microblocks {}/{}-{} off of {}/{}\n", num_mblocks, chain_tip_burn_header_hash.to_hex(), _first_mblock_hash, last_microblock_hash, parent_burn_header_hash.to_hex(), parent_block_hash.to_hex());
+                    test_debug!("\n\nAppend {} microblocks {}/{}-{} off of {}/{}\n", num_mblocks, chain_tip_burn_header_hash, _first_mblock_hash, last_microblock_hash, parent_burn_header_hash, parent_block_hash);
                     (last_microblock_hash, last_microblock_seq)
                 }
                 else {
@@ -1978,7 +1978,7 @@ impl StacksChainState {
             if last_microblock_hash != block.header.parent_microblock || last_microblock_seq != block.header.parent_microblock_sequence {
                 // the pre-processing step should prevent this from being reached
                 panic!("BUG: received discontiguous headers for processing: {} (seq={}) does not connect to {} (microblock parent is {} (seq {}))",
-                       last_microblock_hash.to_hex(), last_microblock_seq, block.block_hash(), block.header.parent_microblock.to_hex(), block.header.parent_microblock_sequence);
+                       last_microblock_hash, last_microblock_seq, block.block_hash(), block.header.parent_microblock, block.header.parent_microblock_sequence);
             }
             
             let mut clarity_tx = StacksChainState::chainstate_block_begin(chainstate_tx, clarity_instance, &parent_burn_header_hash, &parent_block_hash, &MINER_BLOCK_BURN_HEADER_HASH, &MINER_BLOCK_HEADER_HASH);
@@ -1986,7 +1986,7 @@ impl StacksChainState {
             // process microblock stream
             let (microblock_fees, _microblock_burns) = match StacksChainState::process_microblocks_transactions(&mut clarity_tx, &microblocks) {
                 Err((e, offending_mblock_header_hash)) => {
-                    let msg = format!("Invalid Stacks microblocks {},{} (offender {}): {:?}", block.header.parent_microblock.to_hex(), block.header.parent_microblock_sequence, offending_mblock_header_hash.to_hex(), &e);
+                    let msg = format!("Invalid Stacks microblocks {},{} (offender {}): {:?}", block.header.parent_microblock, block.header.parent_microblock_sequence, offending_mblock_header_hash, &e);
                     warn!("{}", &msg);
 
                     clarity_tx.rollback_block();
@@ -1998,14 +1998,14 @@ impl StacksChainState {
             };
             
             test_debug!("\n\nAppend block {}/{} off of {}/{}\nStacks block height: {}, Total Burns: {}\nMicroblock parent: {} (seq {}) (count {})\n", 
-                        chain_tip_burn_header_hash.to_hex(), block.block_hash().to_hex(), parent_burn_header_hash.to_hex(), parent_block_hash.to_hex(),
+                        chain_tip_burn_header_hash, block.block_hash(), parent_burn_header_hash, parent_block_hash,
                         block.header.total_work.work, block.header.total_work.burn,
-                        last_microblock_hash.to_hex(), last_microblock_seq, microblocks.len());
+                        last_microblock_hash, last_microblock_seq, microblocks.len());
 
             // process anchored block
             let (block_fees, block_burns) = match StacksChainState::process_block_transactions(&mut clarity_tx, &block) {
                 Err(e) => {
-                    let msg = format!("Invalid Stacks block {}: {:?}", block.block_hash().to_hex(), &e);
+                    let msg = format!("Invalid Stacks block {}: {:?}", block.block_hash(), &e);
                     warn!("{}", &msg);
 
                     clarity_tx.rollback_block();
@@ -2029,7 +2029,7 @@ impl StacksChainState {
                 return Err(Error::InvalidStacksBlock(msg));
             }
 
-            debug!("Reached state root {}", root_hash.to_hex());
+            debug!("Reached state root {}", root_hash);
             
             // good to go!
             clarity_tx.commit_to_block(chain_tip_burn_header_hash, &block.block_hash());
@@ -2092,12 +2092,12 @@ impl StacksChainState {
             }
         };
 
-        debug!("Process staging block {}/{}", next_staging_block.burn_header_hash.to_hex(), next_staging_block.anchored_block_hash.to_hex());
+        debug!("Process staging block {}/{}", next_staging_block.burn_header_hash, next_staging_block.anchored_block_hash);
 
         let parent_block_header_info = {
             let parent_block_header_info = match StacksChainState::get_anchored_block_header_info(&chainstate_tx.headers_tx, &next_staging_block.parent_burn_header_hash, &next_staging_block.parent_anchored_block_hash)? {
                 Some(parent_info) => {
-                    debug!("Found parent info {}/{}", next_staging_block.parent_burn_header_hash.to_hex(), next_staging_block.parent_anchored_block_hash.to_hex());
+                    debug!("Found parent info {}/{}", next_staging_block.parent_burn_header_hash, next_staging_block.parent_anchored_block_hash);
                     parent_info
                 },
                 None => {
@@ -2108,7 +2108,7 @@ impl StacksChainState {
                     }
                     else {
                         // no parent stored
-                        debug!("No parent block for {}/{} processed yet", next_staging_block.burn_header_hash.to_hex(), next_staging_block.anchored_block_hash.to_hex());
+                        debug!("No parent block for {}/{} processed yet", next_staging_block.burn_header_hash, next_staging_block.anchored_block_hash);
                         return Ok((None, None));
                     }
                 }
@@ -2125,13 +2125,13 @@ impl StacksChainState {
         let block_hash = block.block_hash();
         if block_hash != next_staging_block.anchored_block_hash {
             // database corruption
-            error!("Staging DB corruption: expected block {}, got {}", block_hash.to_hex(), next_staging_block.anchored_block_hash.to_hex());
+            error!("Staging DB corruption: expected block {}, got {}", block_hash, next_staging_block.anchored_block_hash);
             return Err(Error::DBError(db_error::Corruption));
         }
 
         // sanity check -- don't process this block again if we already did so
         if StacksChainState::has_stored_block(chainstate_tx.blocks_tx.get_blocks_path(), &next_staging_block.burn_header_hash, &next_staging_block.anchored_block_hash)? {
-            debug!("Block already processed: {}/{}", &next_staging_block.burn_header_hash.to_hex(), &next_staging_block.anchored_block_hash.to_hex());
+            debug!("Block already processed: {}/{}", &next_staging_block.burn_header_hash, &next_staging_block.anchored_block_hash);
 
             // clear out
             StacksChainState::set_block_processed(&mut chainstate_tx.blocks_tx, &next_staging_block.burn_header_hash, &next_staging_block.anchored_block_hash, true)?;
@@ -2141,7 +2141,7 @@ impl StacksChainState {
         // validation check -- we can't have seen this block's microblock public key hash before in
         // this fork
         if StacksChainState::has_microblock_pubkey_hash(&mut chainstate_tx.headers_tx, &parent_block_header_info.burn_header_hash, &parent_block_header_info.anchored_header, &block.header.microblock_pubkey_hash)? {
-            let msg = format!("Invalid stacks block -- already used microblock pubkey hash {}", &block.header.microblock_pubkey_hash.to_hex());
+            let msg = format!("Invalid stacks block -- already used microblock pubkey hash {}", &block.header.microblock_pubkey_hash);
             warn!("{}", &msg);
             return Err(Error::InvalidStacksBlock(msg));
         }
@@ -2152,7 +2152,7 @@ impl StacksChainState {
         let (microblock_terminus, poison_microblock_opt) = match StacksChainState::validate_parent_microblock_stream(&parent_block_header_info.anchored_header, &block.header, &next_microblocks, false) {
             Some((terminus, poison_opt)) => (terminus, poison_opt),
             None => {
-                debug!("Stopping at block {}/{} -- discontiguous header stream", next_staging_block.burn_header_hash.to_hex(), block_hash.to_hex());
+                debug!("Stopping at block {}/{} -- discontiguous header stream", next_staging_block.burn_header_hash, block_hash);
                 return Ok((None, None));
             }
         };
@@ -2174,7 +2174,7 @@ impl StacksChainState {
 
         // do not consider trailing microblocks that this anchored block does _not_ confirm
         if microblock_terminus < next_microblocks.len() {
-            debug!("Truncate microblock stream from parent {}/{} from {} to {} items", parent_block_header_info.burn_header_hash.to_hex(), parent_block_header_info.anchored_header.block_hash().to_hex(), next_microblocks.len(), microblock_terminus);
+            debug!("Truncate microblock stream from parent {}/{} from {} to {} items", parent_block_header_info.burn_header_hash, parent_block_header_info.anchored_header.block_hash(), next_microblocks.len(), microblock_terminus);
             next_microblocks.truncate(microblock_terminus);
         }
 
@@ -2207,7 +2207,7 @@ impl StacksChainState {
                 // anchored block was invalid.  Either way, the anchored block will _never be_
                 // valid, so we can drop it from the chunk store and orphan all of its descendents.
                 StacksChainState::set_block_processed(&mut chainstate_tx.blocks_tx, &next_staging_block.burn_header_hash, &block.header.block_hash(), false)
-                    .expect(&format!("FATAL: failed to clear invalid block {}/{}", next_staging_block.burn_header_hash.to_hex(), &block.header.block_hash().to_hex()));
+                    .expect(&format!("FATAL: failed to clear invalid block {}/{}", next_staging_block.burn_header_hash, &block.header.block_hash()));
                 
                 StacksChainState::free_block_state(&blocks_path, &next_staging_block.burn_header_hash, &block.header);
 
@@ -2216,7 +2216,7 @@ impl StacksChainState {
                         // specifically, an ancestor microblock was invalid.  Drop any descendent microblocks --
                         // they're never going to be valid in _any_ fork, even if they have a clone
                         // in a neighboring burnchain fork.
-                        error!("Parent microblock stream from {}/{} is invalid at microblock {}: {}", parent_block_header_info.burn_header_hash.to_hex(), parent_block_header_info.anchored_header.block_hash().to_hex(), header_hash, msg);
+                        error!("Parent microblock stream from {}/{} is invalid at microblock {}: {}", parent_block_header_info.burn_header_hash, parent_block_header_info.anchored_header.block_hash(), header_hash, msg);
                         StacksChainState::drop_staging_microblocks(&mut chainstate_tx.blocks_tx, &parent_block_header_info.burn_header_hash, &parent_block_header_info.anchored_header.block_hash(), header_hash)?;
                     },
                     _ => {
@@ -2234,7 +2234,7 @@ impl StacksChainState {
         assert_eq!(next_chain_tip.anchored_header.parent_microblock, last_microblock_hash);
         assert_eq!(next_chain_tip.anchored_header.parent_microblock_sequence, last_microblock_seq);
 
-        debug!("Reached chain tip {}/{} from {}/{}", next_chain_tip.burn_header_hash.to_hex(), next_chain_tip.anchored_header.block_hash().to_hex(), next_staging_block.parent_burn_header_hash.to_hex(), next_staging_block.parent_anchored_block_hash.to_hex());
+        debug!("Reached chain tip {}/{} from {}/{}", next_chain_tip.burn_header_hash, next_chain_tip.anchored_header.block_hash(), next_staging_block.parent_burn_header_hash, next_staging_block.parent_anchored_block_hash);
 
         if next_staging_block.parent_microblock_hash != EMPTY_MICROBLOCK_PARENT_HASH || next_staging_block.parent_microblock_seq != 0 {
             // confirmed one or more parent microblocks

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -829,9 +829,9 @@ impl StacksChainState {
 
         let new_index_block = StacksBlockHeader::make_index_block_hash(new_burn_hash, new_block);
 
-        test_debug!("Begin processing Stacks block off of {}/{}", parent_burn_hash.to_hex(), parent_block.to_hex());
-        test_debug!("Child MARF index root:  {} = {} + {}", new_index_block.to_hex(), new_burn_hash.to_hex(), new_block.to_hex());
-        test_debug!("Parent MARF index root: {} = {} + {}", parent_index_block.to_hex(), parent_burn_hash.to_hex(), parent_block.to_hex());
+        test_debug!("Begin processing Stacks block off of {}/{}", parent_burn_hash, parent_block);
+        test_debug!("Child MARF index root:  {} = {} + {}", new_index_block, new_burn_hash, new_block);
+        test_debug!("Parent MARF index root: {} = {} + {}", parent_index_block, parent_burn_hash, parent_block);
 
         let inner_clarity_tx = clarity_instance.begin_block(&parent_index_block, &new_index_block, headers_db);
 
@@ -859,10 +859,10 @@ impl StacksChainState {
         // (this restriction is required to ensure that a poison microblock transaction can only apply to
         // a single epoch)
         let parent_hash = StacksChainState::get_index_hash(tip_burn_hash, tip_header);
-        match headers_tx.get_indexed(&parent_hash, &format!("chainstate::pubkey_hash::{}", pubkey_hash.to_hex())).map_err(Error::DBError)? {
+        match headers_tx.get_indexed(&parent_hash, &format!("chainstate::pubkey_hash::{}", pubkey_hash)).map_err(Error::DBError)? {
             Some(status_str) => {
                 // pubkey hash was seen before
-                debug!("Public key hash {} already used", pubkey_hash.to_hex());
+                debug!("Public key hash {} already used", pubkey_hash);
                 return Ok(true);
             },
             None => {
@@ -899,7 +899,7 @@ impl StacksChainState {
             };
 
         let indexed_keys = vec![
-            format!("chainstate::pubkey_hash::{}", new_tip.microblock_pubkey_hash.to_hex())
+            format!("chainstate::pubkey_hash::{}", new_tip.microblock_pubkey_hash)
         ];
 
         let indexed_values = vec![
@@ -925,7 +925,7 @@ impl StacksChainState {
         StacksChainState::insert_stacks_block_header(headers_tx, &new_tip_info)?;
         StacksChainState::insert_miner_payment_schedule(headers_tx, block_reward, user_burns)?;
 
-        debug!("Advanced to new tip! {}/{}", new_burn_block.to_hex(), new_tip.block_hash());
+        debug!("Advanced to new tip! {}/{}", new_burn_block, new_tip.block_hash());
         Ok(new_tip_info)
     }
 }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -785,6 +785,13 @@ impl StacksChainState {
         Ok((chainstate_tx, clarity_instance))
     }
 
+    #[cfg(test)]
+    pub fn clarity_eval_read_only(&mut self, parent_id_bhh: &BlockHeaderHash,
+                                  contract: &QualifiedContractIdentifier, code: &str) -> Value {
+        let result = self.clarity_state.eval_read_only(parent_id_bhh, &self.headers_db, contract, code);
+        result.unwrap()
+    }
+
     /// Begin processing an epoch's transactions within the context of a chainstate transaction
     pub fn chainstate_block_begin<'a>(chainstate_tx: &'a ChainstateTx<'a>, clarity_instance: &'a mut ClarityInstance, parent_burn_hash: &BurnchainHeaderHash, parent_block: &BlockHeaderHash, new_burn_hash: &BurnchainHeaderHash, new_block: &BlockHeaderHash) -> ClarityTx<'a> {
         let conf = chainstate_tx.config.clone();

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -115,7 +115,7 @@ impl StacksChainState {
     fn process_transaction_precheck<'a>(clarity_tx: &mut ClarityTx<'a>, tx: &StacksTransaction) -> Result<(), Error> {
         // valid auth?
         if !tx.verify().map_err(Error::NetError)? {
-            let msg = format!("Invalid tx {}: invalid signature(s)", tx.txid().to_hex());
+            let msg = format!("Invalid tx {}: invalid signature(s)", tx.txid());
             warn!("{}", &msg);
 
             return Err(Error::InvalidStacksTransaction(msg));
@@ -123,7 +123,7 @@ impl StacksChainState {
 
         // destined for us?
         if clarity_tx.config.chain_id != tx.chain_id {
-            let msg = format!("Invalid tx {}: invalid chain ID {} (expected {})", tx.txid().to_hex(), tx.chain_id, clarity_tx.config.chain_id);
+            let msg = format!("Invalid tx {}: invalid chain ID {} (expected {})", tx.txid(), tx.chain_id, clarity_tx.config.chain_id);
             warn!("{}", &msg);
 
             return Err(Error::InvalidStacksTransaction(msg));
@@ -132,7 +132,7 @@ impl StacksChainState {
         match tx.version {
             TransactionVersion::Mainnet => {
                 if !clarity_tx.config.mainnet {
-                    let msg = format!("Invalid tx {}: on testnet; got mainnet", tx.txid().to_hex());
+                    let msg = format!("Invalid tx {}: on testnet; got mainnet", tx.txid());
                     warn!("{}", &msg);
 
                     return Err(Error::InvalidStacksTransaction(msg));
@@ -140,7 +140,7 @@ impl StacksChainState {
             },
             TransactionVersion::Testnet => {
                 if clarity_tx.config.mainnet {
-                    let msg = format!("Invalid tx {}: on mainnet; got testnet", tx.txid().to_hex());
+                    let msg = format!("Invalid tx {}: on mainnet; got testnet", tx.txid());
                     warn!("{}", &msg);
 
                     return Err(Error::InvalidStacksTransaction(msg));
@@ -332,7 +332,7 @@ impl StacksChainState {
         .map_err(|e| {
             match e {
                 clarity_error::BadTransaction(ref s) => {
-                    let msg = format!("Error validating STX-transfer transaction {:?}: {}", txid.to_hex(), s);
+                    let msg = format!("Error validating STX-transfer transaction {:?}: {}", txid, s);
                     warn!("{}", &msg);
 
                     Error::InvalidStacksTransaction(msg)
@@ -388,7 +388,7 @@ impl StacksChainState {
                         }
                     }
                 }.map_err(|e| {
-                    warn!("Invalid contract-call transaction {}: {:?}", &tx.txid().to_hex(), &e);
+                    warn!("Invalid contract-call transaction {}: {:?}", &tx.txid(), &e);
                     Error::ClarityError(e)
                 })?;
 
@@ -449,7 +449,7 @@ impl StacksChainState {
                         }
                     }
                 }.map_err(|e| {
-                    warn!("Invalid smart-contract transaction {}: {:?}", &tx.txid().to_hex(), &e);
+                    warn!("Invalid smart-contract transaction {}: {:?}", &tx.txid(), &e);
                     Error::ClarityError(e)
                 })?;
                 
@@ -472,7 +472,7 @@ impl StacksChainState {
 
     /// Process a transaction.  Return the fee and amount of STX destroyed
     pub fn process_transaction<'a>(clarity_tx: &mut ClarityTx<'a>, tx: &StacksTransaction) -> Result<(u64, u128), Error> {
-        test_debug!("Process transaction {}", tx.txid().to_hex());
+        test_debug!("Process transaction {}", tx.txid());
 
         StacksChainState::process_transaction_precheck(clarity_tx, tx)?;
 
@@ -486,13 +486,13 @@ impl StacksChainState {
 
         // check nonces
         if origin.nonce() != origin_account.nonce {
-            let msg = format!("Bad nonce: origin account nonce of tx {} is {} (expected {})", tx.txid().to_hex(), origin.nonce(), origin_account.nonce);
+            let msg = format!("Bad nonce: origin account nonce of tx {} is {} (expected {})", tx.txid(), origin.nonce(), origin_account.nonce);
             warn!("{}", &msg);
             return Err(Error::InvalidStacksTransaction(msg));
         }
 
         if payer.nonce() != payer_account.nonce {
-            let msg = format!("Bad nonce: payer account nonce of tx {} is {} (expected {})", tx.txid().to_hex(), payer.nonce(), payer_account.nonce);
+            let msg = format!("Bad nonce: payer account nonce of tx {} is {} (expected {})", tx.txid(), payer.nonce(), payer_account.nonce);
             warn!("{}", &msg);
             return Err(Error::InvalidStacksTransaction(msg));
         }

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -599,6 +599,7 @@ impl MARF {
 
         test_debug!("Set {}::{} = {}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height, next_block_hash.to_hex());
         test_debug!("Set {}::{} = {}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, next_block_hash.to_hex(), height);
+        test_debug!("Set {} = {}", OWN_BLOCK_HEIGHT_KEY, height);
 
         keys.push(OWN_BLOCK_HEIGHT_KEY.to_string());
         values.push(MARFValue::from(height));

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -2056,14 +2056,9 @@ mod test {
             assert_eq!(MARF::get_block_height_miner_tip(marf.borrow_storage_backend(), block, &block_header, Some(&target_block)).unwrap(),
                        Some(i as u32));
 
-            if i == num_blocks_created {
-                assert_eq!(MARF::get_block_at_height(marf.borrow_storage_backend(), i as u32, &block_header).unwrap(),
-                           Some(target_block.clone()));
-            }
-            else {
-                assert_eq!(MARF::get_block_at_height(marf.borrow_storage_backend(), i as u32, &block_header).unwrap(),
-                           Some(block.clone()));
-            }
+            // get_block_at_height should now always return the correct block_header
+            assert_eq!(MARF::get_block_at_height(marf.borrow_storage_backend(), i as u32, &block_header).unwrap(),
+                       Some(block.clone()));
         }
 
         root_table_cache = None;

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -780,6 +780,13 @@ impl MARF {
         Ok(())
     }
 
+    pub fn get_block_height_of(&mut self, bhh: &BlockHeaderHash, current_block_hash: &BlockHeaderHash) -> Result<Option<u32>, Error> {
+        if Some(bhh) == self.get_open_chain_tip() {
+            return Ok(self.get_open_chain_tip_height())
+        }
+        MARF::get_block_height(&mut self.storage, bhh, current_block_hash)
+    }
+
     /// Get open chain tip
     pub fn get_open_chain_tip(&self) -> Option<&BlockHeaderHash> {
         self.open_chain_tip.as_ref()

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -453,7 +453,7 @@ impl MARF {
             assert!(false);
         }
 
-        test_debug!("MARF Insert in {}: '{}' = '{}' (...{:?})", block_hash.to_hex(), path.to_hex(), leaf_value.data.to_hex(), &leaf_value.path);
+        test_debug!("MARF Insert in {}: '{}' = '{}' (...{:?})", block_hash, path, leaf_value.data, &leaf_value.path);
         
         Trie::add_value(storage, &mut cursor, &mut value)?;
 
@@ -597,8 +597,8 @@ impl MARF {
         let height_key = format!("{}::{}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height);
         let hash_key = format!("{}::{}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, next_block_hash);
 
-        test_debug!("Set {}::{} = {}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height, next_block_hash.to_hex());
-        test_debug!("Set {}::{} = {}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, next_block_hash.to_hex(), height);
+        test_debug!("Set {}::{} = {}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height, next_block_hash);
+        test_debug!("Set {}::{} = {}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, next_block_hash, height);
         test_debug!("Set {} = {}", OWN_BLOCK_HEIGHT_KEY, height);
 
         keys.push(OWN_BLOCK_HEIGHT_KEY.to_string());
@@ -612,10 +612,10 @@ impl MARF {
 
         if height > 0 {
             let prev_height_key = format!("{}::{}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height - 1);
-            let prev_hash_key = format!("{}::{}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, block_hash.to_hex());
+            let prev_hash_key = format!("{}::{}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, block_hash);
 
-            test_debug!("Set {}::{} = {}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height - 1, block_hash.to_hex());
-            test_debug!("Set {}::{} = {}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, block_hash.to_hex(), height - 1);
+            test_debug!("Set {}::{} = {}", BLOCK_HEIGHT_TO_HASH_MAPPING_KEY, height - 1, block_hash);
+            test_debug!("Set {}::{} = {}", BLOCK_HASH_TO_HEIGHT_MAPPING_KEY, block_hash, height - 1);
 
             keys.push(prev_height_key);
             values.push(MARFValue::from(block_hash.clone()));
@@ -709,18 +709,18 @@ impl MARF {
 
         // new chain tip must not exist
         if self.storage.open_block(next_chain_tip).is_ok() {
-            error!("Block data already exists: {}", next_chain_tip.to_hex());
+            error!("Block data already exists: {}", next_chain_tip);
             return Err(Error::ExistsError);
         }
 
         // current chain tip must exist if it's not the "sentinel"
         let is_parent_sentinel = chain_tip == &TrieFileStorage::block_sentinel();
         if !is_parent_sentinel {
-            trace!("Extending off of existing node {}", chain_tip.to_hex());
+            trace!("Extending off of existing node {}", chain_tip);
             self.storage.open_block(chain_tip)?;
         }
         else {
-            trace!("First-ever block {}", next_chain_tip.to_hex());
+            trace!("First-ever block {}", next_chain_tip);
         }
 
         let block_height = 
@@ -2056,7 +2056,7 @@ mod test {
         blocks.push(block_header.clone());
 
         for (i, block) in blocks.iter().enumerate() {
-            debug!("Verify block height and hash at {} {} from {}", i, block, block_header.to_hex());
+            debug!("Verify block height and hash at {} {} from {}", i, block, block_header);
             assert_eq!(MARF::get_block_height_miner_tip(marf.borrow_storage_backend(), block, &block_header, Some(&target_block)).unwrap(),
                        Some(i as u32));
 
@@ -2081,7 +2081,7 @@ mod test {
             let read_from_block = final_block_header.clone();
 
             // all I/O happens off the final block header
-            debug!("{}: Get {} off of {}", i, &triepath.to_hex(), &read_from_block.to_hex());
+            debug!("{}: Get {} off of {}", i, &triepath, &read_from_block);
             let read_value = MARF::get_path(marf.borrow_storage_backend(), &read_from_block,
                                             &TriePath::from_bytes(&path[..]).unwrap()).unwrap().unwrap();
 
@@ -2092,7 +2092,7 @@ mod test {
             //    std::env::set_var("BLOCKSTACK_TRACE", "1");
             }
             // can make a merkle proof to each one using the final committed block header
-            debug!("{}: Check proof for {} off of {}", i, &triepath.to_hex(), &read_from_block.to_hex());
+            debug!("{}: Check proof for {} off of {}", i, &triepath, &read_from_block);
             root_table_cache = Some(
                 merkle_test_marf(marf.borrow_storage_backend(), &read_from_block, &path.to_vec(), &value.data.to_vec(), root_table_cache));
         }

--- a/src/chainstate/stacks/index/mod.rs
+++ b/src/chainstate/stacks/index/mod.rs
@@ -112,13 +112,6 @@ impl TrieHash {
     }
 }
 
-
-impl fmt::Display for TrieHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", to_hex(&self.0))
-    }
-}
-
 impl AsRef<[u8]> for TrieHash {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/src/chainstate/stacks/index/proofs.rs
+++ b/src/chainstate/stacks/index/proofs.rs
@@ -380,8 +380,8 @@ impl TrieMerkleProof {
             }
             if idx == 0 {
                 panic!("ancestor_height = {}, current_height = {}, but ancestor hash `{}` not found in: [{}]",
-                       ancestor_height, current_height, ancestor_root_hash.to_hex(),
-                       ancestor_hashes.iter().map(|x| format!("{}", x.to_hex())).collect::<Vec<_>>().join(", "))
+                       ancestor_height, current_height, ancestor_root_hash,
+                       ancestor_hashes.iter().map(|x| format!("{}", x)).collect::<Vec<_>>().join(", "))
             }
             idx -= 1;
 

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -1270,7 +1270,7 @@ impl TrieFileStorage {
     /// will process a block as if it's hash is all 0's (in order to validate the state root), and
     /// then use this method to switch over the block hash to the "real" block hash.
     fn block_retarget(&mut self, cur_bhh: &BlockHeaderHash, new_bhh: &BlockHeaderHash) -> Result<(), Error> {
-        debug!("Retarget block {} to {}", cur_bhh.to_hex(), new_bhh.to_hex());
+        debug!("Retarget block {} to {}", cur_bhh, new_bhh);
 
         // switch over state
         let block_dir = TrieFileStorage::block_dir(&self.dir_path, new_bhh);

--- a/src/chainstate/stacks/index/trie.rs
+++ b/src/chainstate/stacks/index/trie.rs
@@ -684,7 +684,7 @@ impl Trie {
                 trace!("update_root_hash: Updated {:?} with {:?} from {:?} to {:?} + {:?} = {:?} (fixed root)", &node, &child_ptr, &_cur_hash, &node_hash, &_hs[1..].to_vec(), &h);
             }
 
-            test_debug!("Next root hash is {} (update_skiplist={})", h.to_hex(), update_skiplist);
+            test_debug!("Next root hash is {} (update_skiplist={})", h, update_skiplist);
 
             storage.write_nodetype(child_ptr.ptr(), &node, h)?;
         }
@@ -736,7 +736,7 @@ impl Trie {
                                     trace!("update_root_hash: Updated {:?} with {:?} from {:?} to {:?} + {:?} = {:?}", &node, &child_ptr, &_cur_hash, &content_hash, &hs[1..].to_vec(), &h);
                                 }
             
-                                test_debug!("Next root hash is {} (update_skiplist={})", h.to_hex(), update_skiplist);
+                                test_debug!("Next root hash is {} (update_skiplist={})", h, update_skiplist);
                                 h
                             }
                             else {

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -165,7 +165,7 @@ impl StacksBlockBuilder {
         self.prev_microblock_header.prev_block = block.block_hash();
         self.anchored_done = true;
 
-        test_debug!("\n\nMiner {}: Mined anchored block {}, {} transactions, state root is {}\n", self.miner_id, block.block_hash().to_hex(), block.txs.len(), state_root_hash.to_hex());
+        test_debug!("\n\nMiner {}: Mined anchored block {}, {} transactions, state root is {}\n", self.miner_id, block.block_hash(), block.txs.len(), state_root_hash);
 
         block
     }
@@ -203,7 +203,7 @@ impl StacksBlockBuilder {
 
         self.micro_txs.clear();
         
-        test_debug!("\n\nMiner {}: Mined microblock block {} (seq={}): {} transaction(s)\n", self.miner_id, microblock.block_hash().to_hex(), microblock.header.sequence, microblock.txs.len());
+        test_debug!("\n\nMiner {}: Mined microblock block {} (seq={}): {} transaction(s)\n", self.miner_id, microblock.block_hash(), microblock.header.sequence, microblock.txs.len());
         Ok(microblock)
     }
     
@@ -225,7 +225,7 @@ impl StacksBlockBuilder {
         let new_burn_hash = MINER_BLOCK_BURN_HEADER_HASH.clone();
         let new_block_hash = MINER_BLOCK_HEADER_HASH.clone();
 
-        test_debug!("\n\nMiner {} epoch begin off of {}/{}\n", self.miner_id, self.chain_tip.burn_header_hash.to_hex(), self.header.parent_block.to_hex());
+        test_debug!("\n\nMiner {} epoch begin off of {}/{}\n", self.miner_id, self.chain_tip.burn_header_hash, self.header.parent_block);
 
         if let Some(ref _payout) = self.miner_payouts {
             test_debug!("Miner payout to process: {:?}", _payout);
@@ -251,7 +251,7 @@ impl StacksBlockBuilder {
             let (stx_spent, _stx_burnt) = match StacksChainState::process_microblocks_transactions(&mut tx, &parent_microblocks) {
                 Ok((stx_spent, stx_burnt)) => (stx_spent, stx_burnt),
                 Err((e, mblock_header_hash)) => {
-                    let msg = format!("Invalid Stacks microblocks {},{} (offender {}): {:?}", parent_burn_header_hash.to_hex(), parent_header_hash.to_hex(), mblock_header_hash.to_hex(), &e);
+                    let msg = format!("Invalid Stacks microblocks {},{} (offender {}): {:?}", parent_burn_header_hash, parent_header_hash, mblock_header_hash, &e);
                     warn!("{}", &msg);
 
                     return Err(Error::InvalidStacksMicroblock(msg, mblock_header_hash));
@@ -276,7 +276,7 @@ impl StacksBlockBuilder {
 
         // clear out the block trie we just created, so the block validator logic doesn't step all
         // over it.
-        let moved_filename = format!("{}.mined", index_block_hash.to_hex());
+        let moved_filename = format!("{}.mined", index_block_hash);
         let block_pathbuf = tx.get_block_path(&new_burn_hash, &new_block_hash);
         let mut mined_block_pathbuf = block_pathbuf.clone();
         mined_block_pathbuf.set_file_name(&moved_filename);
@@ -291,7 +291,7 @@ impl StacksBlockBuilder {
 
         debug!("Moved {:?} -> {:?}", &block_pathbuf, &mined_block_pathbuf);
 
-        test_debug!("\n\nMiner {}: Finished mining child of {}/{}. Trie is in {:?}\n", self.miner_id, self.chain_tip.burn_header_hash.to_hex(), self.chain_tip.anchored_header.block_hash().to_hex(), &mined_block_pathbuf);
+        test_debug!("\n\nMiner {}: Finished mining child of {}/{}. Trie is in {:?}\n", self.miner_id, self.chain_tip.burn_header_hash, self.chain_tip.anchored_header.block_hash(), &mined_block_pathbuf);
     }
 }
 
@@ -735,7 +735,7 @@ pub mod test {
                         work: parent_stacks_block.header.total_work.work.checked_add(1).expect("FATAL: stacks block height overflow")
                     };
 
-                    test_debug!("Work in {} {}: {},{}", burn_block.block_height, burn_block.parent_snapshot.burn_header_hash.to_hex(), new_work.burn, new_work.work);
+                    test_debug!("Work in {} {}: {},{}", burn_block.block_height, burn_block.parent_snapshot.burn_header_hash, new_work.burn, new_work.work);
                     let builder = StacksBlockBuilder::from_parent(miner.id, &parent_chain_tip, &new_work, &proof, &miner.next_microblock_privkey());
                     (builder, Some(parent_stacks_block_snapshot))
                 }
@@ -784,12 +784,12 @@ pub mod test {
         };
 
         // "discover" this stacks block
-        test_debug!("\n\nPreprocess Stacks block {}/{}", &commit_snapshot.burn_header_hash.to_hex(), &block_hash.to_hex());
+        test_debug!("\n\nPreprocess Stacks block {}/{}", &commit_snapshot.burn_header_hash, &block_hash);
         let block_res = node.chainstate.preprocess_anchored_block(&mut tx, &commit_snapshot.burn_header_hash, &stacks_block, &parent_block_burn_header_hash).unwrap();
 
         // "discover" this stacks microblock stream
         for mblock in stacks_microblocks.iter() {
-            test_debug!("Preprocess Stacks microblock {}-{} (seq {})", &block_hash.to_hex(), mblock.block_hash().to_hex(), mblock.header.sequence);
+            test_debug!("Preprocess Stacks microblock {}-{} (seq {})", &block_hash, mblock.block_hash(), mblock.header.sequence);
             let mblock_res = node.chainstate.preprocess_streamed_microblock(&commit_snapshot.burn_header_hash, &stacks_block.block_hash(), mblock).unwrap();
             if !mblock_res {
                 return Some(mblock_res)
@@ -961,7 +961,7 @@ pub mod test {
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot, &stacks_block, &microblocks, &block_commit_op);
 
             // process all blocks
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block.block_hash().to_hex(), microblocks.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block.block_hash(), microblocks.len());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 1).unwrap();
 
             // processed _this_ block
@@ -1055,7 +1055,7 @@ pub mod test {
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot, &stacks_block, &microblocks, &block_commit_op);
 
             // process all blocks
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block.block_hash().to_hex(), microblocks.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block.block_hash(), microblocks.len());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 1).unwrap();
 
             // processed _this_ block
@@ -1154,7 +1154,7 @@ pub mod test {
             }
 
             // process all blocks
-            test_debug!("Process Stacks block {}", &fork_snapshot.winning_stacks_block_hash.to_hex());
+            test_debug!("Process Stacks block {}", &fork_snapshot.winning_stacks_block_hash);
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
             // processed exactly one block, but got back two tip-infos
@@ -1304,8 +1304,8 @@ pub mod test {
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot, &stacks_block_2, &microblocks_2, &block_commit_op_2);
 
             // process all blocks
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_1.block_hash().to_hex(), microblocks_1.len());
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_2.block_hash().to_hex(), microblocks_2.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_1.block_hash(), microblocks_1.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_2.block_hash(), microblocks_2.len());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
             // processed _one_ block
@@ -1449,7 +1449,7 @@ pub mod test {
             }
 
             // process all blocks
-            test_debug!("Process Stacks block {}", &fork_snapshot.winning_stacks_block_hash.to_hex());
+            test_debug!("Process Stacks block {}", &fork_snapshot.winning_stacks_block_hash);
             let mut tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
             let mut tip_info_list_2 = node_2.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
@@ -1604,8 +1604,8 @@ pub mod test {
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot, &stacks_block_2, &microblocks_2, &block_commit_op_2);
 
             // process all blocks
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_1.block_hash().to_hex(), microblocks_1.len());
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_2.block_hash().to_hex(), microblocks_2.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_1.block_hash(), microblocks_1.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_2.block_hash(), microblocks_2.len());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
             // processed _one_ block
@@ -1722,14 +1722,14 @@ pub mod test {
             assert!(fork_snapshot_1.consensus_hash != fork_snapshot_2.consensus_hash);
 
             // "discover" the stacks block
-            test_debug!("preprocess fork 1 {}", stacks_block_1.block_hash().to_hex());
+            test_debug!("preprocess fork 1 {}", stacks_block_1.block_hash());
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot_1, &stacks_block_1, &microblocks_1, &block_commit_op_1);
             
-            test_debug!("preprocess fork 2 {}", stacks_block_1.block_hash().to_hex());
+            test_debug!("preprocess fork 2 {}", stacks_block_1.block_hash());
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot_2, &stacks_block_2, &microblocks_2, &block_commit_op_2);
 
             // process all blocks
-            test_debug!("Process all Stacks blocks: {}, {}", &stacks_block_1.block_hash().to_hex(), &stacks_block_2.block_hash().to_hex());
+            test_debug!("Process all Stacks blocks: {}, {}", &stacks_block_1.block_hash(), &stacks_block_2.block_hash());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
             // processed all stacks blocks -- one on each burn chain fork
@@ -1883,8 +1883,8 @@ pub mod test {
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot, &stacks_block_2, &microblocks_2, &block_commit_op_2);
 
             // process all blocks
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_1.block_hash().to_hex(), microblocks_1.len());
-            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_2.block_hash().to_hex(), microblocks_2.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_1.block_hash(), microblocks_1.len());
+            test_debug!("Process Stacks block {} and {} microblocks", &stacks_block_2.block_hash(), microblocks_2.len());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
             // processed _one_ block
@@ -2007,14 +2007,14 @@ pub mod test {
             assert!(fork_snapshot_1.consensus_hash != fork_snapshot_2.consensus_hash);
 
             // "discover" the stacks block
-            test_debug!("preprocess fork 1 {}", stacks_block_1.block_hash().to_hex());
+            test_debug!("preprocess fork 1 {}", stacks_block_1.block_hash());
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot_1, &stacks_block_1, &microblocks_1, &block_commit_op_1);
             
-            test_debug!("preprocess fork 2 {}", stacks_block_1.block_hash().to_hex());
+            test_debug!("preprocess fork 2 {}", stacks_block_1.block_hash());
             preprocess_stacks_block_data(&mut node, &mut burn_node, &fork_snapshot_2, &stacks_block_2, &microblocks_2, &block_commit_op_2);
 
             // process all blocks
-            test_debug!("Process all Stacks blocks: {}, {}", &stacks_block_1.block_hash().to_hex(), &stacks_block_2.block_hash().to_hex());
+            test_debug!("Process all Stacks blocks: {}, {}", &stacks_block_1.block_hash(), &stacks_block_2.block_hash());
             let tip_info_list = node.chainstate.process_blocks(burn_node.burndb.conn(), 2).unwrap();
 
             // processed all stacks blocks -- one on each burn chain fork
@@ -2224,7 +2224,7 @@ pub mod test {
                                     preprocess_stacks_block_data(&mut node, &mut miner_trace.burn_node, &fork_snapshot, &stacks_block, &vec![mblock.clone()], &block_commit_op);
                                 
                                     // process all the blocks we can 
-                                    test_debug!("Process Stacks block {} and microblock {} {}", &stacks_block.block_hash().to_hex(), mblock.block_hash().to_hex(), mblock.header.sequence);
+                                    test_debug!("Process Stacks block {} and microblock {} {}", &stacks_block.block_hash(), mblock.block_hash(), mblock.header.sequence);
                                     let tip_info_list = node.chainstate.process_blocks(miner_trace.burn_node.burndb.conn(), expected_num_blocks).unwrap();
 
                                     num_processed += tip_info_list.len();
@@ -2232,7 +2232,7 @@ pub mod test {
                             }
                             else {
                                 // process all the blocks we can 
-                                test_debug!("Process Stacks block {} and {} microblocks in {}", &stacks_block.block_hash().to_hex(), microblocks.len(), &node_name);
+                                test_debug!("Process Stacks block {} and {} microblocks in {}", &stacks_block.block_hash(), microblocks.len(), &node_name);
                                 let tip_info_list = node.chainstate.process_blocks(miner_trace.burn_node.burndb.conn(), expected_num_blocks).unwrap();
 
                                 num_processed += tip_info_list.len();
@@ -2350,7 +2350,7 @@ pub mod test {
 
         // TODO: test value of 'bar' in last contract(s)
         
-        test_debug!("Produce anchored stacks block {} with smart contract and contract call at burnchain height {} stacks height {}", stacks_block.block_hash().to_hex(), burnchain_height, stacks_block.header.total_work.work);
+        test_debug!("Produce anchored stacks block {} with smart contract and contract call at burnchain height {} stacks height {}", stacks_block.block_hash(), burnchain_height, stacks_block.header.total_work.work);
         (stacks_block, vec![])
     }
     
@@ -2396,7 +2396,7 @@ pub mod test {
         }
 
         test_debug!("Produce anchored stacks block {} with smart contract and {} microblocks with contract call at burnchain height {} stacks height {}", 
-                    stacks_block.block_hash().to_hex(), microblocks.len(), burnchain_height, stacks_block.header.total_work.work);
+                    stacks_block.block_hash(), microblocks.len(), burnchain_height, stacks_block.header.total_work.work);
 
         (stacks_block, microblocks)
     }
@@ -2450,7 +2450,7 @@ pub mod test {
         }
         
         test_debug!("Produce anchored stacks block {} with smart contract and {} microblocks with contract call at burnchain height {} stacks height {}", 
-                    stacks_block.block_hash().to_hex(), microblocks.len(), burnchain_height, stacks_block.header.total_work.work);
+                    stacks_block.block_hash(), microblocks.len(), burnchain_height, stacks_block.header.total_work.work);
 
         (stacks_block, microblocks)
     }

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -132,7 +132,7 @@ fn advance_cli_chain_tip(path: &String) -> (BlockHeaderHash, BlockHeaderHash) {
     let next_block_hash  = friendly_expect_opt(BlockHeaderHash::from_bytes(&random_bytes),
                                               "Failed to generate random block header.");
 
-    friendly_expect(tx.execute("INSERT INTO cli_chain_tips (block_hash) VALUES (?1)", &[&next_block_hash.to_hex() as &dyn ToSql]), 
+    friendly_expect(tx.execute("INSERT INTO cli_chain_tips (block_hash) VALUES (?1)", &[&next_block_hash]), 
                     &format!("FATAL: failed to store next block hash in '{}'", path));
 
     friendly_expect(tx.commit(), &format!("FATAL: failed to commit new chain tip to '{}'", path));

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -22,7 +22,7 @@ use util::db::FromColumn;
 use vm::ast::parse;
 use vm::contexts::OwnedEnvironment;
 use vm::database::{ClarityDatabase, SqliteConnection,
-                   MarfedKV, MemoryBackingStore, marf::NULL_HEADER_DB};
+                   MarfedKV, MemoryBackingStore, NULL_HEADER_DB};
 use vm::errors::{InterpreterResult};
 use vm::{SymbolicExpression, SymbolicExpressionType, Value};
 use vm::analysis::{AnalysisDatabase, run_analysis};

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -49,8 +49,6 @@ fn print_usage(invoked_by: &str) {
 where command is one of:
 
   initialize         to initialize a local VM state database.
-  mine_block         to simulated mining a new block.
-  get_block_height   to print the simulated block height.
   check              to typecheck a potential contract definition.
   launch             to launch a initialize a new contract in the local state database.
   eval               to evaluate (in read-only mode) a program in a given contract context.
@@ -522,14 +520,6 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                     panic_test!();
                 }
             }
-        },
-        // TODO :: need to rework a bunch of how this simulation works.
-        //         get block info items will need to consult the marf
-        "mine_block" => {
-            panic!("Not implemented")
-        },
-        "get_block_height" => {
-            panic!("Not implemented")
         },
         _ => {
             print_usage(invoked_by)

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -949,7 +949,7 @@ mod test {
             let next_index_root = BurnDB::append_chain_tip_snapshot(&mut tx, &prev_snapshot, &next_snapshot, &vec![], &vec![]).unwrap();
             next_snapshot.index_root = next_index_root;
 
-            test_debug!("i = {}, chain_view.burn_block_height = {}, ch = {}", i, chain_view.burn_block_height, next_snapshot.consensus_hash.to_hex());
+            test_debug!("i = {}, chain_view.burn_block_height = {}, ch = {}", i, chain_view.burn_block_height, next_snapshot.consensus_hash);
             
             prev_snapshot = next_snapshot;
         }

--- a/src/testnet/mod.rs
+++ b/src/testnet/mod.rs
@@ -28,4 +28,4 @@ pub struct NodeConfig {
 }
 
 #[cfg(test)]
-mod tests;
+pub mod tests;

--- a/src/testnet/run_loop.rs
+++ b/src/testnet/run_loop.rs
@@ -30,6 +30,7 @@ impl RunLoop {
         }
 
         Self {
+
             config,
             nodes,
             new_burnchain_state_callback: None,
@@ -91,9 +92,8 @@ impl RunLoop {
             Some(res) => res,
             None => panic!("Error while initiating genesis tenure")
         };
-        if let Some(cb) = self.new_tenure_callback {
-            cb(round_index, &first_tenure);
-        }        
+
+        RunLoop::handle_new_tenure_cb(&self.new_tenure_callback, round_index, &first_tenure);
 
         // Run the tenure, keep the artifacts
         let artifacts_from_1st_tenure = match first_tenure.run() {
@@ -116,9 +116,7 @@ impl RunLoop {
             Err(err) => panic!("Error while expecting block #2 from burnchain: {:?}", err)
         };
 
-        if let Some(cb) = self.new_burnchain_state_callback {
-            cb(round_index, &burnchain_state);
-        }        
+        RunLoop::handle_burnchain_state_cb(&self.new_burnchain_state_callback, round_index, &burnchain_state);
 
         let mut leader_tenure = None;
 
@@ -141,11 +139,9 @@ impl RunLoop {
                 microblocks.clone(), 
                 burnchain_state.db.clone());
 
-            if let Some(cb) = self.new_chain_state_callback {
-                let index_bhh = anchored_block_1.header.index_block_hash(
-                    &last_sortitioned_block.burn_header_hash);
-                cb(round_index, &mut node.chain_state, &index_bhh);
-            }
+            let index_bhh = anchored_block_1.header.index_block_hash(
+                &last_sortitioned_block.burn_header_hash);
+            RunLoop::handle_new_chain_state_cb(&self.new_chain_state_callback, round_index, &mut node.chain_state, &index_bhh);
 
             // If the node we're looping on won the sortition, initialize and configure the next tenure
             if won_sortition {
@@ -163,9 +159,7 @@ impl RunLoop {
             // Run the last initialized tenure
             let artifacts_from_tenure = match leader_tenure {
                 Some(mut tenure) => {
-                    if let Some(cb) = self.new_tenure_callback {
-                        cb(round_index, &tenure);
-                    }        
+                    RunLoop::handle_new_tenure_cb(&self.new_tenure_callback, round_index, &tenure);
                     tenure.run()
                 },
                 None => None
@@ -187,9 +181,7 @@ impl RunLoop {
                 Ok(res) => res,
                 Err(err) => panic!("Error while expecting block from burnchain: {:?}", err)
             };
-            if let Some(cb) = self.new_burnchain_state_callback {
-                cb(round_index, &burnchain_state);
-            }        
+            RunLoop::handle_burnchain_state_cb(&self.new_burnchain_state_callback, round_index, &burnchain_state);
     
             leader_tenure = None;
 
@@ -213,11 +205,10 @@ impl RunLoop {
                             &burnchain_state.chain_tip.parent_burn_header_hash,             
                             microblocks.to_vec(), 
                             burnchain_state.db.clone());
-                        if let Some(cb) = self.new_chain_state_callback {
-                            let index_bhh = anchored_block.header.index_block_hash(
-                                &burnchain_state.chain_tip.burn_header_hash);
-                            cb(round_index, &mut node.chain_state, &index_bhh);
-                        }
+                        let index_bhh = anchored_block.header.index_block_hash(
+                            &burnchain_state.chain_tip.burn_header_hash);
+                        RunLoop::handle_new_chain_state_cb(&self.new_chain_state_callback, round_index,
+                                                           &mut node.chain_state, &index_bhh);
                     },
                 };
                 
@@ -242,4 +233,20 @@ impl RunLoop {
     pub fn apply_on_new_chain_states(&mut self, f: fn(u8, &mut StacksChainState, &BlockHeaderHash)) {
         self.new_chain_state_callback = Some(f);
     }
+
+    fn handle_new_tenure_cb(new_tenure_callback: &Option<fn(u8, &LeaderTenure)>,
+                            round_index: u8, tenure: &LeaderTenure) {
+        new_tenure_callback.map(|cb| cb(round_index, tenure));
+    }
+
+    fn handle_burnchain_state_cb(burn_callback: &Option<fn(u8, &BurnchainState)>,
+                                 round_index: u8, state: &BurnchainState) {
+        burn_callback.map(|cb| cb(round_index, state));
+    }
+
+    fn handle_new_chain_state_cb(chain_state_callback: &Option<fn(u8, &mut StacksChainState, &BlockHeaderHash)>,
+                                 round_index: u8, state: &mut StacksChainState, id_hash: &BlockHeaderHash) {
+        chain_state_callback.map(|cb| cb(round_index, state, &id_hash));
+    }
+
 }

--- a/src/testnet/tests.rs
+++ b/src/testnet/tests.rs
@@ -6,7 +6,7 @@ use chainstate::stacks::db::{StacksChainState};
 use super::node::{TESTNET_CHAIN_ID};
 use chainstate::stacks::{TransactionPayload, CoinbasePayload};
 
-fn new_test_conf() -> testnet::Config {
+pub fn new_test_conf() -> testnet::Config {
     // Testnet's name
     let mut rng = rand::thread_rng();
     let mut buf = [0u8; 8];
@@ -63,7 +63,7 @@ fn should_succeed_mining_valid_txs() {
     });
 
     // Use block's hook for asserting expectations
-    run_loop.apply_on_new_chain_states(|round, chain_state| {
+    run_loop.apply_on_new_chain_states(|round, chain_state, _| {
         match round {
             0 => {
                 // Inspecting the chain at round 0.
@@ -239,7 +239,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
     });
 
     // Use block's hook for asserting expectations
-    run_loop.apply_on_new_chain_states(|round, chain_state| {
+    run_loop.apply_on_new_chain_states(|round, chain_state, _| {
         match round {
             0 => {
                 // Inspecting the chain at round 0.

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -411,11 +411,11 @@ impl<'a, C> IndexDBTx<'a, C> {
             Err(e) => {
                 match e {
                     MARFError::NotFoundError => {
-                        test_debug!("Not found: Get '{}' off of {} (parent index root not found)", key, header_hash.to_hex());
+                        test_debug!("Not found: Get '{}' off of {} (parent index root not found)", key, header_hash);
                         return Ok(None);
                     },
                     _ => {
-                        error!("Failed to get root hash of {}: {:?}", &header_hash.to_hex(), &e);
+                        error!("Failed to get root hash of {}: {:?}", &header_hash, &e);
                         return Err(Error::Corruption);
                     }
                 }
@@ -427,7 +427,7 @@ impl<'a, C> IndexDBTx<'a, C> {
                 match marf_value_opt {
                     Some(marf_value) => {
                         let value = self.load_indexed(key, &marf_value)?
-                            .expect(&format!("FATAL: corrupt index: key '{}' from {} (root index {}) is present in the index but missing a value in the DB", &key, &header_hash.to_hex(), &parent_index_root.to_hex()));
+                            .expect(&format!("FATAL: corrupt index: key '{}' from {} (root index {}) is present in the index but missing a value in the DB", &key, &header_hash, &parent_index_root));
 
                         return Ok(Some(value));
                     },
@@ -442,7 +442,7 @@ impl<'a, C> IndexDBTx<'a, C> {
                         return Ok(None);
                     },
                     _ => {
-                        error!("Failed to fetch '{}' off of {}: {:?}", key, &header_hash.to_hex(), &e);
+                        error!("Failed to fetch '{}' off of {}: {:?}", key, &header_hash, &e);
                         return Err(Error::Corruption);
                     }
                 }

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -155,6 +155,13 @@ macro_rules! impl_byte_array_from_column {
                 Ok(inst)
             }
         }
+
+        impl rusqlite::types::ToSql for $thing {
+            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
+                let hex_str = self.to_hex();
+                Ok(hex_str.into())
+            }
+        }
     }
 }
 

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -345,6 +345,11 @@ macro_rules! impl_byte_array_newtype {
                 to_hex(&self.0)
             }
         }
+        impl std::fmt::Display for $thing {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{}", self.to_hex())
+            }
+        }
     }
 }
 

--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -31,9 +31,10 @@ fn test_get_block_info(){
                 "(get-block-info? time (* u2 u3))",
                 "(get-block-info? vrf-seed u1)",
                 "(get-block-info? header-hash u1)",
-                "(get-block-info? burnchain-header-hash u1)"];
+                "(get-block-info? burnchain-header-hash u1)",
+                "(get-block-info? miner-address u1)"];
     let expected = [ "(optional uint)", "(optional uint)", "(optional (buff 32))",
-                       "(optional (buff 32))", "(optional (buff 32))" ];
+                       "(optional (buff 32))", "(optional (buff 32))", "(optional principal)" ];
 
     let bad = ["(get-block-info? none u1)",
                "(get-block-info? time 'true)",

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -172,7 +172,7 @@ impl <'a> ClarityBlockConnection <'a> {
     /// may not have known the "real" block hash at the 
     /// time of opening).
     pub fn commit_to_block(mut self, final_bhh: &BlockHeaderHash) {
-        debug!("Commit Clarity datastore to {}", final_bhh.to_hex());
+        debug!("Commit Clarity datastore to {}", final_bhh);
         self.datastore.commit_to(final_bhh);
 
         self.parent.datastore.replace(self.datastore);

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -314,6 +314,14 @@ impl <'a> ClarityBlockConnection <'a> {
             |_, _| { false })?;
         Ok(result)
     }
+
+    #[cfg(test)]
+    pub fn eval_read_only(&mut self, contract: &QualifiedContractIdentifier, code: &str) -> Result<Value, Error> {
+        let (result, _) = self.with_abort_callback(
+            |vm_env| { vm_env.eval_read_only(contract, code).map_err(Error::from) },
+            |_, _| { false })?;
+        Ok(result)
+    }
 }
 
 
@@ -322,7 +330,7 @@ mod tests {
     use super::*;
     use vm::analysis::errors::CheckErrors;
     use vm::types::{Value, StandardPrincipalData};
-    use vm::database::marf::{ClarityBackingStore, MarfedKV};
+    use vm::database::{NULL_HEADER_DB, ClarityBackingStore, MarfedKV};
     use chainstate::stacks::index::storage::{TrieFileStorage};
     use rusqlite::NO_PARAMS;
 
@@ -335,7 +343,8 @@ mod tests {
 
         {
             let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
-                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
+                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                        &NULL_HEADER_DB);
             
             let contract = "(define-public (foo (x int)) (ok (+ x x)))";
             
@@ -363,7 +372,8 @@ mod tests {
 
         {
             let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
-                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
+                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                        &NULL_HEADER_DB);
 
             let contract = "(define-public (foo (x int)) (ok (+ x x)))";
 
@@ -395,7 +405,8 @@ mod tests {
 
         {
             let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
-                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
+                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                        &NULL_HEADER_DB);
 
             let contract = "
             (define-data-var bar int 0)

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -120,6 +120,19 @@ impl ClarityInstance {
         }
     }
 
+    #[cfg(test)]
+    pub fn eval_read_only(&mut self, at_block: &BlockHeaderHash, header_db: &dyn HeadersDB,
+                          contract: &QualifiedContractIdentifier, program: &str) -> Result<Value, Error> {
+        self.datastore.as_mut().unwrap()
+            .set_chain_tip(at_block);
+        let clarity_db = self.datastore.as_mut().unwrap()
+            .as_clarity_db(header_db);
+        let mut env = OwnedEnvironment::new(clarity_db);
+        env.eval_read_only(contract, program)
+            .map(|(x, _)| x)
+            .map_err(Error::from)
+    }
+
     pub fn destroy(mut self) -> MarfedKV {
         let datastore = self.datastore.take()
             .expect("FAIL: attempt to recover database connection from clarity instance which is still open");

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -425,6 +425,12 @@ impl <'a> OwnedEnvironment <'a> {
                             |exec_env| exec_env.eval_raw(program))
     }
 
+    #[cfg(test)]
+    pub fn eval_read_only(&mut self, contract: &QualifiedContractIdentifier, program: &str) -> Result<(Value, AssetMap)>  {
+        self.execute_in_env(Value::from(QualifiedContractIdentifier::transient().issuer),
+                            |exec_env| exec_env.eval_read_only(contract, program))
+    }
+
     pub fn begin(&mut self) {
         self.context.begin();
     }

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -98,8 +98,6 @@ impl <'a> ClarityDatabase <'a> {
     }
 
     pub fn initialize(&mut self) {
-        self.begin();
-        self.commit();
     }
 
     pub fn begin(&mut self) {

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -52,7 +52,7 @@ pub trait HeadersDB {
 }
 
 fn get_stacks_header_info(conn: &DBConn, id_bhh: &BlockHeaderHash) -> Option<StacksHeaderInfo> {
-    conn.query_row("SELECT * FROM block_headers WHERE state_index_root = ?",
+    conn.query_row("SELECT * FROM block_headers WHERE index_block_hash = ?",
                    [id_bhh].iter(),
                    |x| StacksHeaderInfo::from_row(x).expect("Bad stacks header info in database"))
         .optional()

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -186,7 +186,7 @@ impl <'a> ClarityDatabase <'a> {
             .expect("Failed to obtain the block for the given block height.")
     }
 
-    fn get_index_block_header_hash(&mut self, block_height: u32) -> BlockHeaderHash {
+    pub fn get_index_block_header_hash(&mut self, block_height: u32) -> BlockHeaderHash {
         self.store.get_block_header_hash(block_height)
         // the caller is responsible for ensuring that the block_height given
         //  is < current_block_height, so this should _always_ return a value.

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -61,15 +61,18 @@ fn get_stacks_header_info(conn: &DBConn, id_bhh: &BlockHeaderHash) -> Option<Sta
 
 impl HeadersDB for DBConn {
     fn get_stacks_block_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BlockHeaderHash> {
-        panic!("Not implemented");
+        get_stacks_header_info(self, id_bhh)
+            .map(|x| x.anchored_header.block_hash())
     }
     
     fn get_burn_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BurnchainHeaderHash> {
-        panic!("Not implemented");
+        get_stacks_header_info(self, id_bhh)
+            .map(|x| x.burn_header_hash)
     }
 
     fn get_vrf_proof(&self, id_bhh: &BlockHeaderHash) -> Option<VRFSeed> {
-        panic!("Not implemented");
+        get_stacks_header_info(self, id_bhh)
+            .map(|x| VRFSeed::from_proof(&x.anchored_header.proof))
     }
 }
 

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -1,10 +1,12 @@
 use std::collections::{VecDeque, HashMap};
 use std::convert::TryFrom;
+use rusqlite::OptionalExtension;
 
 use vm::contracts::Contract;
 use vm::errors::{Error, InterpreterError, RuntimeErrorType, CheckErrors, InterpreterResult as Result, IncomparableError};
 use vm::types::{Value, OptionalData, TypeSignature, TupleTypeSignature, PrincipalData, StandardPrincipalData, QualifiedContractIdentifier, NONE};
 
+use chainstate::stacks::db::StacksHeaderInfo;
 use chainstate::burn::{VRFSeed, BlockHeaderHash};
 use burnchains::BurnchainHeaderHash;
 
@@ -16,7 +18,7 @@ use vm::database::structures::{
     ClarityDeserializable
 };
 use vm::database::RollbackWrapper;
-
+use util::db::{DBConn, FromRow};
 
 const SIMMED_BLOCK_TIME: u64 = 10 * 60; // 10 min
 
@@ -39,31 +41,61 @@ pub enum StoreType {
 }
 
 pub struct ClarityDatabase<'a> {
-    pub store: RollbackWrapper<'a>
+    pub store: RollbackWrapper<'a>,
+    headers_db: &'a dyn HeadersDB,
+}
+
+pub trait HeadersDB {
+    fn get_stacks_block_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BlockHeaderHash>;
+    fn get_burn_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BurnchainHeaderHash>;
+    fn get_vrf_proof(&self, id_bhh: &BlockHeaderHash) -> Option<VRFSeed>;
+}
+
+fn get_stacks_header_info(conn: &DBConn, id_bhh: &BlockHeaderHash) -> Option<StacksHeaderInfo> {
+    conn.query_row("SELECT * FROM block_headers WHERE state_index_root = ?",
+                   [id_bhh].iter(),
+                   |x| StacksHeaderInfo::from_row(x).expect("Bad stacks header info in database"))
+        .optional()
+        .expect("Unexpected SQL failure querying block header table")
+}
+
+impl HeadersDB for DBConn {
+    fn get_stacks_block_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BlockHeaderHash> {
+        panic!("Not implemented");
+    }
+    
+    fn get_burn_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BurnchainHeaderHash> {
+        panic!("Not implemented");
+    }
+
+    fn get_vrf_proof(&self, id_bhh: &BlockHeaderHash) -> Option<VRFSeed> {
+        panic!("Not implemented");
+    }
+}
+
+
+impl HeadersDB for &dyn HeadersDB {
+    fn get_stacks_block_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BlockHeaderHash> {
+        (*self).get_stacks_block_header_hash_for_block(id_bhh)
+    }
+    fn get_burn_header_hash_for_block(&self, bhh: &BlockHeaderHash) -> Option<BurnchainHeaderHash> {
+        (*self).get_burn_header_hash_for_block(bhh)
+    }
+    fn get_vrf_proof(&self, bhh: &BlockHeaderHash) -> Option<VRFSeed> {
+        (*self).get_vrf_proof(bhh)
+    }
 }
 
 impl <'a> ClarityDatabase <'a> {
-    pub fn new(store: &'a mut dyn ClarityBackingStore) -> ClarityDatabase<'a> {
+    pub fn new(store: &'a mut dyn ClarityBackingStore, headers_db: &'a dyn HeadersDB) -> ClarityDatabase<'a> {
         ClarityDatabase {
-            store: RollbackWrapper::new(store)
+            store: RollbackWrapper::new(store),
+            headers_db
         }
     }
 
     pub fn initialize(&mut self) {
         self.begin();
-
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let time_now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
-
-        self.set_simmed_block_height(0);
-        for i in 0..20 {
-            let block_time = u64::try_from(time_now - ((20 - i) * SIMMED_BLOCK_TIME)).unwrap();
-            self.sim_mine_block_with_time(block_time);
-        }
-
         self.commit();
     }
 
@@ -152,75 +184,38 @@ impl <'a> ClarityDatabase <'a> {
         self.get(&key)
             .expect("Failed to obtain the block for the given block height.")
     }
-    
-    pub fn get_simmed_block_height(&mut self) -> u64 {
-        let key = ClarityDatabase::make_key_for_trip(
-            &QualifiedContractIdentifier::transient(), StoreType::SimmedBlockHeight, ":dummy:");
-        self.get(&key)
-            .expect("Failed to obtain block height.")
+
+    fn get_index_block_header_hash(&mut self, block_height: u32) -> BlockHeaderHash {
+        self.store.get_block_header_hash(block_height)
+        // the caller is responsible for ensuring that the block_height given
+        //  is < current_block_height, so this should _always_ return a value.
+            .expect("Block header hash must return for provided block height")
     }
 
-    pub fn get_simmed_block_time(&mut self, block_height: u64) -> u64 {
-        self.get_simmed_block(block_height)
-            .block_time
-    }
-    pub fn get_simmed_block_header_hash(&mut self, block_height: u64) -> BlockHeaderHash {
-        BlockHeaderHash::from_bytes(&self.get_simmed_block(block_height)
-                                    .block_header_hash).unwrap()
-    }
-    pub fn get_simmed_burnchain_block_header_hash(&mut self, block_height: u64) -> BurnchainHeaderHash {
-        BurnchainHeaderHash::from_bytes(&self.get_simmed_block(block_height)
-                                        .burn_chain_header_hash).unwrap()
-    }
-    pub fn get_simmed_block_vrf_seed(&mut self, block_height: u64) -> VRFSeed {
-        VRFSeed::from_bytes(&self.get_simmed_block(block_height).vrf_seed).unwrap()
+    pub fn get_current_block_height(&mut self) -> u32 {
+        self.store.get_current_block_height()
     }
 
-    fn set_simmed_block_height(&mut self, block_height: u64) {
-        let block_height_key = ClarityDatabase::make_key_for_trip(
-            &QualifiedContractIdentifier::transient(), StoreType::SimmedBlockHeight, ":dummy:");
-        self.put(&block_height_key, &block_height);
+    pub fn get_block_header_hash(&mut self, block_height: u32) -> BlockHeaderHash {
+        let id_bhh = self.get_index_block_header_hash(block_height);
+        self.headers_db.get_stacks_block_header_hash_for_block(&id_bhh)
+            .expect("Failed to get block data.")
     }
 
-    pub fn sim_mine_block_with_time(&mut self, block_time: u64) {
-        let current_height = self.get_simmed_block_height();
-
-        let block_height = current_height + 1;
-
-        let key = ClarityDatabase::make_key_for_trip(
-            &QualifiedContractIdentifier::transient(), StoreType::SimmedBlock, &block_height.to_string());
-
-        let mut vrf_seed = [0u8; 32];
-        vrf_seed[0] = 1;
-        vrf_seed[31] = block_height as u8;
-
-        let mut block_header_hash = [0u8; 32];
-        block_header_hash[0] = 2;
-        block_header_hash[31] = block_height as u8;
-
-        let mut burn_chain_header_hash = [0u8; 32];
-        burn_chain_header_hash[0] = 3;
-        burn_chain_header_hash[31] = block_height as u8;
-
-        let block_data = SimmedBlock { block_height, vrf_seed, block_header_hash, burn_chain_header_hash, block_time };
-
-        self.put(&key, &block_data);
-        self.set_simmed_block_height(block_height);
+    pub fn get_simmed_block_time(&mut self, block_height: u32) -> u64 {
+        panic!("deprecated")
     }
 
-    pub fn sim_mine_block(&mut self) {
-        let current_height = self.get_simmed_block_height();
-        let current_time = self.get_simmed_block_time(current_height);
-
-        let block_time = current_time.checked_add(SIMMED_BLOCK_TIME)
-            .expect("Integer overflow while increasing simulated block time");
-        self.sim_mine_block_with_time(block_time);
+    pub fn get_burnchain_block_header_hash(&mut self, block_height: u32) -> BurnchainHeaderHash {
+        let id_bhh = self.get_index_block_header_hash(block_height);
+        self.headers_db.get_burn_header_hash_for_block(&id_bhh)
+            .expect("Failed to get block data.")
     }
 
-    pub fn sim_mine_blocks(&mut self, count: u32) {
-        for _i in 0..count {
-            self.sim_mine_block();
-        }
+    pub fn get_block_vrf_seed(&mut self, block_height: u32) -> VRFSeed {
+        let id_bhh = self.get_index_block_header_hash(block_height);
+        self.headers_db.get_vrf_proof(&id_bhh)
+            .expect("Failed to get block data.")
     }
 }
 

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -155,6 +155,14 @@ impl <'a> RollbackWrapper <'a> {
             .or_else(|| self.store.get(key))
     }
 
+    pub fn get_current_block_height(&mut self) -> u32 {
+        self.store.get_current_block_height()
+    }
+
+    pub fn get_block_header_hash(&mut self, block_height: u32) -> Option<BlockHeaderHash> {
+        self.store.get_block_at_height(block_height)
+    }
+
     pub fn prepare_for_contract_metadata(&mut self, contract: &QualifiedContractIdentifier, content_hash: Sha512Trunc256Sum) {
         let key = MarfedKV::make_contract_hash_key(contract);
         let value = self.store.make_contract_commitment(content_hash);

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -104,7 +104,7 @@ struct ContractCommitment {
 
 impl ContractCommitment {
     pub fn serialize(&self) -> String {
-        format!("{}{}", self.hash.to_hex(), to_hex(&self.block_height.to_be_bytes()))
+        format!("{}{}", self.hash, to_hex(&self.block_height.to_be_bytes()))
     }
     pub fn deserialize(input: &str) -> ContractCommitment {
         assert_eq!(input.len(), 72);
@@ -182,7 +182,7 @@ impl MarfedKV {
 
     pub fn begin(&mut self, current: &BlockHeaderHash, next: &BlockHeaderHash) {
         self.marf.begin(current, next)
-            .expect(&format!("ERROR: Failed to begin new MARF block {} - {})", current.to_hex(), next.to_hex()));
+            .expect(&format!("ERROR: Failed to begin new MARF block {} - {})", current, next));
         self.chain_tip = self.marf.get_open_chain_tip()
             .expect("ERROR: Failed to get open MARF")
             .clone();

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -219,6 +219,11 @@ impl MarfedKV {
         &self.chain_tip
     }
 
+    #[cfg(test)]
+    pub fn set_chain_tip(&mut self, bhh: &BlockHeaderHash) {
+        self.chain_tip = bhh.clone();
+    }
+
     // This function *should not* be called by
     //   a smart-contract, rather it should only be used by the VM
     pub fn get_root_hash(&mut self) -> TrieHash {

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use vm::types::{QualifiedContractIdentifier};
 use vm::errors::{InterpreterError, CheckErrors, InterpreterResult as Result, IncomparableError, RuntimeErrorType};
-use vm::database::{SqliteConnection, ClarityDatabase, HeadersDB};
+use vm::database::{SqliteConnection, ClarityDatabase, HeadersDB, NULL_HEADER_DB};
 use vm::analysis::{AnalysisDatabase};
 use chainstate::stacks::index::marf::MARF;
 use chainstate::stacks::index::{MARFValue, Error as MarfError, TrieHash};
@@ -319,22 +319,6 @@ impl ClarityBackingStore for MarfedKV {
         }
         self.marf.insert_batch(&keys, values)
             .expect("ERROR: Unexpected MARF Failure");
-    }
-}
-
-pub struct NullHeadersDB {}
-
-pub const NULL_HEADER_DB: NullHeadersDB = NullHeadersDB {};
-
-impl HeadersDB for NullHeadersDB {
-    fn get_burn_header_hash_for_block(&self, bhh: &BlockHeaderHash) -> Option<BurnchainHeaderHash> {
-        None
-    }
-    fn get_vrf_proof(&self, bhh: &BlockHeaderHash) -> Option<VRFSeed> {
-        None
-    }
-    fn get_stacks_block_header_hash_for_block(&self, id_bhh: &BlockHeaderHash) -> Option<BlockHeaderHash> {
-        None
     }
 }
 

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -10,4 +10,4 @@ pub use self::key_value_wrapper::{RollbackWrapper};
 pub use self::clarity_db::{ClarityDatabase, HeadersDB};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};
-pub use self::marf::{MemoryBackingStore, MarfedKV, ClarityBackingStore};
+pub use self::marf::{MemoryBackingStore, MarfedKV, ClarityBackingStore, NULL_HEADER_DB};

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -7,7 +7,7 @@ mod key_value_wrapper;
 use std::collections::HashMap;
 
 pub use self::key_value_wrapper::{RollbackWrapper};
-pub use self::clarity_db::{ClarityDatabase};
+pub use self::clarity_db::{ClarityDatabase, HeadersDB};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};
 pub use self::marf::{MemoryBackingStore, MarfedKV, ClarityBackingStore};

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -7,7 +7,7 @@ mod key_value_wrapper;
 use std::collections::HashMap;
 
 pub use self::key_value_wrapper::{RollbackWrapper};
-pub use self::clarity_db::{ClarityDatabase, HeadersDB};
+pub use self::clarity_db::{ClarityDatabase, HeadersDB, NULL_HEADER_DB};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};
-pub use self::marf::{MemoryBackingStore, MarfedKV, ClarityBackingStore, NULL_HEADER_DB};
+pub use self::marf::{MemoryBackingStore, MarfedKV, ClarityBackingStore};

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -91,17 +91,17 @@ impl SqliteConnection {
     ///   ClarityDatabase or AnalysisDatabase -- this is done at the backing store level.
 
     pub fn begin(&mut self, key: &BlockHeaderHash) {
-        self.conn.execute(&format!("SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
+        self.conn.execute(&format!("SAVEPOINT SP{};", key), NO_PARAMS)
             .expect(SQL_FAIL_MESSAGE);
     }
 
     pub fn rollback(&mut self, key: &BlockHeaderHash) {
-        self.conn.execute(&format!("ROLLBACK TO SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
+        self.conn.execute(&format!("ROLLBACK TO SAVEPOINT SP{};", key), NO_PARAMS)
             .expect(SQL_FAIL_MESSAGE);
     }
 
     pub fn commit(&mut self, key: &BlockHeaderHash) {
-        self.conn.execute(&format!("RELEASE SAVEPOINT SP{};", key.to_hex()), NO_PARAMS)
+        self.conn.execute(&format!("RELEASE SAVEPOINT SP{};", key), NO_PARAMS)
             .expect(SQL_FAIL_MESSAGE);
     }
 }

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -42,16 +42,15 @@ impl SqliteConnection {
     }
 
     pub fn insert_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str, value: &str) {
-        let blockhash = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);
-        let params: [&dyn ToSql; 3] = [&blockhash, &key, &value.to_string()];
+        let params: [&dyn ToSql; 3] = [&bhh, &key, &value.to_string()];
 
         self.conn.execute("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)", &params)
             .expect(SQL_FAIL_MESSAGE);
     }
 
     pub fn commit_metadata_to(&mut self, from: &BlockHeaderHash, to: &BlockHeaderHash) {
-        let params = [to.to_hex(), from.to_hex()];
+        let params = [to, from];
         let rows_updated = self.conn.execute(
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
             &params)
@@ -59,7 +58,7 @@ impl SqliteConnection {
     }
 
     pub fn move_metadata_to(&mut self, from: &BlockHeaderHash, to: &str) {
-        let params = [to.to_string(), from.to_hex()];
+        let params: [&dyn ToSql; 2] = [&to.to_string(), from];
         let rows_updated = self.conn.execute(
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
             &params)
@@ -67,7 +66,6 @@ impl SqliteConnection {
     }
 
     pub fn get_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str) -> Option<String> {
-        let bhh = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);
         let params: [&dyn ToSql; 2] = [&bhh, &key];
 

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -42,8 +42,6 @@ impl SqliteConnection {
     }
 
     pub fn insert_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str, value: &str) {
-        debug!("insert_metadata: {}, {}, {}", bhh, contract_hash, key);
-
         let blockhash = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);
         let params: [&dyn ToSql; 3] = [&blockhash, &key, &value.to_string()];
@@ -58,7 +56,6 @@ impl SqliteConnection {
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
             &params)
             .expect(SQL_FAIL_MESSAGE);
-        debug!("commit_metadata {} rows committed to blockhash: {} => {}", rows_updated, from, to);
     }
 
     pub fn move_metadata_to(&mut self, from: &BlockHeaderHash, to: &str) {
@@ -67,12 +64,9 @@ impl SqliteConnection {
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
             &params)
             .expect(SQL_FAIL_MESSAGE);
-        debug!("move_metadata {} rows moved to: {} => {}", rows_updated, from, to);
     }
 
     pub fn get_metadata(&mut self, bhh: &BlockHeaderHash, contract_hash: &str, key: &str) -> Option<String> {
-        debug!("get_metadata: {}, {}, {}", bhh, contract_hash, key);
-
         let bhh = bhh.to_hex();
         let key = format!("clr-meta::{}::{}", contract_hash, key);
         let params: [&dyn ToSql; 2] = [&bhh, &key];

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -582,7 +582,8 @@ const AT_BLOCK: SpecialAPI = SpecialAPI {
 block indicated by the _block-hash_ argument. The `expr` closure must be read-only.
 
 Note: The block identifying hash must be a hash returned by the `id-header-hash` block information
-property. This hash uniquely identifies Stacks blocks, whereas `header-hash` is not necessarily unique.
+property. This hash uniquely identifies Stacks blocks and is unique across Stacks forks. While the hash returned by
+`header-hash` is unique within the context of a single fork, it is not unique across Stacks forks.
 
 The function returns the result of evaluating `expr`.
 ",
@@ -813,13 +814,15 @@ const GET_BLOCK_INFO_API: SpecialAPI = SpecialAPI {
     description: "The `get-block-info?` function fetches data for a block of the given block height. The 
 value and type returned are determined by the specified `BlockInfoPropertyName`. If the provided `BlockHeightInt` does
 not correspond to an existing block prior to the current block, the function returns `none`. The currently available property names 
-are `time`, `header-hash`, `burnchain-header-hash`, `id-header-hash`, and `vrf-seed`. 
+are `time`, `header-hash`, `burnchain-header-hash`, `id-header-hash`, `miner-address`, and `vrf-seed`. 
 
 The `time` property returns an integer value of the block header time field. This is a Unix epoch timestamp in seconds 
 which roughly corresponds to when the block was mined. **Warning**: this does not increase monotonically with each block
 and block times are accurate only to within two hours. See [BIP113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) for more information. 
 
 The `header-hash`, `burnchain-header-hash`, `id-header-hash`, and `vrf-seed` properties return a 32-byte buffer. 
+
+The `miner-address` property returns a `principal` corresponding to the miner of the given block.
 
 The `id-header-hash` is the block identifier value that must be used as input to the `at-block` function.
 ",

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -581,10 +581,13 @@ const AT_BLOCK: SpecialAPI = SpecialAPI {
     description: "The `at-block` function evaluates the expression `expr` _as if_ it were evaluated at the end of the
 block indicated by the _block-hash_ argument. The `expr` closure must be read-only.
 
+Note: The block identifying hash must be a hash returned by the `id-header-hash` block information
+property. This hash uniquely identifies Stacks blocks, whereas `header-hash` is not necessarily unique.
+
 The function returns the result of evaluating `expr`.
 ",
     example: "(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 (var-get data))
-(at-block (get-block-info? header-hash (- block-height u10)) (var-get data))"
+(at-block (get-block-info? id-header-hash (- block-height u10)) (var-get data))"
 };
         
 
@@ -810,13 +813,15 @@ const GET_BLOCK_INFO_API: SpecialAPI = SpecialAPI {
     description: "The `get-block-info?` function fetches data for a block of the given block height. The 
 value and type returned are determined by the specified `BlockInfoPropertyName`. If the provided `BlockHeightInt` does
 not correspond to an existing block prior to the current block, the function returns `none`. The currently available property names 
-are `time`, `header-hash`, `burnchain-header-hash`, and `vrf-seed`. 
+are `time`, `header-hash`, `burnchain-header-hash`, `id-header-hash`, and `vrf-seed`. 
 
 The `time` property returns an integer value of the block header time field. This is a Unix epoch timestamp in seconds 
 which roughly corresponds to when the block was mined. **Warning**: this does not increase monotonically with each block
 and block times are accurate only to within two hours. See [BIP113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) for more information. 
 
-The `header-hash`, `burnchain-header-hash`, and `vrf-seed` properties return a 32-byte buffer. 
+The `header-hash`, `burnchain-header-hash`, `id-header-hash`, and `vrf-seed` properties return a 32-byte buffer. 
+
+The `id-header-hash` is the block identifier value that must be used as input to the `at-block` function.
 ",
     example: "(get-block-info? time u10) ;; Returns (some 1557860301)
 (get-block-info? header-hash u2) ;; Returns (some 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb)

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -214,12 +214,12 @@ pub fn special_get_block_info(args: &[SymbolicExpression],
         x => Err(CheckErrors::TypeValueError(TypeSignature::UIntType, x))
     }?;
 
-    let height_value = match u64::try_from(height_value) {
+    let height_value = match u32::try_from(height_value) {
         Ok(result) => result,
         _ => return Ok(Value::none())
     };
 
-    let current_block_height = env.global_context.database.get_simmed_block_height();
+    let current_block_height = env.global_context.database.get_current_block_height();
     if height_value >= current_block_height {
         return Ok(Value::none())
     }
@@ -230,15 +230,15 @@ pub fn special_get_block_info(args: &[SymbolicExpression],
             Value::UInt(block_time as u128)
         },
         BlockInfoProperty::VrfSeed => {
-            let vrf_seed = env.global_context.database.get_simmed_block_vrf_seed(height_value);
+            let vrf_seed = env.global_context.database.get_block_vrf_seed(height_value);
             Value::Buffer(BuffData { data: vrf_seed.as_bytes().to_vec() })
         },
         BlockInfoProperty::HeaderHash => {
-            let header_hash = env.global_context.database.get_simmed_block_header_hash(height_value);
+            let header_hash = env.global_context.database.get_block_header_hash(height_value);
             Value::Buffer(BuffData { data: header_hash.as_bytes().to_vec() })
         },
         BlockInfoProperty::BurnchainHeaderHash => {
-            let burnchain_header_hash = env.global_context.database.get_simmed_burnchain_block_header_hash(height_value);
+            let burnchain_header_hash = env.global_context.database.get_burnchain_block_header_hash(height_value);
             Value::Buffer(BuffData { data: burnchain_header_hash.as_bytes().to_vec() })
         },
     };

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -241,6 +241,10 @@ pub fn special_get_block_info(args: &[SymbolicExpression],
             let burnchain_header_hash = env.global_context.database.get_burnchain_block_header_hash(height_value);
             Value::Buffer(BuffData { data: burnchain_header_hash.as_bytes().to_vec() })
         },
+        BlockInfoProperty::IdentityHeaderHash => {
+            let id_header_hash = env.global_context.database.get_index_block_header_hash(height_value);
+            Value::Buffer(BuffData { data: id_header_hash.as_bytes().to_vec() })            
+        },
     };
 
     Ok(Value::some(result))

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -226,7 +226,7 @@ pub fn special_get_block_info(args: &[SymbolicExpression],
 
     let result = match block_info_prop {
         BlockInfoProperty::Time => {
-            let block_time = env.global_context.database.get_simmed_block_time(height_value);
+            let block_time = env.global_context.database.get_block_time(height_value);
             Value::UInt(block_time as u128)
         },
         BlockInfoProperty::VrfSeed => {

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -245,7 +245,11 @@ pub fn special_get_block_info(args: &[SymbolicExpression],
             let id_header_hash = env.global_context.database.get_index_block_header_hash(height_value);
             Value::Buffer(BuffData { data: id_header_hash.as_bytes().to_vec() })            
         },
+        BlockInfoProperty::MinerAddress => {
+            let miner_address = env.global_context.database.get_miner_address(height_value);
+            Value::from(miner_address)
+        },
     };
-
+    
     Ok(Value::some(result))
 }

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -8,8 +8,7 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::{MemoryBackingStore, MarfedKV, NULL_HEADER_DB};
-use vm::database::ClarityDatabase;
+use vm::database::{MemoryBackingStore, MarfedKV, NULL_HEADER_DB, ClarityDatabase};
 use vm::clarity::ClarityInstance;
 use vm::ast;
 

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -1,3 +1,4 @@
+use chainstate::stacks::index::storage::{TrieFileStorage};
 use vm::execute as vm_execute;
 use chainstate::burn::BlockHeaderHash;
 use vm::errors::{Error, CheckErrors, RuntimeErrorType};
@@ -7,8 +8,10 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::MemoryBackingStore;
+use vm::database::marf::{MemoryBackingStore, MarfedKV, NULL_HEADER_DB};
 use vm::database::ClarityDatabase;
+use vm::clarity::ClarityInstance;
+use vm::ast;
 
 use vm::tests::{with_memory_environment, with_marfed_environment, execute, symbols_from_values};
 
@@ -82,6 +85,16 @@ fn test_get_block_info_eval() {
     ];
 
     let expected = [
+        Ok(Value::none()),
+        Ok(Value::none()),
+        Ok(Value::none()),
+        Err(CheckErrors::TypeValueError(TypeSignature::UIntType, Value::Int(-1)).into()),
+        Err(CheckErrors::TypeValueError(TypeSignature::UIntType, Value::Bool(true)).into()),
+        Ok(Value::none()),
+        Ok(Value::none()),
+        Ok(Value::none()),
+    ];
+/*    let expected = [
         Ok(Value::UInt(0)),
         Ok(Value::none()),
         Ok(Value::none()),
@@ -93,7 +106,7 @@ fn test_get_block_info_eval() {
             Value::buff_from(hex_bytes("0300000000000000000000000000000000000000000000000000000000000001").unwrap()).unwrap())),
         Ok(Value::some(
             Value::buff_from(hex_bytes("0100000000000000000000000000000000000000000000000000000000000001").unwrap()).unwrap())),
-    ];
+    ]; */
 
     for i in 0..contracts.len() {
         let mut marf = MemoryBackingStore::new();
@@ -141,84 +154,107 @@ fn is_err_code(v: &Value, e: i128) -> bool {
     }
 }
 
-fn test_simple_token_system(owned_env: &mut OwnedEnvironment) {
-    let tokens_contract = SIMPLE_TOKENS;
+fn test_block_headers(n: u8) -> BlockHeaderHash {
+    BlockHeaderHash([n as u8; 32])
+}
 
-    let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
-    let p2 = execute("'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G");
-
-    {
-        let mut env = owned_env.get_exec_environment(None);
-
-        let contract_identifier = QualifiedContractIdentifier::local("tokens").unwrap();
-        env.initialize_contract(contract_identifier, tokens_contract).unwrap();
-    }
+#[test]
+fn test_simple_token_system() {
+    let mut clarity = ClarityInstance::new(MarfedKV::temporary());
+    let p1 = PrincipalData::from(PrincipalData::parse_standard_principal("SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR").unwrap());
+    let p2 = PrincipalData::from(PrincipalData::parse_standard_principal("SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G").unwrap());
+    let contract_identifier = QualifiedContractIdentifier::local("tokens").unwrap();
 
     {
-        let mut env = owned_env.get_exec_environment(Some(p2.clone()));
-        assert!(!is_committed(&env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                                                    "token-transfer",
-                                                    &symbols_from_values(vec![p1.clone(), Value::UInt(210)])).unwrap()));
-    }
+        let mut block = clarity.begin_block(&TrieFileStorage::block_sentinel(),
+                                        &test_block_headers(0),
+                                        &NULL_HEADER_DB);
 
-    {
-        let mut env = owned_env.get_exec_environment(Some(p1.clone()));
-        assert!(is_committed(&
-                             env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                                                  "token-transfer",
-                                                  &symbols_from_values(vec![p2.clone(), Value::UInt(9000)])).unwrap()));
+        let tokens_contract = SIMPLE_TOKENS;
+
+        let contract_ast = ast::build_ast(&contract_identifier, tokens_contract).unwrap();
+
+        block.initialize_smart_contract(&contract_identifier, &contract_ast, tokens_contract, |_, _| false)
+            .unwrap();
 
         assert!(!is_committed(&
-                              env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                                                   "token-transfer",
-                                                   &symbols_from_values(vec![p2.clone(), Value::UInt(1001)])).unwrap()));
+            block.run_contract_call(&p2, &contract_identifier, "token-transfer",
+                                    &[p1.clone().into(), Value::UInt(210)], |_, _| false).unwrap().0));
+        assert!(is_committed(&
+            block.run_contract_call(&p1, &contract_identifier, "token-transfer",
+                                    &[p2.clone().into(), Value::UInt(9000)], |_, _| false).unwrap().0));
+
+        assert!(!is_committed(&
+            block.run_contract_call(&p1, &contract_identifier, "token-transfer",
+                                    &[p2.clone().into(), Value::UInt(1001)], |_, _| false).unwrap().0));
         assert!(is_committed(& // send to self!
-                             env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), "token-transfer",
-                                                  &symbols_from_values(vec![p1.clone(), Value::UInt(1000)])).unwrap()));
-        
+            block.run_contract_call(&p1, &contract_identifier, "token-transfer",
+                                    &[p1.clone().into(), Value::UInt(1000)], |_, _| false).unwrap().0));
+
         assert_eq!(
-            env.eval_read_only(&QualifiedContractIdentifier::local("tokens").unwrap(),
-                               "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
+            block.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
             Value::UInt(1000));
         assert_eq!(
-            env.eval_read_only(&QualifiedContractIdentifier::local("tokens").unwrap(),
-                               "(my-get-token-balance 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G)").unwrap(),
+            block.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G)").unwrap(),
             Value::UInt(9200));
-        assert!(is_committed(&env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                             "faucet", 
-                             &vec![]).unwrap()));
-        
-        assert!(is_committed(&env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                             "faucet", 
-                             &vec![]).unwrap()));
-        
-        assert!(is_committed(&env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                             "faucet", 
-                             &vec![]).unwrap()));
-        
-        assert_eq!(
-            env.eval_read_only(&QualifiedContractIdentifier::local("tokens").unwrap(),
-                               "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
-                               Value::UInt(1003));
 
-        assert!(!is_committed(&env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                              "mint-after", 
-                              &symbols_from_values(vec![Value::UInt(25)])).unwrap()));
-        
-        env.global_context.database.sim_mine_blocks(10);
-        assert!(is_committed(&env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), 
-                             "mint-after", 
-                             &symbols_from_values(vec![Value::UInt(25)])).unwrap()));
-        
-        assert!(!is_committed(&
-                              env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), "faucet", &vec![]).unwrap()));
+        assert!(is_committed(&block.run_contract_call(&p1, &contract_identifier,
+                                                      "faucet",
+                                                      &[], |_, _| false).unwrap().0));
+
+        assert!(is_committed(&block.run_contract_call(&p1, &contract_identifier,
+                                                      "faucet",
+                                                      &[], |_, _| false).unwrap().0));
+
+        assert!(is_committed(&block.run_contract_call(&p1, &contract_identifier,
+                                                      "faucet",
+                                                      &[], |_, _| false).unwrap().0));
         
         assert_eq!(
-            env.eval_read_only(&QualifiedContractIdentifier::local("tokens").unwrap(),
-                               "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
+            block.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
+            Value::UInt(1003));
+
+        assert!(!is_committed(
+            &block.run_contract_call(&p1, &contract_identifier,
+                                     "mint-after", 
+                                     &[Value::UInt(25)], |_, _| false).unwrap().0));
+        block.commit_block();
+    }
+
+    for i in 0..25 {
+        {
+            let block = clarity.begin_block(&test_block_headers(i),
+                                            &test_block_headers(i+1),
+                                            &NULL_HEADER_DB);
+            block.commit_block();
+        }
+    }
+
+    {
+        let mut block = clarity.begin_block(&test_block_headers(25),
+                                        &test_block_headers(26),
+                                        &NULL_HEADER_DB);
+        assert!(is_committed(
+            &block.run_contract_call(&p1, &contract_identifier,
+                                     "mint-after", 
+                                     &[Value::UInt(25)], |_, _| false).unwrap().0));
+        
+        assert!(!is_committed(
+            &block.run_contract_call(&p1, &contract_identifier,
+                                     "faucet", 
+                                     &[], |_, _| false).unwrap().0));
+
+        assert_eq!(
+            block.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
             Value::UInt(1004));
         assert_eq!(
-            env.execute_contract(&QualifiedContractIdentifier::local("tokens").unwrap(), "my-get-token-balance", &symbols_from_values(vec![p1.clone()])).unwrap(),
+            block.run_contract_call(&p1, &contract_identifier,
+                                    "my-get-token-balance",
+                                    &[p1.clone().into()], |_, _| false).unwrap().0,
             Value::UInt(1004));
     }
 }
@@ -652,7 +688,6 @@ fn test_all() {
                     test_contract_caller,
                     test_fully_qualified_contract_call,
                     test_simple_naming_system,
-                    test_simple_token_system,
                     test_simple_contract_call ];
     for test in to_test.iter() {
         with_memory_environment(test, false);

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -3,8 +3,7 @@ use vm::analysis::errors::{CheckErrors};
 use vm::types::{Value};
 use vm::contexts::{OwnedEnvironment};
 use vm::representations::SymbolicExpression;
-use vm::database::marf::MarfedKV;
-use vm::database::ClarityDatabase;
+use vm::database::{MarfedKV, ClarityDatabase, NULL_HEADER_DB};
 use vm::types::{QualifiedContractIdentifier, PrincipalData};
 
 use vm::tests::{symbols_from_values, execute, is_err_code, is_committed};
@@ -172,7 +171,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
 
     {
-        marf_kv.as_clarity_db().initialize();
+        marf_kv.as_clarity_db(&NULL_HEADER_DB).initialize();
     }
 
     marf_kv.test_commit();
@@ -180,7 +179,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap());
 
     {
-        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB));
         f(&mut owned_env)
     }
 
@@ -192,7 +191,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[2 as u8; 32]).unwrap());
 
     {
-        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB));
         a(&mut owned_env)
     }
 
@@ -202,7 +201,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[3 as u8; 32]).unwrap());
 
     {
-        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB));
         b(&mut owned_env)
     }
 
@@ -213,7 +212,7 @@ where F0: FnOnce(&mut OwnedEnvironment),
                   &BlockHeaderHash::from_bytes(&[4 as u8; 32]).unwrap());
 
     {
-        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB));
         z(&mut owned_env)
     }
 

--- a/src/vm/tests/integrations.rs
+++ b/src/vm/tests/integrations.rs
@@ -7,6 +7,7 @@ use chainstate::stacks::{
     StacksPrivateKey, TransactionSpendingCondition, TransactionAuth, TransactionVersion,
     StacksPublicKey, TransactionPayload, StacksTransactionSigner,
     StacksTransaction, TransactionSmartContract, TransactionContractCall, StacksAddress };
+use chainstate::burn::VRFSeed;
 use burnchains::Address;
 use address::AddressHashMode;
 use net::{Error as NetError, StacksMessageCodec};
@@ -66,6 +67,7 @@ const GET_INFO_CONTRACT: &'static str = "
         (define-map block-data 
           ((height uint))
           ((stacks-hash (buff 32)) 
+           (id-hash (buff 32))
            (btc-hash (buff 32))
            (vrf-seed (buff 32))))
         (define-private (test-1) (get-block-info? time u1))
@@ -75,13 +77,45 @@ const GET_INFO_CONTRACT: &'static str = "
         (define-private (test-5) (get-block-info? header-hash (- block-height u1)))
         (define-private (test-6) (get-block-info? burnchain-header-hash u1))
         (define-private (test-7) (get-block-info? vrf-seed u1))
-        (define-public (update-info)
-          (let ((height (- block-height u1)))
+
+        (define-private (get-block-id-hash (height uint)) (unwrap-panic
+          (get id-hash (map-get? block-data ((height height))))))
+
+        ;; should always return true!
+        ;;   evaluates 'block-height' at the block in question.
+        ;;   NOTABLY, this would fail if the MARF couldn't figure out
+        ;;    the height of the 'current chain tip'.
+        (define-private (exotic-block-height (height uint))
+          (is-eq (at-block (get-block-id-hash height) block-height)
+                 height))
+
+        (define-private (exotic-data-checks (height uint))
+          (let ((block-to-check (unwrap-panic (get-block-info? id-header-hash height)))
+                (block-info (unwrap-panic (map-get? block-data ((height (- height u1)))))))
+            (and (is-eq (print (unwrap-panic (at-block block-to-check (get-block-info? id-header-hash (- block-height u1)))))
+                        (print (get id-hash block-info)))
+                 (is-eq (print (unwrap-panic (at-block block-to-check (get-block-info? header-hash (- block-height u1)))))
+                        (print (unwrap-panic (get-block-info? header-hash (- height u1))))
+                        (print (get stacks-hash block-info)))
+                 (is-eq (print (unwrap-panic (at-block block-to-check (get-block-info? vrf-seed (- block-height u1)))))
+                        (print (unwrap-panic (get-block-info? vrf-seed (- height u1))))
+                        (print (get vrf-seed block-info)))
+                 (is-eq (print (unwrap-panic (at-block block-to-check (get-block-info? burnchain-header-hash (- block-height u1)))))
+                        (print (unwrap-panic (get-block-info? burnchain-header-hash (- height u1))))
+                        (print (get btc-hash block-info))))))
+
+        (define-private (inner-update-info (height uint))
             (let ((value (tuple 
               (stacks-hash (unwrap-panic (get-block-info? header-hash height)))
+              (id-hash (unwrap-panic (get-block-info? id-header-hash height)))
               (btc-hash (unwrap-panic (get-block-info? burnchain-header-hash height)))
               (vrf-seed (unwrap-panic (get-block-info? vrf-seed height))))))
-             (ok (map-set block-data ((height height)) value)))))
+             (ok (map-set block-data ((height height)) value))))
+
+        (define-public (update-info)
+          (begin
+            (inner-update-info (- block-height u2))
+            (inner-update-info (- block-height u1))))
        ";
 
 const SK_1: &'static str = "a1289f6438855da7decf9b61b852c882c398cff1446b2a0f823538aa2ebef92e01";
@@ -90,7 +124,9 @@ const SK_3: &'static str = "cb95ddd0fe18ec57f4f3533b95ae564b3f1ae063dbf75b46334b
 
 #[test]
 fn integration_test_get_info() {
-    let conf = testnet::tests::new_test_conf();
+    let mut conf = testnet::tests::new_test_conf();
+
+    conf.burnchain_block_time = 1500;
 
     let contract_sk = StacksPrivateKey::new();
 
@@ -100,15 +136,17 @@ fn integration_test_get_info() {
     let mut run_loop = testnet::RunLoop::new(conf);
     run_loop.apply_on_new_tenures(|round, tenure| {
         let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+        let principal_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
 
-        match round {
-            1 => {
-                let publish_tx = make_contract_publish(&contract_sk, 0, "get-info", GET_INFO_CONTRACT);
-                eprintln!("Tenure in 1 started!");
-                tenure.mem_pool.submit(publish_tx);
-            },
-            _ => {}
-        };
+        if round == 1 { // block-height = 2
+            let publish_tx = make_contract_publish(&contract_sk, 0, "get-info", GET_INFO_CONTRACT);
+            eprintln!("Tenure in 1 started!");
+            tenure.mem_pool.submit(publish_tx);
+        } else if round >= 2 { // block-height > 2
+            let tx = make_contract_call(&principal_sk, (round - 2).into(), &to_addr(&contract_sk), "get-info", "update-info", &[]);
+            tenure.mem_pool.submit(tx);
+        }
+
         return
     });
 
@@ -133,7 +171,7 @@ fn integration_test_get_info() {
 
                 let parent = block.header.parent_block;
                 eprintln!("Current Block: {}       Parent Block: {}", bhh.to_hex(), parent.to_hex());
-                let parent = Value::buff_from(parent.as_bytes().to_vec()).unwrap();
+                let parent_val = Value::buff_from(parent.as_bytes().to_vec()).unwrap();
 
                 assert_eq!(
                     chain_state.clarity_eval_read_only(
@@ -143,14 +181,45 @@ fn integration_test_get_info() {
                 assert_eq!(
                     chain_state.clarity_eval_read_only(
                         bhh, &contract_identifier, "(test-4 u1)"),
-                    Value::some(parent.clone()));
+                    Value::some(parent_val.clone()));
 
                 assert_eq!(
                     chain_state.clarity_eval_read_only(
                         bhh, &contract_identifier, "(test-5)"),
-                    Value::some(parent));
+                    Value::some(parent_val));
+
+                // test-6 and test-7 return the block at height 1's VRF-seed,
+                //   which in this integration test, should be blocks[0]
+                let last_tip = blocks[0];
+                eprintln!("Last block info: stacks: {}, burn: {}", last_tip.1.to_hex(), last_tip.0.to_hex());
+                let last_block = StacksChainState::load_block(&chain_state.blocks_path, &last_tip.0, &last_tip.1).unwrap().unwrap();
+                assert_eq!(parent, last_block.header.block_hash());
+
+                let last_vrf_seed = VRFSeed::from_proof(&last_block.header.proof).as_bytes().to_vec();
+                let last_burn_header = last_tip.0.as_bytes().to_vec();
+
+                assert_eq!(
+                    chain_state.clarity_eval_read_only(
+                        bhh, &contract_identifier, "(test-6)"),
+                    Value::some(Value::buff_from(last_burn_header).unwrap()));
+                assert_eq!(
+                    chain_state.clarity_eval_read_only(
+                        bhh, &contract_identifier, "(test-7)"),
+                    Value::some(Value::buff_from(last_vrf_seed).unwrap()));
             },
-            4 => {
+            3 => {
+                assert_eq!(Value::Bool(true), chain_state.clarity_eval_read_only(
+                    bhh, &contract_identifier, "(exotic-block-height u1)"));
+                assert_eq!(Value::Bool(true), chain_state.clarity_eval_read_only(
+                    bhh, &contract_identifier, "(exotic-block-height u2)"));
+                assert_eq!(Value::Bool(true), chain_state.clarity_eval_read_only(
+                    bhh, &contract_identifier, "(exotic-block-height u3)"));
+
+                assert_eq!(Value::Bool(true), chain_state.clarity_eval_read_only(
+                    bhh, &contract_identifier, "(exotic-data-checks u2)"));
+                assert_eq!(Value::Bool(true), chain_state.clarity_eval_read_only(
+                    bhh, &contract_identifier, "(exotic-data-checks u3)"));
+
             },
             _ => {},
         }

--- a/src/vm/tests/integrations.rs
+++ b/src/vm/tests/integrations.rs
@@ -1,0 +1,160 @@
+use vm::{
+    database::HeadersDB,
+    types::QualifiedContractIdentifier,
+    Value, ClarityName, ContractName, errors::RuntimeErrorType, errors::Error as ClarityError };
+use chainstate::stacks::{
+    db::StacksChainState, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+    StacksPrivateKey, TransactionSpendingCondition, TransactionAuth, TransactionVersion,
+    StacksPublicKey, TransactionPayload, StacksTransactionSigner,
+    StacksTransaction, TransactionSmartContract, TransactionContractCall, StacksAddress };
+use burnchains::Address;
+use address::AddressHashMode;
+use net::{Error as NetError, StacksMessageCodec};
+use util::{log, strings::StacksString, hash::hex_bytes, hash::to_hex};
+
+use util::db::{DBConn, FromRow};
+
+use testnet;
+use testnet::mem_pool::MemPool;
+
+fn serialize_sign_standard_single_sig_tx(payload: TransactionPayload,
+                                         sender: &StacksPrivateKey, nonce: u64) -> Vec<u8> {
+    let mut spending_condition = TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(sender))
+        .expect("Failed to create p2pkh spending condition from public key.");
+    spending_condition.set_nonce(nonce);
+    spending_condition.set_fee_rate(0);
+    let auth = TransactionAuth::Standard(spending_condition);
+    let unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
+    let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
+    tx_signer.sign_origin(sender).unwrap();
+    tx_signer.get_tx().unwrap().serialize()    
+}
+
+fn make_contract_publish(sender: &StacksPrivateKey, nonce: u64, contract_name: &str, contract_content: &str) -> Vec<u8> {
+    let name = ContractName::from(contract_name);
+    let code_body = StacksString::from_string(&contract_content.to_string()).unwrap();
+
+    let payload = TransactionSmartContract { name, code_body };
+
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce)
+}
+
+fn make_contract_call(
+    sender: &StacksPrivateKey, nonce: u64,
+    contract_addr: &StacksAddress, contract_name: &str,
+    function_name: &str, function_args: &[Value]) -> Vec<u8> {
+
+    let contract_name = ContractName::from(contract_name);
+    let function_name = ClarityName::from(function_name);
+
+    let payload = TransactionContractCall {
+        address: contract_addr.clone(),
+        contract_name, function_name,
+        function_args: function_args.iter().map(|x| x.clone()).collect()
+    };
+
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce)
+}
+
+fn to_addr(sk: &StacksPrivateKey) -> StacksAddress {
+    StacksAddress::from_public_keys(
+        C32_ADDRESS_VERSION_TESTNET_SINGLESIG, &AddressHashMode::SerializeP2PKH, 1, &vec![StacksPublicKey::from_private(sk)])
+        .unwrap()
+}
+
+const GET_INFO_CONTRACT: &'static str = "
+        (define-map block-data 
+          ((height uint))
+          ((stacks-hash (buff 32)) 
+           (btc-hash (buff 32))
+           (vrf-seed (buff 32))))
+        (define-private (test-1) (get-block-info? time u1))
+        (define-private (test-2) (get-block-info? time block-height))
+        (define-private (test-3) (get-block-info? time u100000))
+        (define-private (test-4 (x uint)) (get-block-info? header-hash x))
+        (define-private (test-5) (get-block-info? header-hash (- block-height u1)))
+        (define-private (test-6) (get-block-info? burnchain-header-hash u1))
+        (define-private (test-7) (get-block-info? vrf-seed u1))
+        (define-public (update-info)
+          (let ((height (- block-height u1)))
+            (let ((value (tuple 
+              (stacks-hash (unwrap-panic (get-block-info? header-hash height)))
+              (btc-hash (unwrap-panic (get-block-info? burnchain-header-hash height)))
+              (vrf-seed (unwrap-panic (get-block-info? vrf-seed height))))))
+             (ok (map-set block-data ((height height)) value)))))
+       ";
+
+const SK_1: &'static str = "a1289f6438855da7decf9b61b852c882c398cff1446b2a0f823538aa2ebef92e01";
+const SK_2: &'static str = "4ce9a8f7539ea93753a36405b16e8b57e15a552430410709c2b6d65dca5c02e201";
+const SK_3: &'static str = "cb95ddd0fe18ec57f4f3533b95ae564b3f1ae063dbf75b46334bd86245aef78501";
+
+#[test]
+fn integration_test_get_info() {
+    let conf = testnet::tests::new_test_conf();
+
+    let contract_sk = StacksPrivateKey::new();
+
+    let num_rounds = 4;
+    let contract_addr = to_addr(&contract_sk);
+
+    let mut run_loop = testnet::RunLoop::new(conf);
+    run_loop.apply_on_new_tenures(|round, tenure| {
+        let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+
+        match round {
+            1 => {
+                let publish_tx = make_contract_publish(&contract_sk, 0, "get-info", GET_INFO_CONTRACT);
+                eprintln!("Tenure in 1 started!");
+                tenure.mem_pool.submit(publish_tx);
+            },
+            _ => {}
+        };
+        return
+    });
+
+    run_loop.apply_on_new_chain_states(|round, ref mut chain_state, bhh| {
+        let contract_identifier =
+            QualifiedContractIdentifier::parse(&format!("{}.{}",
+                                                        to_addr(
+                                                            &StacksPrivateKey::from_hex(SK_1).unwrap()).to_string(),
+                                                        "get-info")).unwrap();
+
+        match round {
+            1 => {
+                // - Chain length should be 2.
+                let mut blocks = StacksChainState::list_blocks(&chain_state.blocks_db, &chain_state.blocks_path).unwrap();
+                blocks.sort();
+                assert!(blocks.len() == 2);
+                
+                // Block #1 should only have 2 txs
+                let chain_tip = blocks.last().unwrap();
+                let block = StacksChainState::load_block(&chain_state.blocks_path, &chain_tip.0, &chain_tip.1).unwrap().unwrap();
+                assert!(block.txs.len() == 2);
+
+                let parent = block.header.parent_block;
+                eprintln!("Current Block: {}       Parent Block: {}", bhh.to_hex(), parent.to_hex());
+                let parent = Value::buff_from(parent.as_bytes().to_vec()).unwrap();
+
+                assert_eq!(
+                    chain_state.clarity_eval_read_only(
+                        bhh, &contract_identifier, "block-height"),
+                    Value::UInt(2));
+
+                assert_eq!(
+                    chain_state.clarity_eval_read_only(
+                        bhh, &contract_identifier, "(test-4 u1)"),
+                    Value::some(parent.clone()));
+
+                assert_eq!(
+                    chain_state.clarity_eval_read_only(
+                        bhh, &contract_identifier, "(test-5)"),
+                    Value::some(parent));
+            },
+            4 => {
+            },
+            _ => {},
+        }
+    });
+
+    run_loop.start(num_rounds);
+}

--- a/src/vm/tests/integrations.rs
+++ b/src/vm/tests/integrations.rs
@@ -170,7 +170,7 @@ fn integration_test_get_info() {
                 assert!(block.txs.len() == 2);
 
                 let parent = block.header.parent_block;
-                eprintln!("Current Block: {}       Parent Block: {}", bhh.to_hex(), parent.to_hex());
+                eprintln!("Current Block: {}       Parent Block: {}", bhh, parent);
                 let parent_val = Value::buff_from(parent.as_bytes().to_vec()).unwrap();
 
                 assert_eq!(
@@ -191,7 +191,7 @@ fn integration_test_get_info() {
                 // test-6 and test-7 return the block at height 1's VRF-seed,
                 //   which in this integration test, should be blocks[0]
                 let last_tip = blocks[0];
-                eprintln!("Last block info: stacks: {}, burn: {}", last_tip.1.to_hex(), last_tip.0.to_hex());
+                eprintln!("Last block info: stacks: {}, burn: {}", last_tip.1, last_tip.0);
                 let last_block = StacksChainState::load_block(&chain_state.blocks_path, &last_tip.0, &last_tip.1).unwrap().unwrap();
                 assert_eq!(parent, last_block.header.block_hash());
 

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -11,6 +11,7 @@ use vm::database::{ClarityDatabase, MarfedKV, MemoryBackingStore,
 use chainstate::stacks::index::storage::{TrieFileStorage};
 use chainstate::burn::BlockHeaderHash;
 
+mod integrations;
 mod forking;
 mod assets;
 mod iterables;

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -5,8 +5,8 @@ use vm::contexts::{OwnedEnvironment,GlobalContext, Environment};
 use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
-use vm::database::marf::{ MarfedKV, MemoryBackingStore };
-use vm::database::ClarityDatabase;
+use vm::database::{ClarityDatabase, MarfedKV, MemoryBackingStore,
+                   NULL_HEADER_DB};
 
 use chainstate::stacks::index::storage::{TrieFileStorage};
 use chainstate::burn::BlockHeaderHash;
@@ -41,7 +41,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
                   &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap());
 
     {
-        marf_kv.as_clarity_db().initialize();
+        marf_kv.as_clarity_db(&NULL_HEADER_DB).initialize();
     }
 
     marf_kv.test_commit();
@@ -49,7 +49,7 @@ where F: FnOnce(&mut OwnedEnvironment) -> ()
                   &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap());
 
     {
-        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db());
+        let mut owned_env = OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB));
         // start an initial transaction.
         if !top_level {
             owned_env.begin();

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -133,6 +133,7 @@ define_named_enum!(BlockInfoProperty {
     HeaderHash("header-hash"),
     IdentityHeaderHash("id-header-hash"),
     BurnchainHeaderHash("burnchain-header-hash"),
+    MinerAddress("miner-address"),
 });
 
 impl OptionalData {
@@ -161,6 +162,7 @@ impl BlockInfoProperty {
         match self {
             Time => TypeSignature::UIntType,
             IdentityHeaderHash | VrfSeed | HeaderHash | BurnchainHeaderHash => BUFF_32.clone(),
+            MinerAddress => TypeSignature::PrincipalType,
         }
     }
 }

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -24,7 +24,7 @@ pub struct TupleData {
     pub data_map: BTreeMap<ClarityName, Value>
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuffData {
     pub data: Vec<u8>,
 }
@@ -131,6 +131,7 @@ define_named_enum!(BlockInfoProperty {
     Time("time"),
     VrfSeed("vrf-seed"),
     HeaderHash("header-hash"),
+    IdentityHeaderHash("id-header-hash"),
     BurnchainHeaderHash("burnchain-header-hash"),
 });
 
@@ -159,7 +160,7 @@ impl BlockInfoProperty {
         use self::BlockInfoProperty::*;
         match self {
             Time => TypeSignature::UIntType,
-            VrfSeed | HeaderHash | BurnchainHeaderHash => BUFF_32.clone(),
+            IdentityHeaderHash | VrfSeed | HeaderHash | BurnchainHeaderHash => BUFF_32.clone(),
         }
     }
 }
@@ -281,13 +282,25 @@ impl fmt::Display for ResponseData {
     }
 }
 
+impl fmt::Display for BuffData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", hash::to_hex(&self.data))
+    }
+}
+
+impl fmt::Debug for BuffData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Value::Int(int) => write!(f, "{}", int),
             Value::UInt(int) => write!(f, "u{}", int),
             Value::Bool(boolean) => write!(f, "{}", boolean),
-            Value::Buffer(vec_bytes) => write!(f, "0x{}", hash::to_hex(&vec_bytes.data)),
+            Value::Buffer(vec_bytes) => write!(f, "0x{}", &vec_bytes),
             Value::Tuple(data) => write!(f, "{}", data),
             Value::Principal(principal_data) => write!(f, "{}", principal_data),
             Value::Optional(opt_data) => write!(f, "{}", opt_data),

--- a/src/vm/variables.rs
+++ b/src/vm/variables.rs
@@ -26,7 +26,7 @@ pub fn lookup_reserved_variable(name: &str, _context: &LocalContext, env: &mut E
                 Ok(Some(sender))
             },
             NativeVariables::BlockHeight => {
-                let block_height = env.global_context.database.get_simmed_block_height();
+                let block_height = env.global_context.database.get_current_block_height();
                 Ok(Some(Value::UInt(block_height as u128)))
             },
             NativeVariables::BurnBlockHeight => {


### PR DESCRIPTION
This PR removes the simming code for block-info and replaces it with actual information from the header database. This PR touches a couple of different spots:

1. Clarity instances need to be passed a handle to the headers_db
2. `at-block` _cannot_ accept the stacks header hash as an input -- this is non-unique and is a value that has no meaning to the MARF. This PR adds an `id-hash-header` option to `get-block-info` to allow smart contracts to use that value. An alternative is to use the block-height, and keep the `id-hash-header` hidden. If this is preferred, I can change that.
3. The MARF needs to be able to figure out what block height the current block is, even if it's not the "miner_tip", the clearest example is for evaluating something like `(at-block <foo> block-height)`, the block that the MARF _switches_ to is not the miner_tip, but it still needs to return a correct value for `block-height`. In order to do that, this PR just sets a static key to the current block height for every MARF block (this replaces the code that attempts to detect when the miner_tip is the correct result).
4. In testing the integration of all these pieces, the testnet `run_loop` callback signature was updated to allow the tests to run clarity code snippets when new chainstate arrives, and passes in the block header of the new block.

This PR _doesn't_ yet implement fetching the miner address or block time -- fetching those would require either providing the Clarity VM instance with a handle to the BurnDB in addition to the headers db, or shoving that information into the headers db, and I didn't want to go down either of those paths without getting @jcnelson's thoughts on that first.
