### PR TITLE
Analysis + Parser Cost Tracking

### DIFF
--- a/sip/sip-008-analysis-cost-assessment.md
+++ b/sip/sip-008-analysis-cost-assessment.md
@@ -1,4 +1,4 @@
-# SIP 009 Clarity Parsing and Analysis Cost Assessment
+# SIP 008 Clarity Parsing and Analysis Cost Assessment
 
 ## Preamble
 

--- a/sip/sip-009-analysis-cost-assessment.md
+++ b/sip/sip-009-analysis-cost-assessment.md
@@ -222,6 +222,35 @@ checking pass.
 
 Some functions require additional work from the static analysis system.
 
+## Functions on iterables (e.g., map, filter, fold)
+
+Functions on iterables need to perform an additional check that the
+supplied type is a list or buffer before performing the normal
+argument type checking. This cost is assessed as:
+
+```
+a
+```
+
+where a is a constant.
+
+## Functions on options/responses
+
+Similarly to the functions on iterables, option/response functions
+must perform a simple check to see if the supplied input is an option or
+response before performing additional argument type checking. This cost is
+assessed as:
+
+```
+a
+```
+
+## Data functions (ft balance checks, nft lookups, map-get?, ...)
+
+Static checks on intra-contract data functions do not require database lookups
+(unlike the runtime costs of these functions). Rather, these functions
+incur normal type lookup (i.e., fetching the type of an NFT, data map, or data var)
+and type checking costs.
 
 ## get
 

--- a/sip/sip-009-analysis-cost-assessment.md
+++ b/sip/sip-009-analysis-cost-assessment.md
@@ -1,0 +1,170 @@
+# SIP 006 Clarity Execution Cost Assessment
+
+## Preamble
+
+Title: Clarity Execution Cost Assessment
+
+Author: Aaron Blankstein <aaron@blockstack.com>
+
+Status: Draft
+
+Type: Standard
+
+Created: 10/19/2019
+
+License: BSD 2-Clause
+
+# Abstract
+
+This document describes the measured costs and asymptotic costs
+assessed for the analysis of Clarity code. This will not specify the
+_constants_ associated with those asymptotic cost functions. Those
+constants will necessarily be measured via benchmark harnesses and
+regression analyses.
+
+# Measurements for Execution Cost
+
+The cost of analyzing Clarity code is measured using the same 5 categories
+described in SIP-006 for the measurement of execution costs:
+
+1. Runtime cost: captures the number of cycles that a single
+   processor would require to process the Clarity block. This is a
+   _unitless_ metric, so it will not correspond directly to cycles,
+   but rather is meant to provide a basis for comparison between
+   different Clarity code blocks.
+2. Data write count: captures the number of independent writes
+   performed on the underlying data store (see SIP-004).
+3. Data read count: captures the number of independent reads
+   performed on the underlying data store.
+4. Data write length: the number of bytes written to the underlying
+   data store.
+5. Data read length: the number of bytes read from the underlying
+   data store.
+
+Importantly, these costs are used to set a _block limit_ for each
+block.  When it comes to selecting transactions for inclusion in a
+block, miners are free to make their own choices based on transaction
+fees, however, blocks may not exceed the _block limit_. If they do so,
+the block is considered invalid by the network --- none of the block's
+transactions will be materialized and the leader forfeits all rewards
+from the block.
+
+# Common Analysis Metrics and Costs
+
+## Type signature size
+
+Types in Clarity may described using type signatures. For example,
+`(tuple (a int) (b int))` describes a tuple with two keys `a` and `b`
+of type `int`. These type descriptions are used by the Clarity analysis
+passes to check the type correctness of Clarity code. Clarity type signatures
+have varying size, e.g., the signature `int` is smaller than the signature for a
+list of integers.
+
+The signature size of a Clarity type is defined as follows:
+
+```
+type_signature_size(x) :=
+  if x = 
+     int      => 1
+    uint      => 1
+    bool      => 1
+    principal => 1
+    buffer    => 2
+    optional  => 1 + type_signature_size(entry_type)
+    response  => 1 + type_signature_size(ok_type) + type_signature_size(err_type)
+    list      => 2 + type_signature_size(entry_type)
+    tuple     => 1 + 2*(count(entries)) 
+                   + sum(type_signature_size for each entry)
+                   + sum(len(key_name) for each entry)
+```
+
+## Type annotation
+
+Each node in a Clarity contract's AST is annotated with the type value
+for that node during the type checking analysis pass.
+
+The runtime cost of type annotation is:
+
+```
+a + b*X
+```
+
+where a and b are constants, and X is the type signature size of the
+type being annotated.
+
+## Variable lookup
+
+Looking up variables during static analysis incurs a non-constant cost -- the stack
+depth _and_ the length of the variable name affect this cost. However,
+variable names in Clarity have bounded length -- 128 characters. Therefore,
+the cost assessed for variable lookups may safely be constant with respect
+to name length.
+
+The stack depth affects the lookup cost because the variable must be
+checked for in each context on the stack.
+
+Cost Function:
+
+```
+a*X+b
+```
+
+where a and b are constants,
+X := stack depth
+
+## Function Lookup
+
+Looking up a function incurs a constant cost with respect
+to name length (for the same reason as variable lookup). However,
+because functions may only be defined in the top-level contract
+context, stack depth does not affect function lookup.
+
+Cost Function:
+
+```
+a
+```
+
+where a is a constant.
+
+## Name Binding
+
+The cost of binding a name in Clarity -- in either a local or the contract
+context is _constant_ with respect to the length of the name:
+
+```
+binding_cost = a
+```
+
+where a is a constant
+
+## Type check cost
+
+The cost of a static type check is _linear_ in the size of the type signature:
+
+```
+type_check_cost(expected, actual) :=
+  a + b*X
+```
+
+where a and b are constants, and
+
+X := `max(type_signature_size(expected), type_signature_size(actual))`
+
+## Function Application
+
+Static analysis of a function application in Clarity requires
+type checking the function's expected arguments against the
+supplied types.
+
+The cost of applying a function is:
+
+
+```
+a + sum(type_check_cost(expected, actual) for each argument)
+```
+
+where a is a constant.
+
+This is also the _entire_ cost of type analysis for most function calls
+(e.g., intra-contract function calls, most simple native functions). 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -258,16 +258,16 @@ impl<'a> ClarityTx<'a> {
 
     #[cfg(test)]
     pub fn commit_block(self) -> () {
-        self.block.commit_block()
+        self.block.commit_block();
     }
 
     pub fn commit_block_will_move(self, will_move: &str) -> () {
-        self.block.commit_block_will_move(will_move)
+        self.block.commit_block_will_move(will_move);
     }
 
     pub fn commit_to_block(self, burn_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash) -> () {
         let index_block_hash = StacksBlockHeader::make_index_block_hash(burn_hash, block_hash);
-        self.block.commit_to_block(&index_block_hash)
+        self.block.commit_to_block(&index_block_hash);
     }
 
     pub fn rollback_block(self) -> () {

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -88,6 +88,10 @@ impl <'a> AnalysisDatabase <'a> {
     }
 
     pub fn get_public_function_type(&mut self, contract_identifier: &QualifiedContractIdentifier, function_name: &str) -> CheckResult<Option<FunctionType>> {
+        // TODO: this function loads the whole contract to obtain the function type.
+        //         but it doesn't need to -- rather this information can just be 
+        //         stored as its own entry. the analysis cost tracking currently only
+        //         charges based on the function type size.
         let contract = self.load_contract(contract_identifier)
             .ok_or(CheckErrors::NoSuchContract(contract_identifier.to_string()))?;
         Ok(contract.get_public_function_type(function_name)
@@ -95,6 +99,10 @@ impl <'a> AnalysisDatabase <'a> {
     }
 
     pub fn get_read_only_function_type(&mut self, contract_identifier: &QualifiedContractIdentifier, function_name: &str) -> CheckResult<Option<FunctionType>> {
+        // TODO: this function loads the whole contract to obtain the function type.
+        //         but it doesn't need to -- rather this information can just be 
+        //         stored as its own entry. the analysis cost tracking currently only
+        //         charges based on the function type size.
         let contract = self.load_contract(contract_identifier)
             .ok_or(CheckErrors::NoSuchContract(contract_identifier.to_string()))?;
         Ok(contract.get_read_only_function_type(function_name)
@@ -102,6 +110,10 @@ impl <'a> AnalysisDatabase <'a> {
     }
 
     pub fn get_defined_trait(&mut self, contract_identifier: &QualifiedContractIdentifier, trait_name: &str) -> CheckResult<Option<BTreeMap<ClarityName, FunctionSignature>>> {
+        // TODO: this function loads the whole contract to obtain the function type.
+        //         but it doesn't need to -- rather this information can just be 
+        //         stored as its own entry. the analysis cost tracking currently only
+        //         charges based on the function type size.
         let contract = self.load_contract(contract_identifier)
             .ok_or(CheckErrors::NoSuchContract(contract_identifier.to_string()))?;
         Ok(contract.get_defined_trait(trait_name)

--- a/src/vm/analysis/contract_interface_builder/mod.rs
+++ b/src/vm/analysis/contract_interface_builder/mod.rs
@@ -20,6 +20,7 @@ pub fn build_contract_interface(contract_analysis: &ContractAnalysis) -> Contrac
         expressions: _,
         contract_identifier: _,
         type_map: _,
+        cost_track: _,
     } = contract_analysis;
 
     contract_interface.functions.append(

--- a/src/vm/analysis/errors.rs
+++ b/src/vm/analysis/errors.rs
@@ -1,7 +1,7 @@
 use vm::representations::SymbolicExpression;
 use vm::diagnostic::{Diagnostic, DiagnosableError};
 use vm::types::{TypeSignature, TupleTypeSignature, Value};
-use vm::costs::{ExecutionCost};
+use vm::costs::{ExecutionCost, CostErrors};
 use std::error;
 use std::fmt;
 
@@ -197,6 +197,21 @@ impl fmt::Display for CheckError {
         }
 
         Ok(())
+    }
+}
+
+impl From<CostErrors> for CheckError {
+    fn from(err: CostErrors) -> Self {
+        CheckError::from(CheckErrors::from(err))
+    }
+}
+
+impl From<CostErrors> for CheckErrors {
+    fn from(err: CostErrors) -> Self {
+        match err {
+            CostErrors::CostOverflow => CheckErrors::CostOverflow,
+            CostErrors::CostBalanceExceeded(a, b) => CheckErrors::CostBalanceExceeded(a, b),
+        }
     }
 }
 

--- a/src/vm/analysis/mod.rs
+++ b/src/vm/analysis/mod.rs
@@ -9,6 +9,7 @@ pub mod contract_interface_builder;
 pub use self::types::{ContractAnalysis, AnalysisPass};
 use vm::representations::{SymbolicExpression};
 use vm::types::{TypeSignature, QualifiedContractIdentifier};
+use vm::costs::LimitedCostTracker;
 
 pub use self::errors::{CheckResult, CheckError, CheckErrors};
 pub use self::analysis_db::{AnalysisDatabase};
@@ -35,20 +36,21 @@ pub fn mem_type_check(snippet: &str) -> CheckResult<(Option<TypeSignature>, Cont
 
 // Legacy function
 // The analysis is not just checking type.
+#[cfg(test)]
 pub fn type_check(contract_identifier: &QualifiedContractIdentifier, 
                   expressions: &mut [SymbolicExpression],
                   analysis_db: &mut AnalysisDatabase, 
                   insert_contract: bool) -> CheckResult<ContractAnalysis> {
-    run_analysis(&contract_identifier, expressions, analysis_db, insert_contract)
+    run_analysis(&contract_identifier, expressions, analysis_db, insert_contract, LimitedCostTracker::new_max_limit())
 }
 
 pub fn run_analysis(contract_identifier: &QualifiedContractIdentifier, 
                     expressions: &mut [SymbolicExpression],
                     analysis_db: &mut AnalysisDatabase, 
-                    save_contract: bool) -> CheckResult<ContractAnalysis> {
-
+                    save_contract: bool,
+                    cost_tracker: LimitedCostTracker) -> CheckResult<ContractAnalysis> {
     analysis_db.execute(|db| {
-        let mut contract_analysis = ContractAnalysis::new(contract_identifier.clone(), expressions.to_vec());
+        let mut contract_analysis = ContractAnalysis::new(contract_identifier.clone(), expressions.to_vec(), cost_tracker);
         ReadOnlyChecker::run_pass(&mut contract_analysis, db)?;
         TypeChecker::run_pass(&mut contract_analysis, db)?;
         TraitChecker::run_pass(&mut contract_analysis, db)?;

--- a/src/vm/analysis/tests/costs.rs
+++ b/src/vm/analysis/tests/costs.rs
@@ -1,0 +1,86 @@
+use vm::execute as vm_execute;
+use vm::errors::{Error, CheckErrors, RuntimeErrorType};
+use vm::types::{Value, PrincipalData, ResponseData, QualifiedContractIdentifier, AssetIdentifier};
+use vm::contexts::{OwnedEnvironment, GlobalContext, AssetMap, AssetMapEntry};
+use vm::functions::NativeFunctions;
+use vm::representations::SymbolicExpression;
+use vm::contracts::Contract;
+use util::hash::hex_bytes;
+use vm::tests::{with_memory_environment, with_marfed_environment, symbols_from_values,
+                execute };
+use vm::clarity::ClarityInstance;
+
+use vm::contexts::{Environment};
+use vm::costs::{ExecutionCost};
+use vm::database::{ClarityDatabase, MarfedKV, MemoryBackingStore,
+                   NULL_HEADER_DB};
+
+use chainstate::stacks::index::storage::{TrieFileStorage};
+use chainstate::burn::BlockHeaderHash;
+
+use vm::tests::costs::get_simple_test;
+
+pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
+    let marf = MarfedKV::temporary();
+    let mut clarity_instance = ClarityInstance::new(marf);
+
+    let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let p2 = execute("'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G");
+
+    let p1_principal = match p1 {
+        Value::Principal(PrincipalData::Standard(ref data)) => data.clone(),
+        _ => panic!()
+    };
+
+    let contract_other = "(define-map map-foo ((a int)) ((b int)))
+                          (define-public (foo-exec (a int)) (ok 1))";
+
+    let contract_self = format!("(define-map map-foo ((a int)) ((b int)))
+                         (define-non-fungible-token nft-foo int)
+                         (define-fungible-token ft-foo)
+                         (define-data-var var-foo int 0)
+                         (define-constant tuple-foo (tuple (a 1)))
+                         (define-constant list-foo (list 'true))
+                         (define-constant list-bar (list 1))
+                         (define-public (execute) (ok {}))", prog);
+
+    let self_contract_id = QualifiedContractIdentifier::new(p1_principal.clone(), "self".into());
+    let other_contract_id = QualifiedContractIdentifier::new(p1_principal.clone(), "contract-other".into());
+
+    {
+        let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
+                                                    &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                    &NULL_HEADER_DB);
+
+        let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&other_contract_id, contract_other).unwrap();
+        conn.initialize_smart_contract(
+            &other_contract_id, &ct_ast, contract_other, |_,_| false).unwrap();
+        conn.save_analysis(&other_contract_id, &ct_analysis).unwrap();
+
+        conn.commit_block();
+    }
+
+    {
+        let mut conn = clarity_instance.begin_block(&BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                    &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap(),
+                                                    &NULL_HEADER_DB);
+
+        let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&self_contract_id, &contract_self).unwrap();
+        conn.initialize_smart_contract(
+            &self_contract_id, &ct_ast, &contract_self, |_,_| false).unwrap();
+        conn.save_analysis(&self_contract_id, &ct_analysis).unwrap();
+
+        conn.commit_block().get_total()
+    }
+}
+
+#[test]
+fn test_all() {
+    let baseline = test_tracked_costs("1");
+
+    for f in NativeFunctions::ALL.iter() {
+        let test = get_simple_test(f);
+        let cost = test_tracked_costs(test);
+        assert!(cost.exceeds(&baseline));
+    }
+}

--- a/src/vm/analysis/tests/mod.rs
+++ b/src/vm/analysis/tests/mod.rs
@@ -234,6 +234,7 @@ fn test_bad_syntax_binding() {
 fn test_unbound_variable() {
     let snippet = "(+ 1 unicorn)";
     let err = mem_type_check(snippet).unwrap_err();
+    eprintln!("{}", err.diagnostic);
     assert!(format!("{}", err.diagnostic).contains("use of unresolved variable 'unicorn'"));
 }
 

--- a/src/vm/analysis/tests/mod.rs
+++ b/src/vm/analysis/tests/mod.rs
@@ -3,6 +3,8 @@ use vm::analysis::{AnalysisDatabase, mem_type_check};
 use vm::analysis::errors::CheckErrors;
 use vm::analysis::{ContractAnalysis, type_check};
 
+mod costs;
+
 #[test]
 fn test_list_types_must_match() {
     let snippet = "(list 1 'true)";

--- a/src/vm/analysis/trait_checker/tests.rs
+++ b/src/vm/analysis/trait_checker/tests.rs
@@ -269,7 +269,7 @@ fn test_define_map_storing_trait_references() {
 
     let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
 
-    let err = build_ast(&dispatching_contract_id, dispatching_contract_src).unwrap_err();
+    let err = build_ast(&dispatching_contract_id, dispatching_contract_src, &mut ()).unwrap_err();
 
     match err.err {
         ParseErrors::TraitReferenceNotAllowed => {},
@@ -289,7 +289,7 @@ fn test_cycle_in_traits_1_contract() {
 
     let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
 
-    let err = build_ast(&dispatching_contract_id, dispatching_contract_src).unwrap_err();
+    let err = build_ast(&dispatching_contract_id, dispatching_contract_src, &mut ()).unwrap_err();
     match err.err {
         ParseErrors::CircularReference(_) => {},
         _ => {
@@ -426,7 +426,7 @@ fn test_dynamic_dispatch_collision_trait() {
     let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
 
     let _contract_defining_trait = parse(&contract_defining_trait_id, contract_defining_trait_src).unwrap();
-    let err = build_ast(&dispatching_contract_id, dispatching_contract_src).unwrap_err();
+    let err = build_ast(&dispatching_contract_id, dispatching_contract_src, &mut ()).unwrap_err();
     match err.err {
         ParseErrors::NameAlreadyUsed(_) => {},
         _ => {
@@ -447,7 +447,7 @@ fn test_dynamic_dispatch_collision_defined_trait() {
 
     let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
 
-    let err = build_ast(&dispatching_contract_id, dispatching_contract_src).unwrap_err();
+    let err = build_ast(&dispatching_contract_id, dispatching_contract_src, &mut ()).unwrap_err();
     match err.err {
         ParseErrors::NameAlreadyUsed(_) => {},
         _ => {
@@ -473,7 +473,7 @@ fn test_dynamic_dispatch_collision_imported_trait() {
     let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
 
     let _contract_defining_trait = parse(&contract_defining_trait_id, contract_defining_trait_src).unwrap();
-    let err = build_ast(&dispatching_contract_id, dispatching_contract_src).unwrap_err();
+    let err = build_ast(&dispatching_contract_id, dispatching_contract_src, &mut ()).unwrap_err();
     match err.err {
         ParseErrors::NameAlreadyUsed(_) => {},
         _ => {

--- a/src/vm/analysis/type_checker/contexts.rs
+++ b/src/vm/analysis/type_checker/contexts.rs
@@ -153,7 +153,7 @@ impl ContractContext {
         Ok(())
     }
 
-    pub fn get_trait(&mut self, trait_name: &str) -> Option<&BTreeMap<ClarityName, FunctionSignature>> {
+    pub fn get_trait(&self, trait_name: &str) -> Option<&BTreeMap<ClarityName, FunctionSignature>> {
         self.traits.get(trait_name)
     }
 

--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -12,6 +12,8 @@ use vm::types::signatures::{FunctionSignature};
 use vm::functions::NativeFunctions;
 use vm::functions::define::DefineFunctionsParsed;
 use vm::variables::NativeVariables;
+use vm::costs::{CostTracker, ExecutionCost, LimitedCostTracker,
+                cost_functions, analysis_typecheck_cost, CostOverflowingMath};
 
 use super::AnalysisDatabase;
 pub use super::types::{ContractAnalysis, AnalysisPass};
@@ -47,26 +49,47 @@ pub struct TypeChecker <'a, 'b> {
     pub type_map: TypeMap,
     contract_context: ContractContext,
     function_return_tracker: Option<Option<TypeSignature>>,
-    db: &'a mut AnalysisDatabase<'b>
+    db: &'a mut AnalysisDatabase<'b>,
+    pub cost_track: LimitedCostTracker,
+}
+
+impl CostTracker for TypeChecker<'_, '_> {
+    fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CheckErrors> {
+        self.cost_track.add_cost(cost)
+    }
 }
 
 impl <'a, 'b> AnalysisPass for TypeChecker <'a, 'b> {
     fn run_pass(contract_analysis: &mut ContractAnalysis, analysis_db: &mut AnalysisDatabase) -> CheckResult<()> {
-        let mut command = TypeChecker::new(analysis_db);
-        command.run(contract_analysis)?;
-        command.into_contract_analysis(contract_analysis);
-        Ok(())
+        let cost_track = contract_analysis.take_contract_cost_tracker();
+        let mut command = TypeChecker::new(analysis_db, cost_track);
+
+        // run the analysis, and replace the cost tracker whether or not the
+        //   analysis succeeded.
+        match command.run(contract_analysis) {
+            Ok(_) => {
+                let cost_track = command.into_contract_analysis(contract_analysis);
+                contract_analysis.replace_contract_cost_tracker(cost_track);                
+                Ok(())
+            },
+            err => {
+                let TypeChecker { cost_track, .. } = command;
+                contract_analysis.replace_contract_cost_tracker(cost_track);                
+                err
+            },
+        }
     }
 }
 
 pub type TypeResult = CheckResult<TypeSignature>;
 
 impl FunctionType {
-    pub fn check_args(&self, args: &[TypeSignature]) -> CheckResult<TypeSignature> {
+    pub fn check_args<T: CostTracker>(&self, accounting: &mut T, args: &[TypeSignature]) -> CheckResult<TypeSignature> {
         match self {
             FunctionType::Variadic(expected_type, return_type) => {
                 check_arguments_at_least(1, args)?;
                 for found_type in args.iter() {
+                    analysis_typecheck_cost(accounting, expected_type, found_type)?;
                     if !expected_type.admits_type(found_type) {
                         return Err(CheckErrors::TypeError(
                             expected_type.clone(), found_type.clone()).into())
@@ -77,6 +100,7 @@ impl FunctionType {
             FunctionType::Fixed(FixedFunction { args: arg_types, returns }) => {
                 check_argument_count(arg_types.len(), args)?;
                 for (expected_type, found_type) in arg_types.iter().map(|x| &x.signature).zip(args) {
+                    analysis_typecheck_cost(accounting, expected_type, found_type)?;
                     if !expected_type.admits_type(found_type) {
                         return Err(CheckErrors::TypeError(
                             expected_type.clone(), found_type.clone()).into())
@@ -88,6 +112,7 @@ impl FunctionType {
                 check_argument_count(1, args)?;
                 let found_type = &args[0];
                 for expected_type in arg_types.iter() {
+                    analysis_typecheck_cost(accounting, expected_type, found_type)?;
                     if expected_type.admits_type(found_type) {
                         return  Ok(return_type.clone())
                     }
@@ -100,6 +125,7 @@ impl FunctionType {
                 }
                 let (first, rest) = args.split_first()
                     .ok_or(CheckErrors::RequiresAtLeastArguments(1, args.len()))?;
+                analysis_typecheck_cost(accounting, &TypeSignature::IntType, first)?;
                 let return_type = match first {
                     TypeSignature::IntType => Ok(TypeSignature::IntType),
                     TypeSignature::UIntType => Ok(TypeSignature::UIntType),
@@ -107,6 +133,7 @@ impl FunctionType {
                                                          first.clone()))
                 }?;
                 for found_type in rest.iter() {
+                    analysis_typecheck_cost(accounting, &TypeSignature::IntType, found_type)?;
                     if found_type != &return_type {
                         return Err(CheckErrors::TypeError(return_type, found_type.clone()).into())
                     }
@@ -116,20 +143,33 @@ impl FunctionType {
             FunctionType::ArithmeticComparison => {
                 check_argument_count(2, args)?;
                 let (first, second) = (&args[0], &args[1]);
-                if first != second {
-                    return Err(CheckErrors::TypeError(first.clone(), second.clone()).into())
-                }
+                analysis_typecheck_cost(accounting, &TypeSignature::IntType, first)?;
+                analysis_typecheck_cost(accounting, &TypeSignature::IntType, second)?;
+
                 if first != &TypeSignature::IntType && first != &TypeSignature::UIntType {
                     return Err(CheckErrors::UnionTypeError(
                         vec![TypeSignature::IntType, TypeSignature::UIntType],
                         first.clone()).into())
                 }
+
+                if first != second {
+                    return Err(CheckErrors::TypeError(first.clone(), second.clone()).into())
+                }
+
                 Ok(TypeSignature::BoolType)
             },
         }
     }
 }
 
+fn trait_type_size(trait_sig: &BTreeMap<ClarityName, FunctionSignature>) -> CheckResult<u64> {
+    let mut total_size = 0;
+    for (_func_name, value) in trait_sig.iter() {
+        total_size = total_size.cost_overflow_add(
+            value.total_type_size()? as u64)?;
+    }
+    Ok(total_size)
+}
 
 fn type_reserved_variable(variable_name: &str) -> Option<TypeSignature> {
     if let Some(variable) = NativeVariables::lookup_by_name(variable_name) {
@@ -152,21 +192,24 @@ pub fn no_type() -> TypeSignature {
 }
 
 impl <'a, 'b> TypeChecker <'a, 'b> {
-    fn new(db: &'a mut AnalysisDatabase<'b>) -> TypeChecker<'a, 'b> {
+    fn new(db: &'a mut AnalysisDatabase<'b>, cost_track: LimitedCostTracker) -> TypeChecker<'a, 'b> {
         Self {
-            db,
+            db, cost_track,
             contract_context: ContractContext::new(),
             function_return_tracker: None,
-            type_map: TypeMap::new()
+            type_map: TypeMap::new(),
         }
     }
 
-    fn into_contract_analysis(self, contract_analysis: &mut ContractAnalysis) {
+    fn into_contract_analysis(self, contract_analysis: &mut ContractAnalysis) -> LimitedCostTracker {
         self.contract_context.into_contract_analysis(contract_analysis);
         contract_analysis.type_map = Some(self.type_map);
+        self.cost_track
     }
 
     pub fn track_return_type(&mut self, return_type: TypeSignature) -> CheckResult<()> {
+        runtime_cost!(cost_functions::ANALYSIS_TYPE_CHECK, self, return_type.type_size()?)?;
+
         match self.function_return_tracker {
             Some(ref mut tracker) => {
                 let new_type = match tracker.take() {
@@ -209,7 +252,6 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
 
     // Type check an expression, with an expected_type that should _admit_ the expression.
     pub fn type_check_expects(&mut self, expr: &SymbolicExpression, context: &TypingContext, expected_type: &TypeSignature) -> TypeResult {
-        
         match (&expr.expr, expected_type) {
             (LiteralValue(Value::Principal(PrincipalData::Contract(ref contract_identifier))), TypeSignature::TraitReferenceType(trait_identifier)) => {
                 let contract_to_check = self.db.load_contract(&contract_identifier)
@@ -228,6 +270,8 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
         }
 
         let actual_type = self.type_check(expr, context)?;
+        analysis_typecheck_cost(self, expected_type, &actual_type)?;
+
         if !expected_type.admits_type(&actual_type) {
             let mut err: CheckError = CheckErrors::TypeError(expected_type.clone(), actual_type).into();
             err.set_expression(expr);
@@ -239,6 +283,8 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
 
     // Type checks an expression, recursively type checking its subexpressions
     pub fn type_check(&mut self, expr: &SymbolicExpression, context: &TypingContext) -> TypeResult {
+        runtime_cost!(cost_functions::ANALYSIS_VISIT, self, 1)?;
+
         let mut result = self.inner_type_check(expr, context);
 
         if let Err(ref mut error) = result {
@@ -262,7 +308,7 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
     fn type_check_function_type(&mut self, func_type: &FunctionType,
                                 args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
         let typed_args = self.type_check_all(args, context)?;
-        func_type.check_args(&typed_args)
+        func_type.check_args(self, &typed_args)
     }
 
     fn get_function_type(&self, function_name: &str) -> Option<FunctionType> {
@@ -370,17 +416,23 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
         }
     }
 
-    fn lookup_variable(&self, name: &str, context: &TypingContext) -> TypeResult {
+    fn lookup_variable(&mut self, name: &str, context: &TypingContext) -> TypeResult {
+        runtime_cost!(cost_functions::ANALYSIS_LOOKUP_VARIABLE_CONST, self, 1)?;
+
         if let Some(type_result) = type_reserved_variable(name) {
             Ok(type_result)
         } else if let Some(type_result) = self.contract_context.get_variable_type(name) {
             Ok(type_result.clone())
-        } else if let Some(type_result) = context.lookup_variable_type(name) {
-            Ok(type_result.clone())
         } else if let Some(type_result) = context.lookup_trait_reference_type(name) {
             Ok(TypeSignature::TraitReferenceType(type_result.clone()))
         } else {
-            Err(CheckErrors::UndefinedVariable(name.to_string()).into())
+            runtime_cost!(cost_functions::ANALYSIS_LOOKUP_VARIABLE_DEPTH, self, context.depth)?;
+
+            if let Some(type_result) = context.lookup_variable_type(name) {
+                Ok(type_result.clone())
+            } else {
+                Err(CheckErrors::UndefinedVariable(name.to_string()).into())
+            }
         }
     }
 
@@ -400,6 +452,7 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
             }
         };
 
+        runtime_cost!(cost_functions::ANALYSIS_TYPE_ANNOTATE, self, type_sig.type_size()?)?;
         self.type_map.set_type(expr, type_sig.clone())?;
         Ok(type_sig)
     }
@@ -446,16 +499,20 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
             match define_type {
                 DefineFunctionsParsed::Constant { name, value } => {
                     let (v_name, v_type) = self.type_check_define_variable(name, value, context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, v_type.type_size()?)?;
                     self.contract_context.add_variable_type(v_name, v_type)?;
                 },
                 DefineFunctionsParsed::PrivateFunction { signature, body } => {
                     let (f_name, f_type) = self.type_check_define_function(signature, body, context)?;
+
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, f_type.total_type_size()?)?;
                     self.contract_context.add_private_function_type(f_name, FunctionType::Fixed(f_type))?;
                 },
                 DefineFunctionsParsed::PublicFunction { signature, body } => {
                     let (f_name, f_type) = self.type_check_define_function(signature, body, context)?;
-                    let return_type = f_type.returns.clone();
-                    if let TypeSignature::ResponseType(_) = return_type {
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, f_type.total_type_size()?)?;
+
+                    if f_type.returns.is_response_type() {
                         self.contract_context.add_public_function_type(f_name, FunctionType::Fixed(f_type))?;
                         return Ok(Some(()));
                     } else {
@@ -464,37 +521,55 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
                 },
                 DefineFunctionsParsed::ReadOnlyFunction { signature, body } => {
                     let (f_name, f_type) = self.type_check_define_function(signature, body, context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, f_type.total_type_size()?)?;
                     self.contract_context.add_read_only_function_type(f_name, FunctionType::Fixed(f_type))?;
                 },
                 DefineFunctionsParsed::Map { name, key_type, value_type } => {
-                    let (f_name, f_type) = self.type_check_define_map(name, key_type, value_type)?;
-                    self.contract_context.add_map_type(f_name, f_type)?;
+                    let (f_name, map_type) = self.type_check_define_map(name, key_type, value_type)?;
+                    let total_type_size = u64::from(map_type.0.type_size()?).cost_overflow_add(
+                        u64::from(map_type.1.type_size()?))?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, total_type_size)?;
+                    self.contract_context.add_map_type(f_name, map_type)?;
                 },
                 DefineFunctionsParsed::PersistedVariable { name, data_type, initial } => {
                     let (v_name, v_type) = self.type_check_define_persisted_variable(name, data_type, initial, context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, v_type.type_size()?)?;
                     self.contract_context.add_persisted_variable_type(v_name, v_type)?;
                 },
                 DefineFunctionsParsed::BoundedFungibleToken { name, max_supply } => {
                     let token_name = self.type_check_define_ft(name, Some(max_supply), context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, TypeSignature::UIntType.type_size()?)?;
                     self.contract_context.add_ft(token_name)?;
                 },
                 DefineFunctionsParsed::UnboundedFungibleToken { name } => {
                     let token_name = self.type_check_define_ft(name, None, context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, TypeSignature::UIntType.type_size()?)?;
                     self.contract_context.add_ft(token_name)?;
                 },
                 DefineFunctionsParsed::NonFungibleToken { name, nft_type } => {
                     let (token_name, token_type) = self.type_check_define_nft(name, nft_type, context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, token_type.type_size()?)?;
                     self.contract_context.add_nft(token_name, token_type)?;
                 },
                 DefineFunctionsParsed::Trait { name, functions } => {
                     let (trait_name, trait_signature) = self.type_check_define_trait(name, functions, context)?;
+                    runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, trait_type_size(&trait_signature)?)?;
                     self.contract_context.add_trait(trait_name, trait_signature)?;
                 },
                 DefineFunctionsParsed::UseTrait { name, trait_identifier } => {
                     let result = self.db.get_defined_trait(&trait_identifier.contract_identifier, &trait_identifier.name)?;
                     match result {
-                        Some(trait_sig) => self.contract_context.add_trait(trait_identifier.name.clone(), trait_sig)?,
-                        None => return Err(CheckErrors::TraitReferenceUnknown(name.to_string()).into())
+                        Some(trait_sig) => {
+                            let type_size = trait_type_size(&trait_sig)?;
+                            runtime_cost!(cost_functions::ANALYSIS_GET_TRAIT_ENTRY, self, type_size)?;
+                            runtime_cost!(cost_functions::ANALYSIS_BIND_NAME, self, type_size)?;
+                            self.contract_context.add_trait(trait_identifier.name.clone(), trait_sig)?
+                        },
+                        None => {
+                            // still had to do a db read, even if it didn't exist!
+                            runtime_cost!(cost_functions::ANALYSIS_GET_TRAIT_ENTRY, self, 1)?;
+                            return Err(CheckErrors::TraitReferenceUnknown(name.to_string()).into())
+                        }
                     }
                 },
                 DefineFunctionsParsed::ImplTrait { trait_identifier } => {
@@ -508,4 +583,3 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
         }
     }
 }
-

--- a/src/vm/analysis/type_checker/natives/iterables.rs
+++ b/src/vm/analysis/type_checker/natives/iterables.rs
@@ -10,7 +10,10 @@ use vm::analysis::type_checker::{
     TypeResult, TypingContext, CheckResult, check_argument_count, CheckErrors, no_type, TypeChecker};
 use super::{TypedNativeFunction, SimpleNativeFunction};
 
-fn get_simple_native_or_user_define(function_name: &str, checker: &TypeChecker) -> CheckResult<FunctionType> {
+use vm::costs::{cost_functions, analysis_typecheck_cost};
+
+fn get_simple_native_or_user_define(function_name: &str, checker: &mut TypeChecker) -> CheckResult<FunctionType> {
+    runtime_cost!(cost_functions::ANALYSIS_LOOKUP_FUNCTION, checker, 1);
     if let Some(ref native_function) = NativeFunctions::lookup_by_name(function_name) {
         if let TypedNativeFunction::Simple(SimpleNativeFunction(function_type)) = TypedNativeFunction::type_native_function(native_function) {
             Ok(function_type)
@@ -31,18 +34,19 @@ pub fn check_special_map(checker: &mut TypeChecker, args: &[SymbolicExpression],
     // we will only lookup native or defined functions here.
     //   you _cannot_ map a special function.
     let function_type = get_simple_native_or_user_define(function_name, checker)?;
-        
+
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
     let argument_type = checker.type_check(&args[1], context)?;
     
     match argument_type {
         TypeSignature::ListType(list_data) => {
             let (arg_items_type, arg_length) = list_data.destruct();
-            let mapped_type = function_type.check_args(&[arg_items_type])?;
+            let mapped_type = function_type.check_args(checker, &[arg_items_type])?;
             TypeSignature::list_of(mapped_type, arg_length)
                 .map_err(|_| CheckErrors::ConstructedListTooLarge.into())
         },
         TypeSignature::BufferType(buffer_data) => {
-            let mapped_type = function_type.check_args(&[TypeSignature::min_buffer()])?;
+            let mapped_type = function_type.check_args(checker, &[TypeSignature::min_buffer()])?;
             TypeSignature::list_of(mapped_type, buffer_data.into())
                 .map_err(|_| CheckErrors::ConstructedListTooLarge.into())
         },
@@ -58,7 +62,8 @@ pub fn check_special_filter(checker: &mut TypeChecker, args: &[SymbolicExpressio
     // we will only lookup native or defined functions here.
     //   you _cannot_ map a special function.
     let function_type = get_simple_native_or_user_define(function_name, checker)?;
-        
+
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
     let argument_type = checker.type_check(&args[1], context)?;
 
     {
@@ -68,7 +73,7 @@ pub fn check_special_filter(checker: &mut TypeChecker, args: &[SymbolicExpressio
             _ => Err(CheckErrors::ExpectedListOrBuffer(argument_type.clone()))
         }?;
     
-        let filter_type = function_type.check_args(&[input_type])?;
+        let filter_type = function_type.check_args(checker, &[input_type])?;
 
         if TypeSignature::BoolType != filter_type {
             return Err(CheckErrors::TypeError(TypeSignature::BoolType, filter_type).into())
@@ -87,6 +92,7 @@ pub fn check_special_fold(checker: &mut TypeChecker, args: &[SymbolicExpression]
     //   you _cannot_ fold a special function.
     let function_type = get_simple_native_or_user_define(function_name, checker)?;
     
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
     let argument_type = checker.type_check(&args[1], context)?;
 
     let input_type = match argument_type {
@@ -102,10 +108,10 @@ pub fn check_special_fold(checker: &mut TypeChecker, args: &[SymbolicExpression]
     //           B = list items type
     
     // f must accept the initial value and the list items type
-    let return_type = function_type.check_args(&[input_type.clone(), initial_value_type])?;
+    let return_type = function_type.check_args(checker, &[input_type.clone(), initial_value_type])?;
 
     // f must _also_ accepts its own return type!
-    let return_type = function_type.check_args(&[input_type, return_type])?;
+    let return_type = function_type.check_args(checker, &[input_type, return_type])?;
     
     Ok(return_type)
 }
@@ -114,9 +120,14 @@ pub fn check_special_concat(checker: &mut TypeChecker, args: &[SymbolicExpressio
     check_argument_count(2, args)?;
     
     let lhs_type = checker.type_check(&args[0], context)?;
+    let rhs_type = checker.type_check(&args[1], context)?;
+
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+
+    analysis_typecheck_cost(checker, &lhs_type, &rhs_type)?;
+    
     match lhs_type {
         TypeSignature::ListType(lhs_list) => {
-            let rhs_type = checker.type_check(&args[1], context)?;
             if let TypeSignature::ListType(rhs_list) = rhs_type {
                 let (lhs_entry_type, lhs_max_len) = lhs_list.destruct();
                 let (rhs_entry_type, rhs_max_len) = rhs_list.destruct();
@@ -131,7 +142,6 @@ pub fn check_special_concat(checker: &mut TypeChecker, args: &[SymbolicExpressio
             }
         },
         TypeSignature::BufferType(lhs_buff_len) => {
-            let rhs_type = checker.type_check(&args[1], context)?;
             if let TypeSignature::BufferType(rhs_buff_len) = rhs_type {
                 let size: u32 = u32::from(lhs_buff_len).checked_add(u32::from(rhs_buff_len))
                     .ok_or(CheckErrors::MaxLengthOverflow)?;
@@ -148,11 +158,15 @@ pub fn check_special_concat(checker: &mut TypeChecker, args: &[SymbolicExpressio
 pub fn check_special_append(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
     check_argument_count(2, args)?;
 
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+
     let lhs_type = checker.type_check(&args[0], context)?;
     match lhs_type {
         TypeSignature::ListType(lhs_list) => {
             let rhs_type = checker.type_check(&args[1], context)?;
             let (lhs_entry_type, lhs_max_len) = lhs_list.destruct();
+
+            analysis_typecheck_cost(checker, &lhs_entry_type, &rhs_type)?;
 
             let list_entry_type = TypeSignature::least_supertype(&lhs_entry_type, &rhs_type)?;
             let new_len = lhs_max_len.checked_add(1)
@@ -174,12 +188,15 @@ pub fn check_special_as_max_len(checker: &mut TypeChecker, args: &[SymbolicExpre
             return Err(CheckErrors::TypeError(TypeSignature::UIntType, expected_len_type).into())
         }
     };
+    runtime_cost!(cost_functions::ANALYSIS_TYPE_ANNOTATE, checker, TypeSignature::UIntType.type_size()?)?;
     checker.type_map.set_type(&args[1], TypeSignature::UIntType)?;
 
     let expected_len = u32::try_from(expected_len)
         .map_err(|_e| CheckErrors::MaxLengthOverflow)?;
 
     let iterable = checker.type_check(&args[0], context)?;
+    analysis_typecheck_cost(checker, &iterable, &iterable)?;
+
     match iterable {
         TypeSignature::ListType(list) => {
             let (lhs_entry_type, _) = list.destruct();
@@ -197,6 +214,7 @@ pub fn check_special_len(checker: &mut TypeChecker, args: &[SymbolicExpression],
     check_argument_count(1, args)?;
 
     let collection_type = checker.type_check(&args[0], context)?;
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
 
     match collection_type {
         TypeSignature::ListType(_) | TypeSignature::BufferType(_) => Ok(()),

--- a/src/vm/analysis/type_checker/natives/iterables.rs
+++ b/src/vm/analysis/type_checker/natives/iterables.rs
@@ -13,7 +13,7 @@ use super::{TypedNativeFunction, SimpleNativeFunction};
 use vm::costs::{cost_functions, analysis_typecheck_cost};
 
 fn get_simple_native_or_user_define(function_name: &str, checker: &mut TypeChecker) -> CheckResult<FunctionType> {
-    runtime_cost!(cost_functions::ANALYSIS_LOOKUP_FUNCTION, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_LOOKUP_FUNCTION, checker, 1)?;
     if let Some(ref native_function) = NativeFunctions::lookup_by_name(function_name) {
         if let TypedNativeFunction::Simple(SimpleNativeFunction(function_type)) = TypedNativeFunction::type_native_function(native_function) {
             Ok(function_type)
@@ -35,7 +35,7 @@ pub fn check_special_map(checker: &mut TypeChecker, args: &[SymbolicExpression],
     //   you _cannot_ map a special function.
     let function_type = get_simple_native_or_user_define(function_name, checker)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1)?;
     let argument_type = checker.type_check(&args[1], context)?;
     
     match argument_type {
@@ -63,7 +63,7 @@ pub fn check_special_filter(checker: &mut TypeChecker, args: &[SymbolicExpressio
     //   you _cannot_ map a special function.
     let function_type = get_simple_native_or_user_define(function_name, checker)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1)?;
     let argument_type = checker.type_check(&args[1], context)?;
 
     {
@@ -92,7 +92,7 @@ pub fn check_special_fold(checker: &mut TypeChecker, args: &[SymbolicExpression]
     //   you _cannot_ fold a special function.
     let function_type = get_simple_native_or_user_define(function_name, checker)?;
     
-    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1)?;
     let argument_type = checker.type_check(&args[1], context)?;
 
     let input_type = match argument_type {
@@ -122,7 +122,7 @@ pub fn check_special_concat(checker: &mut TypeChecker, args: &[SymbolicExpressio
     let lhs_type = checker.type_check(&args[0], context)?;
     let rhs_type = checker.type_check(&args[1], context)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1)?;
 
     analysis_typecheck_cost(checker, &lhs_type, &rhs_type)?;
     
@@ -158,7 +158,7 @@ pub fn check_special_concat(checker: &mut TypeChecker, args: &[SymbolicExpressio
 pub fn check_special_append(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
     check_argument_count(2, args)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1)?;
 
     let lhs_type = checker.type_check(&args[0], context)?;
     match lhs_type {
@@ -214,7 +214,7 @@ pub fn check_special_len(checker: &mut TypeChecker, args: &[SymbolicExpression],
     check_argument_count(1, args)?;
 
     let collection_type = checker.type_check(&args[0], context)?;
-    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_ITERABLE_FUNC, checker, 1)?;
 
     match collection_type {
         TypeSignature::ListType(_) | TypeSignature::BufferType(_) => Ok(()),

--- a/src/vm/analysis/type_checker/natives/maps.rs
+++ b/src/vm/analysis/type_checker/natives/maps.rs
@@ -9,11 +9,14 @@ use vm::analysis::type_checker::{TypeResult, TypingContext,
                                  check_arguments_at_least,
                                  CheckError, CheckErrors, no_type, TypeChecker};
 
+use vm::costs::{cost_functions, analysis_typecheck_cost};
+
 fn check_and_type_map_arg_tuple(checker: &mut TypeChecker, expr: &SymbolicExpression, context: &TypingContext) -> TypeResult {
     match tuples::get_definition_type_of_tuple_argument(expr) {
         Explicit => checker.type_check(expr, context),
         Implicit(ref inner_expr) => {
             let type_result = check_special_tuple_cons(checker, inner_expr, context)?;
+            runtime_cost!(cost_functions::ANALYSIS_TYPE_ANNOTATE, checker, type_result.type_size()?)?;
             checker.type_map.set_type(expr, type_result.clone())?;
             Ok(type_result)
         }
@@ -31,6 +34,10 @@ pub fn check_special_fetch_entry(checker: &mut TypeChecker, args: &[SymbolicExpr
 
     let (expected_key_type, value_type) = checker.contract_context.get_map_type(map_name)
         .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
+    runtime_cost!(cost_functions::ANALYSIS_TYPE_LOOKUP, &mut checker.cost_track, expected_key_type.type_size()?)?;
+    runtime_cost!(cost_functions::ANALYSIS_TYPE_LOOKUP, &mut checker.cost_track, value_type.type_size()?)?;
+    analysis_typecheck_cost(&mut checker.cost_track, expected_key_type, &key_type)?;
 
     let option_type = TypeSignature::new_option(value_type.clone())?;
 
@@ -59,6 +66,12 @@ pub fn check_special_fetch_contract_entry(checker: &mut TypeChecker, args: &[Sym
     
     let (expected_key_type, value_type) = checker.db.get_map_type(&contract_identifier, map_name)?;
 
+    let fetch_size = expected_key_type.type_size()?
+        .checked_add(value_type.type_size()?)
+        .ok_or_else(|| CheckErrors::CostOverflow)?;
+    runtime_cost!(cost_functions::ANALYSIS_FETCH_CONTRACT_ENTRY, &mut checker.cost_track, fetch_size)?;
+    analysis_typecheck_cost(&mut checker.cost_track, &expected_key_type, &key_type)?;
+
     let option_type = TypeSignature::new_option(value_type)?;
     
     if !expected_key_type.admits_type(&key_type) {
@@ -78,52 +91,48 @@ pub fn check_special_delete_entry(checker: &mut TypeChecker, args: &[SymbolicExp
 
     let (expected_key_type, _) = checker.contract_context.get_map_type(map_name)
         .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
+    runtime_cost!(cost_functions::ANALYSIS_TYPE_LOOKUP, &mut checker.cost_track, expected_key_type.type_size()?)?;
+    analysis_typecheck_cost(&mut checker.cost_track, expected_key_type, &key_type)?;
     
     if !expected_key_type.admits_type(&key_type) {
         return Err(CheckError::new(CheckErrors::TypeError(expected_key_type.clone(), key_type)))
+    } else {
+        return Ok(TypeSignature::BoolType)
+    }
+}
+
+fn check_set_or_insert_entry(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
+    check_arguments_at_least(3, args)?;
+    
+    let map_name = args[0].match_atom()
+        .ok_or(CheckErrors::BadMapName)?;
+        
+    let key_type = check_and_type_map_arg_tuple(checker, &args[1], context)?;
+    let value_type = check_and_type_map_arg_tuple(checker, &args[2], context)?;
+        
+    let (expected_key_type, expected_value_type) = checker.contract_context.get_map_type(map_name)
+        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
+    runtime_cost!(cost_functions::ANALYSIS_TYPE_LOOKUP, &mut checker.cost_track, expected_key_type.type_size()?)?;
+    runtime_cost!(cost_functions::ANALYSIS_TYPE_LOOKUP, &mut checker.cost_track, value_type.type_size()?)?;
+
+    analysis_typecheck_cost(&mut checker.cost_track, expected_key_type, &key_type)?;
+    analysis_typecheck_cost(&mut checker.cost_track, expected_value_type, &value_type)?;
+    
+    if !expected_key_type.admits_type(&key_type) {
+        return Err(CheckError::new(CheckErrors::TypeError(expected_key_type.clone(), key_type)))
+    } else if !expected_value_type.admits_type(&value_type) {
+        return Err(CheckError::new(CheckErrors::TypeError(expected_value_type.clone(), value_type)))
     } else {
         return Ok(TypeSignature::BoolType)
     }
 }
 
 pub fn check_special_set_entry(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
-    check_arguments_at_least(3, args)?;
-    
-    let map_name = args[0].match_atom()
-        .ok_or(CheckErrors::BadMapName)?;
-        
-    let key_type = check_and_type_map_arg_tuple(checker, &args[1], context)?;
-    let value_type = check_and_type_map_arg_tuple(checker, &args[2], context)?;
-    
-    let (expected_key_type, expected_value_type) = checker.contract_context.get_map_type(map_name)
-        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
-    
-    if !expected_key_type.admits_type(&key_type) {
-        return Err(CheckError::new(CheckErrors::TypeError(expected_key_type.clone(), key_type)))
-    } else if !expected_value_type.admits_type(&value_type) {
-        return Err(CheckError::new(CheckErrors::TypeError(expected_value_type.clone(), value_type)))
-    } else {
-        return Ok(TypeSignature::BoolType)
-    }
+    check_set_or_insert_entry(checker, args, context)
 }
 
 pub fn check_special_insert_entry(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
-    check_arguments_at_least(3, args)?;
-    
-    let map_name = args[0].match_atom()
-        .ok_or(CheckErrors::BadMapName)?;
-        
-    let key_type = check_and_type_map_arg_tuple(checker, &args[1], context)?;
-    let value_type = check_and_type_map_arg_tuple(checker, &args[2], context)?;
-        
-    let (expected_key_type, expected_value_type) = checker.contract_context.get_map_type(map_name)
-        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
-    
-    if !expected_key_type.admits_type(&key_type) {
-        return Err(CheckError::new(CheckErrors::TypeError(expected_key_type.clone(), key_type)))
-    } else if !expected_value_type.admits_type(&value_type) {
-        return Err(CheckError::new(CheckErrors::TypeError(expected_value_type.clone(), value_type)))
-    } else {
-        return Ok(TypeSignature::BoolType)
-    }
+    check_set_or_insert_entry(checker, args, context)
 }

--- a/src/vm/analysis/type_checker/natives/options.rs
+++ b/src/vm/analysis/type_checker/natives/options.rs
@@ -9,7 +9,7 @@ use vm::costs::{cost_functions, analysis_typecheck_cost};
 pub fn check_special_okay(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
     check_argument_count(1, args)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CONS, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CONS, checker, 1)?;
 
     let inner_type = checker.type_check(&args[0], context)?;
     let resp_type = TypeSignature::new_response(inner_type, no_type())?;
@@ -19,7 +19,7 @@ pub fn check_special_okay(checker: &mut TypeChecker, args: &[SymbolicExpression]
 pub fn check_special_some(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
     check_argument_count(1, args)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CONS, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CONS, checker, 1)?;
     
     let inner_type = checker.type_check(&args[0], context)?;
     let resp_type = TypeSignature::new_option(inner_type)?;
@@ -29,7 +29,7 @@ pub fn check_special_some(checker: &mut TypeChecker, args: &[SymbolicExpression]
 pub fn check_special_error(checker: &mut TypeChecker, args: &[SymbolicExpression], context: &TypingContext) -> TypeResult {
     check_argument_count(1, args)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CONS, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CONS, checker, 1)?;
     
     let inner_type = checker.type_check(&args[0], context)?;
     let resp_type = TypeSignature::new_response(no_type(), inner_type)?;
@@ -41,7 +41,7 @@ pub fn check_special_is_response(checker: &mut TypeChecker, args: &[SymbolicExpr
     
     let input = checker.type_check(&args[0], context)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1)?;
 
     if let TypeSignature::ResponseType(_types) = input {
         return Ok(TypeSignature::BoolType)
@@ -55,7 +55,7 @@ pub fn check_special_is_optional(checker: &mut TypeChecker, args: &[SymbolicExpr
     
     let input = checker.type_check(&args[0], context)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1)?;
 
     if let TypeSignature::OptionalType(_type) = input {
         return Ok(TypeSignature::BoolType)
@@ -93,7 +93,7 @@ pub fn check_special_asserts(checker: &mut TypeChecker, args: &[SymbolicExpressi
 }
 
 fn inner_unwrap(input: TypeSignature, checker: &mut TypeChecker) -> TypeResult {
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1)?;
 
     match input {
         TypeSignature::OptionalType(input_type) => {
@@ -116,7 +116,7 @@ fn inner_unwrap(input: TypeSignature, checker: &mut TypeChecker) -> TypeResult {
 }
 
 fn inner_unwrap_err(input: TypeSignature, checker: &mut TypeChecker) -> TypeResult {
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1)?;
 
     if let TypeSignature::ResponseType(response_type) = input {
         let err_type = response_type.1;
@@ -157,7 +157,7 @@ pub fn check_special_try_ret(checker: &mut TypeChecker, args: &[SymbolicExpressi
     
     let input = checker.type_check(&args[0], context)?;
 
-    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1);
+    runtime_cost!(cost_functions::ANALYSIS_OPTION_CHECK, checker, 1)?;
 
     match input {
         TypeSignature::OptionalType(input_type) => {

--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -92,7 +92,7 @@ fn test_define_trait(){
 
     let contract_identifier = QualifiedContractIdentifier::transient();
     for (bad_test, expected) in bad.iter().zip(bad_expected.iter()) {
-        let res = build_ast(&contract_identifier, bad_test).unwrap_err();
+        let res = build_ast(&contract_identifier, bad_test, &mut ()).unwrap_err();
         assert_eq!(expected, &res.err);
     }
 }
@@ -112,7 +112,7 @@ fn test_use_trait(){
     
     let contract_identifier = QualifiedContractIdentifier::transient();
     for (bad_test, expected) in bad.iter().zip(bad_expected.iter()) {
-        let res = build_ast(&contract_identifier, bad_test).unwrap_err();
+        let res = build_ast(&contract_identifier, bad_test, &mut ()).unwrap_err();
         assert_eq!(expected, &res.err);
     }
 }
@@ -128,7 +128,7 @@ fn test_impl_trait(){
     
     let contract_identifier = QualifiedContractIdentifier::transient();
     for (bad_test, expected) in bad.iter().zip(bad_expected.iter()) {
-        let res = build_ast(&contract_identifier, bad_test).unwrap_err();
+        let res = build_ast(&contract_identifier, bad_test, &mut ()).unwrap_err();
         assert_eq!(expected, &res.err);
     }
 }
@@ -317,7 +317,7 @@ fn test_trait_reference_unknown(){
     
     let contract_identifier = QualifiedContractIdentifier::transient();
     for (bad_test, expected) in bad.iter() {
-        let res = build_ast(&contract_identifier, bad_test).unwrap_err();
+        let res = build_ast(&contract_identifier, bad_test, &mut ()).unwrap_err();
         assert_eq!(expected, &res.err);
     }
 }

--- a/src/vm/analysis/types.rs
+++ b/src/vm/analysis/types.rs
@@ -36,7 +36,7 @@ pub struct ContractAnalysis {
 }
 
 impl ContractAnalysis {
-    pub fn new(contract_identifier: QualifiedContractIdentifier, expressions: Vec<SymbolicExpression>) -> ContractAnalysis {
+    pub fn new(contract_identifier: QualifiedContractIdentifier, expressions: Vec<SymbolicExpression>, cost_track: LimitedCostTracker) -> ContractAnalysis {
         ContractAnalysis {
             contract_identifier,
             expressions,
@@ -51,7 +51,7 @@ impl ContractAnalysis {
             implemented_traits: BTreeSet::new(),
             fungible_tokens: BTreeSet::new(),
             non_fungible_tokens: BTreeMap::new(),
-            cost_track: Some(LimitedCostTracker::new_max_limit())
+            cost_track: Some(cost_track)
         }
     }
 

--- a/src/vm/ast/definition_sorter/tests.rs
+++ b/src/vm/ast/definition_sorter/tests.rs
@@ -13,7 +13,7 @@ fn run_scoped_parsing_helper(contract: &str) -> ParseResult<ContractAST> {
     let pre_expressions = parser::parse(contract)?;
     let mut contract_ast = ContractAST::new(contract_identifier.clone(), pre_expressions);
     ExpressionIdentifier::run_pass(&mut contract_ast)?;
-    DefinitionSorter::run_pass(&mut contract_ast)?;
+    DefinitionSorter::run_pass(&mut contract_ast, &mut ())?;
     Ok(contract_ast)
 }
 

--- a/src/vm/ast/mod.rs
+++ b/src/vm/ast/mod.rs
@@ -8,6 +8,7 @@ pub mod types;
 pub mod errors;
 pub mod stack_depth_checker;
 use vm::errors::{Error, RuntimeErrorType};
+use vm::costs::{cost_functions, CostTracker};
 
 use vm::representations::{SymbolicExpression};
 use vm::types::QualifiedContractIdentifier;
@@ -22,19 +23,53 @@ use self::traits_resolver::TraitsResolver;
 use self::stack_depth_checker::StackDepthChecker;
 
 /// Legacy function
-pub fn parse(contract_identifier: &QualifiedContractIdentifier,source_code: &str) -> Result<Vec<SymbolicExpression>, Error> {
-    let ast = build_ast(contract_identifier, source_code)
-        .map_err(|e| RuntimeErrorType::ASTError(e))?;
+#[cfg(test)]
+pub fn parse(contract_identifier: &QualifiedContractIdentifier, source_code: &str) -> Result<Vec<SymbolicExpression>, Error> {
+    let ast = build_ast(contract_identifier, source_code, &mut ())?;
     Ok(ast.expressions)
 }
 
-pub fn build_ast(contract_identifier: &QualifiedContractIdentifier, source_code: &str) -> ParseResult<ContractAST> {
+pub fn build_ast<T: CostTracker>(contract_identifier: &QualifiedContractIdentifier, source_code: &str, cost_track: &mut T) -> ParseResult<ContractAST> {
+    runtime_cost!(cost_functions::AST_PARSE, cost_track, source_code.len() as u64)?;
     let pre_expressions = parser::parse(source_code)?;
     let mut contract_ast = ContractAST::new(contract_identifier.clone(), pre_expressions);
     StackDepthChecker::run_pass(&mut contract_ast)?;
     ExpressionIdentifier::run_pass(&mut contract_ast)?;
-    DefinitionSorter::run_pass(&mut contract_ast)?;
+    DefinitionSorter::run_pass(&mut contract_ast, cost_track)?;
     TraitsResolver::run_pass(&mut contract_ast)?;
     SugarExpander::run_pass(&mut contract_ast)?;
     Ok(contract_ast)
+}
+
+#[cfg(test)]
+mod tests {
+    use vm::costs::LimitedCostTracker;
+    use super::*;
+
+    fn dependency_edge_counting_runtime(iters: usize) -> u64 {
+        let mut progn = "(define-private (a0) 1)".to_string();
+        for i in 1..iters {
+            progn.push_str(
+                &format!("\n(define-private (a{}) (begin", i));
+            for x in 0..i {
+                progn.push_str(&format!(" (a{}) ", x));
+            }
+            progn.push_str("))");
+        }
+
+        let mut cost_track = LimitedCostTracker::new_max_limit();
+        build_ast(&QualifiedContractIdentifier::transient(), &progn, &mut cost_track).unwrap();
+
+        cost_track.get_total().runtime
+    }
+
+    #[test]
+    fn test_edge_counting_runtime() {
+        let ratio_4_8 = dependency_edge_counting_runtime(8) / dependency_edge_counting_runtime(4);
+        let ratio_8_16 = dependency_edge_counting_runtime(16) / dependency_edge_counting_runtime(8);
+
+        // this really is just testing for the non-linearity
+        //   in the runtime cost assessment (because the edge count in the dependency graph is going up O(n^2)).
+        assert!(ratio_8_16 > ratio_4_8);
+    }
 }

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -10,7 +10,7 @@ use vm::database::{ClarityDatabase};
 use vm::representations::{SymbolicExpression, ClarityName, ContractName};
 use vm::contracts::Contract;
 use vm::ast::ContractAST;
-use vm::costs::{CostTracker, ExecutionCost, LimitedCostTracker, cost_functions};
+use vm::costs::{CostTracker, ExecutionCost, LimitedCostTracker, cost_functions, CostErrors};
 use vm::ast;
 use vm::{eval, is_reserved};
 
@@ -464,13 +464,13 @@ impl <'a> OwnedEnvironment <'a> {
 }
 
 impl CostTracker for Environment<'_,'_> {
-    fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CheckErrors> {
+    fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CostErrors> {
         self.global_context.cost_track.add_cost(cost)
     }
 }
 
 impl CostTracker for GlobalContext<'_> {
-    fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CheckErrors> {
+    fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CostErrors> {
         self.cost_track.add_cost(cost)
     }
 }
@@ -520,7 +520,9 @@ impl <'a,'b> Environment <'a,'b> {
     }
 
     pub fn eval_read_only(&mut self, contract_identifier: &QualifiedContractIdentifier, program: &str) -> Result<Value> {
-        let parsed = ast::parse(contract_identifier, program)?;
+        let parsed = ast::build_ast(contract_identifier, program, self)?
+            .expressions;
+
         if parsed.len() < 1 {
             return Err(RuntimeErrorType::ParseError("Expected a program of at least length 1".to_string()).into())
         }
@@ -544,7 +546,8 @@ impl <'a,'b> Environment <'a,'b> {
     pub fn eval_raw(&mut self, program: &str) -> Result<Value> {
         let contract_id = QualifiedContractIdentifier::transient();
 
-        let parsed = ast::parse(&contract_id, program)?;
+        let parsed = ast::build_ast(&contract_id, program, self)?
+            .expressions;
         if parsed.len() < 1 {
             return Err(RuntimeErrorType::ParseError("Expected a program of at least length 1".to_string()).into())
         }
@@ -633,8 +636,7 @@ impl <'a,'b> Environment <'a,'b> {
     }
 
     pub fn initialize_contract(&mut self, contract_identifier: QualifiedContractIdentifier, contract_content: &str) -> Result<()> {
-        let contract_ast = ast::build_ast(&contract_identifier, contract_content)
-            .map_err(RuntimeErrorType::ASTError)?;
+        let contract_ast = ast::build_ast(&contract_identifier, contract_content, self)?;
         self.initialize_contract_from_ast(contract_identifier, &contract_ast, &contract_content)
     }
 

--- a/src/vm/costs/cost_functions.rs
+++ b/src/vm/costs/cost_functions.rs
@@ -34,8 +34,22 @@ def_runtime_cost!(ANALYSIS_LOOKUP_FUNCTION_TYPES { Linear(1, 1) });
 def_runtime_cost!(ANALYSIS_LOOKUP_VARIABLE_CONST { Constant(1) });
 def_runtime_cost!(ANALYSIS_LOOKUP_VARIABLE_DEPTH { NLogN(1, 1) });
 
-pub const ANALYSIS_GET_TRAIT_ENTRY: SimpleCostSpecification = SimpleCostSpecification {
-    write_length: Constant(0),
+def_runtime_cost!(AST_PARSE { Linear(1, 1) });
+def_runtime_cost!(AST_CYCLE_DETECTION { Linear(1, 1) });
+
+pub const ANALYSIS_STORAGE: SimpleCostSpecification = SimpleCostSpecification {
+    write_length: Linear(1, 1),
+    write_count: Constant(1),
+    runtime: Linear(1, 1),
+    read_count: Constant(1),
+    read_length: Constant(1),
+};
+
+pub const ANALYSIS_USE_TRAIT_ENTRY: SimpleCostSpecification = SimpleCostSpecification {
+    // increases the total storage consumed by the contract!
+    //  so we count the additional write_length, but since it does _not_ require
+    //  an additional _write_, we don't charge for that.
+    write_length: Linear(1, 1),
     write_count: Constant(0),
     runtime: Linear(1, 1),
     read_count: Constant(1),

--- a/src/vm/costs/cost_functions.rs
+++ b/src/vm/costs/cost_functions.rs
@@ -1,5 +1,5 @@
 use super::{SimpleCostSpecification, TypeCheckCost};
-use super::CostFunctions::{Linear, Constant, NLogN};
+use super::CostFunctions::{Linear, Constant, NLogN, LogN};
 
 macro_rules! def_runtime_cost {
     ($Name:ident { $runtime:expr }) => {
@@ -23,7 +23,7 @@ def_runtime_cost!(ANALYSIS_OPTION_CONS { Constant(1) });
 def_runtime_cost!(ANALYSIS_OPTION_CHECK { Constant(1) });
 def_runtime_cost!(ANALYSIS_BIND_NAME { Linear(1, 1) });
 def_runtime_cost!(ANALYSIS_LIST_ITEMS_CHECK { Linear(1, 1) });
-def_runtime_cost!(ANALYSIS_CHECK_TUPLE_GET { NLogN(1, 1) });
+def_runtime_cost!(ANALYSIS_CHECK_TUPLE_GET { LogN(1, 1) });
 def_runtime_cost!(ANALYSIS_CHECK_TUPLE_CONS { NLogN(1, 1) });
 def_runtime_cost!(ANALYSIS_TUPLE_ITEMS_CHECK { Linear(1, 1) });
 def_runtime_cost!(ANALYSIS_CHECK_LET { Linear(1, 1) });

--- a/src/vm/costs/cost_functions.rs
+++ b/src/vm/costs/cost_functions.rs
@@ -14,6 +14,50 @@ macro_rules! def_runtime_cost {
     }
 }
 
+def_runtime_cost!(ANALYSIS_TYPE_ANNOTATE { Linear(1, 1) });
+def_runtime_cost!(ANALYSIS_TYPE_CHECK { Linear(1, 1) });
+def_runtime_cost!(ANALYSIS_TYPE_LOOKUP { Linear(1, 1) });
+def_runtime_cost!(ANALYSIS_VISIT { Constant(1) });
+def_runtime_cost!(ANALYSIS_ITERABLE_FUNC { Constant(1) });
+def_runtime_cost!(ANALYSIS_OPTION_CONS { Constant(1) });
+def_runtime_cost!(ANALYSIS_OPTION_CHECK { Constant(1) });
+def_runtime_cost!(ANALYSIS_BIND_NAME { Linear(1, 1) });
+def_runtime_cost!(ANALYSIS_LIST_ITEMS_CHECK { Linear(1, 1) });
+def_runtime_cost!(ANALYSIS_CHECK_TUPLE_GET { NLogN(1, 1) });
+def_runtime_cost!(ANALYSIS_CHECK_TUPLE_CONS { NLogN(1, 1) });
+def_runtime_cost!(ANALYSIS_TUPLE_ITEMS_CHECK { Linear(1, 1) });
+def_runtime_cost!(ANALYSIS_CHECK_LET { Linear(1, 1) });
+
+def_runtime_cost!(ANALYSIS_LOOKUP_FUNCTION { Constant(1) });
+def_runtime_cost!(ANALYSIS_LOOKUP_FUNCTION_TYPES { Linear(1, 1) });
+
+def_runtime_cost!(ANALYSIS_LOOKUP_VARIABLE_CONST { Constant(1) });
+def_runtime_cost!(ANALYSIS_LOOKUP_VARIABLE_DEPTH { NLogN(1, 1) });
+
+pub const ANALYSIS_GET_TRAIT_ENTRY: SimpleCostSpecification = SimpleCostSpecification {
+    write_length: Constant(0),
+    write_count: Constant(0),
+    runtime: Linear(1, 1),
+    read_count: Constant(1),
+    read_length: Linear(1, 1)
+};
+
+pub const ANALYSIS_GET_FUNCTION_ENTRY: SimpleCostSpecification = SimpleCostSpecification {
+    write_length: Constant(0),
+    write_count: Constant(0),
+    runtime: Linear(1, 1),
+    read_count: Constant(1),
+    read_length: Linear(1, 1)
+};
+
+pub const ANALYSIS_FETCH_CONTRACT_ENTRY: SimpleCostSpecification = SimpleCostSpecification {
+    write_length: Constant(0),
+    write_count: Constant(0),
+    runtime: Linear(1, 1),
+    read_count: Constant(1),
+    read_length: Linear(1, 1)
+};
+
 def_runtime_cost!(LOOKUP_VARIABLE_DEPTH { Linear(1, 1) });
 def_runtime_cost!(LOOKUP_VARIABLE_SIZE { Linear(1, 0) });
 def_runtime_cost!(LOOKUP_FUNCTION { Constant(1) });

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -104,6 +104,7 @@ pub enum CostFunctions {
     Constant(u64),
     Linear(u64, u64),
     NLogN(u64, u64),
+    LogN(u64, u64),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -222,6 +223,14 @@ impl CostFunctions {
             CostFunctions::Constant(val) => Ok(*val),
             CostFunctions::Linear(a, b) => { a.cost_overflow_mul(input)?
                                              .cost_overflow_add(*b) }
+            CostFunctions::LogN(a, b) => {
+                // a*input*log(input)) + b
+                //  and don't do log(0).
+                int_log2(cmp::max(input, 1))
+                    .ok_or_else(|| CostErrors::CostOverflow)?
+                    .cost_overflow_mul(*a)?
+                    .cost_overflow_add(*b)
+            }
             CostFunctions::NLogN(a, b) => {
                 // a*input*log(input)) + b
                 //  and don't do log(0).

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -7,7 +7,7 @@ use vm::types::{Value, TypeSignature};
 use vm::contexts::StackTrace;
 use chainstate::burn::BlockHeaderHash;
 use chainstate::stacks::index::{Error as MarfError};
-
+use vm::costs::CostErrors;
 use serde_json::Error as SerdeJSONErr;
 use rusqlite::Error as SqliteError;
 
@@ -139,6 +139,18 @@ impl error::Error for Error {
 impl error::Error for RuntimeErrorType {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
+    }
+}
+
+impl From<CostErrors> for Error {
+    fn from(err: CostErrors) -> Self {
+        Error::from(CheckErrors::from(err))
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Self {
+        Error::from(RuntimeErrorType::ASTError(err))
     }
 }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -255,7 +255,8 @@ pub fn execute(program: &str) -> Result<Option<Value>> {
     let conn = marf.as_clarity_db();
     let mut global_context = GlobalContext::new(conn, LimitedCostTracker::new_max_limit());
     global_context.execute(|g| {
-        let parsed = ast::parse(&contract_id, program)?;
+        let parsed = ast::build_ast(&contract_id, program, &mut ())?
+            .expressions;
         eval_all(&parsed, &mut contract_context, g)
     })
 }

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -172,7 +172,7 @@ fn test_simple_token_system() {
 
         let tokens_contract = SIMPLE_TOKENS;
 
-        let contract_ast = ast::build_ast(&contract_identifier, tokens_contract).unwrap();
+        let contract_ast = ast::build_ast(&contract_identifier, tokens_contract, &mut ()).unwrap();
 
         block.initialize_smart_contract(&contract_identifier, &contract_ast, tokens_contract, |_, _| false)
             .unwrap();

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -17,7 +17,7 @@ use vm::database::{ClarityDatabase, MarfedKV, MemoryBackingStore,
 use chainstate::stacks::index::storage::{TrieFileStorage};
 use chainstate::burn::BlockHeaderHash;
 
-fn get_simple_test(function: &NativeFunctions) -> &'static str {
+pub fn get_simple_test(function: &NativeFunctions) -> &'static str {
     use vm::functions::NativeFunctions::*;
     match function {
         Add => "(+ 1 1)",
@@ -37,7 +37,7 @@ fn get_simple_test(function: &NativeFunctions) -> &'static str {
         Or => "(or 'true 'false)",
         Not => "(not 'true)",
         Equals => "(is-eq 1 2)",
-        If => "(if 'true (+ 1 2) 'false)",
+        If => "(if 'true (+ 1 2) 2)",
         Let => "(let ((x 1)) x)",
         FetchVar => "(var-get var-foo)",
         SetVar => "(var-set var-foo 1)",
@@ -76,7 +76,7 @@ fn get_simple_test(function: &NativeFunctions) -> &'static str {
         Unwrap => "(unwrap-panic (ok 1))",
         UnwrapErr => "(unwrap-err-panic (err 1))",
         Match => "(match (some 1) x (+ x 1) 1)",
-        TryRet => "(try! (some 1))",
+        TryRet => "(try! (if 'true (ok 1) (err 1)))",
         IsOkay => "(is-ok (ok 1))",
         IsNone => "(is-none none)",
         IsErr => "(is-err (err 1))",

--- a/src/vm/tests/defines.rs
+++ b/src/vm/tests/defines.rs
@@ -157,7 +157,7 @@ fn test_recursive_panic() {
               (* a (factorial (- a 1)))))
          (factorial 10)";
 
-    let err = build_ast(&QualifiedContractIdentifier::transient(), tests).unwrap_err();
+    let err = build_ast(&QualifiedContractIdentifier::transient(), tests, &mut ()).unwrap_err();
     match err.err {
         ParseErrors::CircularReference(_) => {},
         _ => {

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -19,7 +19,7 @@ mod defines;
 mod simple_apply_eval;
 mod datamaps;
 mod contracts;
-mod costs;
+pub mod costs;
 mod traits;
 
 pub fn with_memory_environment<F>(f: F, top_level: bool)

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -11,7 +11,7 @@ use vm::errors::{RuntimeErrorType, CheckErrors, InterpreterResult as Result, Inc
 use util::hash;
 
 pub use vm::types::signatures::{
-    TupleTypeSignature, AssetIdentifier, FixedFunction,
+    TupleTypeSignature, AssetIdentifier, FixedFunction, FunctionSignature,
     TypeSignature, FunctionType, ListTypeData, FunctionArg, parse_name_type_pairs,
     BUFF_64, BUFF_32, BUFF_20, BufferLength
 };


### PR DESCRIPTION
This adds cost tracking to the static analysis and ast modules.

SIP-009 provides details on how costs are assessed -- the major points to note are:

1. The cost of static analysis is assessed _only_ in the type checker. The other static analysis passes have either the same or lower asymptotic costs for the same checks on functions, so those costs can be safely folded into the type checker's costs. This makes the assessed costs depend less on the specifics of the implementation.
2. The cost of most functions for type checking are simply the cost of evaluating the function application -- type checking arguments and then annotating the return type. Functions which need to do additional kinds of matching (like iterables and options functions) will have an additional constant cost imposed. Otherwise, the only functions which need to be treated specially are ones which need to lookup fields in tuples or functions that require database lookups.

This implements #1166 