### PR TITLE
Remove non-STX asset transfer from SIP-005

### DIFF
--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -618,7 +618,7 @@ as follows:
 * A variable-length **payload**, of which there are five varieties.
 
 The _payload type ID_ can take any of the following values:
-* `0x00`:  the payload that follows is a **stx-token-transfer payload**
+* `0x00`:  the payload that follows is a **token-transfer payload**
 * `0x01`:  the payload that follows is a **contract-call payload**
 * `0x02`:  the payload that follows is a **smart-contract payload**
 * `0x03`:  the payload that follows is a **poison-microblock payload**

--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -618,19 +618,11 @@ as follows:
 * A variable-length **payload**, of which there are five varieties.
 
 The _payload type ID_ can take any of the following values:
-* `0x00`:  the payload that follows is a **token-transfer payload**
+* `0x00`:  the payload that follows is a **stx-token-transfer payload**
 * `0x01`:  the payload that follows is a **contract-call payload**
 * `0x02`:  the payload that follows is a **smart-contract payload**
 * `0x03`:  the payload that follows is a **poison-microblock payload**
 * `0x04`:  the payload that follows is a **coinbase payload**.
-
-A _token-transfer payload_ is encoded as follows:
-* A 1-byte **asset type ID** to indicate whether or not the transaction will
-  send STX (`0x00`), a fungible token (`0x01`), or a non-fungible token (`0x02`)
-* One of the following:
-   * A **STX token-transfer** structure, if the asset type ID is `0x01`
-   * A **Fungible token-transfer** structure, if the asset type ID is `0x02`
-   * A **Non-fungible token-transfer** structure, if the asset type ID is `0x03`
 
 The _STX token-transfer_ structure is encoded as follows:
 * A **recipient address**, comprised of a 1-byte address version number and a
@@ -638,24 +630,6 @@ The _STX token-transfer_ structure is encoded as follows:
 account to recieve the tokens,
 * An 8-byte number denominating the number of microSTX to send to the recipient
   address's account.
-
-The _Fungible token-transfer_ structure is encoded as follows:
-* An **asset info** structure, described above, which encodes the
-  fully-qualified name of the fungible token type,
-* A **recipient address**, comprised of a 1-byte address version number and a
-  20-byte public key hash that identifies a (possibly unmaterialized) standard
-account to recieve the tokens,
-* An 8-byte number denominating the number of fungible token units to send to
-  the recipient address's account.
-
-The _Non-fungible token-transfer_ structure is encoded as follows:
-* An **asset info** structure, described above, which encodes the
-  fully-qualified name of the non-fungible token type,
-* A length-prefixed **asset name** string, described above, which encodes the
-  name of the particular non-fungible token to send,
-* A **recipient address**, comprised of a 1-byte address version number and a
-  20-byte public key hash that identifies a (possibly unmaterialized) standard
-account to recieve the tokens.
 
 Note that if a transaction contains a token-transfer payload, it MUST have only
 a standard authorization field.  It cannot be sponsored.


### PR DESCRIPTION
Update SIP-005 to reflect removal of fungible and non-fungible asset transfers from token transfer payloads.