### PR TITLE
Resolve OOM issue in value deserialize: #1276

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -101,10 +101,10 @@ pub fn apply(function: &CallableType, args: &[SymbolicExpression],
         env.call_stack.remove(&identifier, track_recursion)?;
         resp
     } else {
+        env.call_stack.insert(&identifier, track_recursion);
         let eval_tried: Result<Vec<Value>> =
             args.iter().map(|x| eval(x, env, context)).collect();
         let evaluated_args = eval_tried?;
-        env.call_stack.insert(&identifier, track_recursion);
         let mut resp = match function {
             CallableType::NativeFunction(_, function) => function(&evaluated_args),
             CallableType::UserFunction(function) => function.apply(&evaluated_args, env),
@@ -232,6 +232,27 @@ mod test {
     use vm::types::{TypeSignature, QualifiedContractIdentifier};
     use vm::callables::{DefinedFunction, DefineType};
     use vm::eval;
+    use vm::execute;
+    use vm::errors::RuntimeErrorType;
+
+    #[test]
+    fn test_stack_depth() {
+        let program = "(+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 
+                       (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 
+                       (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 
+                       (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 
+                       (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 
+                       1 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)
+                         1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)
+                         1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)
+                         1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)
+                         1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)
+
+                      ";
+            assert_eq!(
+                execute(program).unwrap_err(),
+                RuntimeErrorType::MaxStackDepthReached.into());
+    }
 
     #[test]
     fn test_simple_user_function() {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -104,7 +104,13 @@ pub fn apply(function: &CallableType, args: &[SymbolicExpression],
         env.call_stack.insert(&identifier, track_recursion);
         let eval_tried: Result<Vec<Value>> =
             args.iter().map(|x| eval(x, env, context)).collect();
-        let evaluated_args = eval_tried?;
+        let evaluated_args = match eval_tried {
+            Ok(x) => x,
+            Err(e) => {
+                env.call_stack.remove(&identifier, track_recursion)?;
+                return Err(e)
+            }
+        };
         let mut resp = match function {
             CallableType::NativeFunction(_, function) => function(&evaluated_args),
             CallableType::UserFunction(function) => function.apply(&evaluated_args, env),

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -1,7 +1,7 @@
 use vm::errors::{RuntimeErrorType, InterpreterResult, InterpreterError, 
                  IncomparableError, Error as ClarityError, CheckErrors};
-use vm::types::{Value, StandardPrincipalData, OptionalData, PrincipalData, BufferLength,
-                TypeSignature, TupleData, QualifiedContractIdentifier, TraitIdentifier, ResponseData};
+use vm::types::{Value, StandardPrincipalData, OptionalData, PrincipalData, BufferLength, MAX_VALUE_SIZE,
+                TypeSignature, TupleData, QualifiedContractIdentifier, ResponseData};
 use vm::database::{ClaritySerializable, ClarityDeserializable};
 use vm::representations::{ClarityName, ContractName, MAX_STRING_LEN};
 
@@ -51,20 +51,8 @@ impl error::Error for SerializationError {
     }
 }
 
-/*
- * jude -- it would be better for the transaction-parsing logic to know, through the type system,
- * whether or not a failure to parse a Clarity value was due to an unexpected EOF or
- * semantically-invalid data.  Disabling this From impl fixes this.
-impl From<std::io::Error> for SerializationError {
-    fn from(err: std::io::Error) -> Self {
-        match err.kind() {
-            std::io::ErrorKind::UnexpectedEof => "Unexpected end of byte stream".into(),
-            _ => SerializationError::IOError(IncomparableError { err })
-        }
-    }
-}
-*/
-
+// Note: a byte stream that describes a longer type than
+//   there are available bytes to read will result in an IOError(UnexpectedEOF)
 impl From<std::io::Error> for SerializationError {
     fn from(err: std::io::Error) -> Self {
         SerializationError::IOError(IncomparableError { err })
@@ -308,6 +296,10 @@ impl Value {
                 r.read_exact(&mut len)?;
                 let len = u32::from_be_bytes(len);
 
+                if len > MAX_VALUE_SIZE {
+                    return Err("Illegal list type".into());
+                }
+
                 let (list_type, entry_type) = match expected_type {
                     None => (None, None),
                     Some(TypeSignature::ListType(list_type)) => {
@@ -337,6 +329,10 @@ impl Value {
                 let mut len = [0; 4];
                 r.read_exact(&mut len)?;
                 let len = u32::from_be_bytes(len);
+
+                if len > MAX_VALUE_SIZE {
+                    return Err(SerializationError::DeserializationError("Illegal tuple type".to_string()));
+                }
 
                 let tuple_type = match expected_type {
                     None => None,
@@ -549,12 +545,12 @@ mod tests {
 
 
         // make a list that says it is longer than it is!
-        //   this describes a list of size 1+MAX_VALUE_SIZE of Value::Bool(true)'s, but is actually only 59 bools.
+        //   this describes a list of size MAX_VALUE_SIZE of Value::Bool(true)'s, but is actually only 59 bools.
         let mut eof = vec![3u8; 64 as usize];
         // list prefix
         eof[0] = 11;
         // list length
-        Write::write_all(&mut eof.get_mut(1..5).unwrap(), &(1+MAX_VALUE_SIZE).to_be_bytes()).unwrap();
+        Write::write_all(&mut eof.get_mut(1..5).unwrap(), &(MAX_VALUE_SIZE).to_be_bytes()).unwrap();
 
         /*
          * jude -- this should return an IOError
@@ -743,6 +739,23 @@ mod tests {
                 expected,
                 &Value::try_deserialize_hex_untyped(test));
         }
+    }
+
+    #[test]
+    fn try_deser_large_list() {
+        let buff = vec![11, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255];
+
+        assert_eq!(Value::try_deserialize_bytes_untyped(&buff).unwrap_err(),
+                   SerializationError::DeserializationError("Illegal list type".to_string()));
+    }
+
+
+    #[test]
+    fn try_deser_large_tuple() {
+        let buff = vec![12, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255];
+
+        assert_eq!(Value::try_deserialize_bytes_untyped(&buff).unwrap_err(),
+                   SerializationError::DeserializationError("Illegal tuple type".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
This resolves some simple OOM issues in Value deserialize (#1276) by checking that the length is less than the Clarity max value size. This only solves OOM issues within a single iteration. Recursive calls in `deserialize_read` can cause other issues, which will be resolved in a subsequent PR.

This PR also fixes an ordering bug in the stack depth check in `vm::eval` -- argument evaluation must count against the stack depth limit.

Tests are provided for both fixes.